### PR TITLE
fix: update display while looping

### DIFF
--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -21,7 +21,7 @@ Probes are the heart of the monitoring requests. Probes are just arrays of reque
   ]
 ```
 
-Monica goes through each probe object, sends it out, and determines whether an alert or notification need to be sent out.
+Monika goes through each probe object, sends it out, and determines whether an alert or notification need to be sent out.
 
 ## Request Anatomy
 

--- a/src/utils/looper.ts
+++ b/src/utils/looper.ts
@@ -4,25 +4,16 @@ import { probing } from '../utils/probing'
 import { validateResponse, sendAlerts } from './alert'
 
 const MILLISECONDS = 1000
-async function doProbes(config: Config) {
-  log('\nProbes: ')
-  config.probes.forEach(async (item) => {
-    log(`Probe ID: ${item.id}`)
-    log(`Probe Name: ${item.name}`)
-    log(`Probe Description: ${item.description}`)
-    log(`Probe Request Method: ${item.request.method}`)
-    log(`Probe Request URL: ${item.request.url}`)
-    log(`Probe Request Headers: ${JSON.stringify(item.request.headers)}`)
-    log(`Probe Request Body: ${JSON.stringify(item.request.body)}`)
-    log(`Probe Alerts: ${item.alerts.toString()}\n`)
 
-    // probe each url
-    log('\nProbing....')
+async function doProbes(config: Config) {
+  // probe each url
+  log('\nProbing....')
+  config.probes.forEach(async (item) => {
     try {
       const probRes = await probing(item)
       const validatedResp = validateResponse(item.alerts, probRes)
 
-      log('status:', probRes.status, 'for:', item.request.url)
+      log('id:', item.id, '- status:', probRes.status, 'for:', item.request.url)
 
       await sendAlerts({
         validations: validatedResp,
@@ -37,6 +28,18 @@ async function doProbes(config: Config) {
 
 export function looper(config: Config) {
   const interval = config.interval ?? 0
+
+  log('Probes:')
+  config.probes.forEach(async (item) => {
+    log(`Probe ID: ${item.id}`)
+    log(`Probe Name: ${item.name}`)
+    log(`Probe Description: ${item.description}`)
+    log(`Probe Request Method: ${item.request.method}`)
+    log(`Probe Request URL: ${item.request.url}`)
+    log(`Probe Request Headers: ${JSON.stringify(item.request.headers)}`)
+    log(`Probe Request Body: ${JSON.stringify(item.request.body)}`)
+    log(`Probe Alerts: ${item.alerts.toString()}\n`)
+  })
 
   doProbes(config).catch((error) => console.error(error.message))
   if (interval > 0) {


### PR DESCRIPTION
# PR

## What issue this pr fixes

I found the display of all the probes in the config while repeating annoying.
So displaying the probes once, and only the results during looper.

## Changes
1. removed the probe display/logs from main loop
2. fix some typos
