### PR TITLE
Update exit message

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -18,11 +18,12 @@ require(`../${dev ? 'src' : 'lib'}`)
  */
 process.on('SIGINT', () => {
   if (!process.env.DISABLE_EXIT_MESSAGE) {
-    console.log('\nThank you for using http-probe!')
-    console.log('We need your help to make http-probe better.')
+    console.log('\nThank you for using Monika!')
+    console.log('We need your help to make Monika better.')
     console.log(
-      'Can you give us some feedback by clicking this link https://github.com/hyperjumptech/http-probe/discussions ?'
+      'Can you give us some feedback by clicking this link https://github.com/hyperjumptech/monika/discussions ?'
     )
+    console.log('')
   }
   process.exit(process.exitCode)
 })


### PR DESCRIPTION
This PR replaces `http-probe` strings to `monika` in the exit message.