### PR TITLE
Chore: Change example, test, and documentation domain to example.com

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -5,7 +5,7 @@
       "id": "unique-id-mailgun",
       "type": "mailgun",
       "data": {
-        "recipients": ["recipient1@mailgun.com"],
+        "recipients": ["recipient1@example.com"],
         "apiKey": "YOUR_API_KEY",
         "domain": "YOUR_DOMAIN"
       }
@@ -14,7 +14,7 @@
       "id": "unique-id-sendgrid",
       "type": "sendgrid",
       "data": {
-        "recipients": ["recipient1@sendgrid.com"],
+        "recipients": ["recipient1@example.com"],
         "apiKey": "YOUR_API_KEY"
       }
     },
@@ -22,8 +22,8 @@
       "id": "unique-id-smtp",
       "type": "smtp",
       "data": {
-        "recipients": ["recipient1@smtp.com"],
-        "hostname": "smtp.mail.com",
+        "recipients": ["recipient1@example.com"],
+        "hostname": "smtp.example.com",
         "port": 222,
         "username": "smtpusername",
         "password": "smtppassword"
@@ -34,7 +34,7 @@
       "type": "webhook",
       "data": {
         "method": "POST",
-        "url": "https://examplewebhookurl.com/webhook"
+        "url": "https://example.com/webhook"
       }
     }
   ],

--- a/test/testConfigs/mailgun/mailgunconfig.json
+++ b/test/testConfigs/mailgun/mailgunconfig.json
@@ -5,7 +5,7 @@
       "id": "unique-id",
       "type": "mailgun",
       "data": {
-        "recipients": ["a@a.com"],
+        "recipients": ["a@example.com"],
         "apiKey": "adfsafdsadfdsafsafds",
         "domain": "api.mailgun.net"
       }

--- a/test/testConfigs/noInterval.json
+++ b/test/testConfigs/noInterval.json
@@ -4,7 +4,7 @@
       "id": "unique-id",
       "type": "webhook",
       "data": {
-        "url": "http://www.dennypradipta.com",
+        "url": "http://www.example.com",
         "method": "GET"
       }
     }

--- a/test/testConfigs/probes/invalidProbeRequestAlert.json
+++ b/test/testConfigs/probes/invalidProbeRequestAlert.json
@@ -4,7 +4,7 @@
       "id": "unique-id",
       "type": "webhook",
       "data": {
-        "url": "http://www.dennypradipta.com",
+        "url": "http://www.example.com",
         "method": "GET"
       }
     }

--- a/test/testConfigs/probes/invalidProbeRequestMethod.json
+++ b/test/testConfigs/probes/invalidProbeRequestMethod.json
@@ -4,7 +4,7 @@
       "id": "unique-id",
       "type": "webhook",
       "data": {
-        "url": "http://www.dennypradipta.com",
+        "url": "http://www.example.com",
         "method": "GET"
       }
     }

--- a/test/testConfigs/probes/invalidProbeRequestURL.json
+++ b/test/testConfigs/probes/invalidProbeRequestURL.json
@@ -4,7 +4,7 @@
       "id": "unique-id",
       "type": "webhook",
       "data": {
-        "url": "http://www.dennypradipta.com",
+        "url": "http://www.example.com",
         "method": "GET"
       }
     }

--- a/test/testConfigs/probes/noProbeAlerts.json
+++ b/test/testConfigs/probes/noProbeAlerts.json
@@ -4,7 +4,7 @@
       "id": "unique-id",
       "type": "webhook",
       "data": {
-        "url": "http://www.dennypradipta.com",
+        "url": "http://www.example.com",
         "method": "GET"
       }
     }

--- a/test/testConfigs/probes/noProbeName.json
+++ b/test/testConfigs/probes/noProbeName.json
@@ -4,7 +4,7 @@
       "id": "unique-id",
       "type": "webhook",
       "data": {
-        "url": "http://www.dennypradipta.com",
+        "url": "http://www.example.com",
         "method": "GET"
       }
     }

--- a/test/testConfigs/probes/noProbeRequest.json
+++ b/test/testConfigs/probes/noProbeRequest.json
@@ -4,7 +4,7 @@
       "id": "unique-id",
       "type": "webhook",
       "data": {
-        "url": "http://www.dennypradipta.com",
+        "url": "http://www.example.com",
         "method": "GET"
       }
     }

--- a/test/testConfigs/probes/noProbes.json
+++ b/test/testConfigs/probes/noProbes.json
@@ -5,7 +5,7 @@
       "id": "unique-id",
       "type": "webhook",
       "data": {
-        "url": "http://www.dennypradipta.com",
+        "url": "http://www.example.com",
         "method": "GET"
       }
     }

--- a/test/testConfigs/sendgrid/sendgridconfig.json
+++ b/test/testConfigs/sendgrid/sendgridconfig.json
@@ -5,7 +5,7 @@
       "id": "unique-id",
       "type": "sendgrid",
       "data": {
-        "recipients": ["a@a.com"],
+        "recipients": ["a@example.com"],
         "apiKey": "adfsafdsadfdsafsafds"
       }
     }

--- a/test/testConfigs/smtp/smtpconfig.json
+++ b/test/testConfigs/smtp/smtpconfig.json
@@ -5,8 +5,8 @@
       "id": "unique-id",
       "type": "smtp",
       "data": {
-        "recipients": ["a@a.com"],
-        "hostname": "https://www.dennypradipta.com",
+        "recipients": ["a@example.com"],
+        "hostname": "https://www.example.com",
         "port": 8080,
         "username": "dennypradipta",
         "password": "bismillah"

--- a/test/testConfigs/smtp/smtpconfigNoRecipients.json
+++ b/test/testConfigs/smtp/smtpconfigNoRecipients.json
@@ -5,7 +5,7 @@
       "id": "unique-id",
       "type": "smtp",
       "data": {
-        "hostname": "https://www.dennypradipta.com",
+        "hostname": "https://www.example.com",
         "port": 8080,
         "username": "dennypradipta",
         "password": "bismillah"

--- a/test/testConfigs/webhook/webhookconfig.json
+++ b/test/testConfigs/webhook/webhookconfig.json
@@ -5,7 +5,7 @@
       "id": "unique-id",
       "type": "webhook",
       "data": {
-        "url": "http://www.dennypradipta.com",
+        "url": "http://www.example.com",
         "method": "GET"
       }
     }

--- a/test/testMail/smtp.test.ts
+++ b/test/testMail/smtp.test.ts
@@ -10,8 +10,8 @@ const transport: Mail = mailMock.createTransport({
   port: 2323,
 })
 const opt: Mail.Options = {
-  from: 'me@mail.com',
-  to: 'symontest@mailinator.com',
+  from: 'me@example.com',
+  to: 'symontest@example.com',
   subject: 'unit test',
   html: '<p>A unit test</p>',
 }
@@ -24,7 +24,7 @@ describe('Smtp test', () => {
         port: 587,
         username: 'me@symon.org',
         password: 'symonPass',
-        recipients: ['symon@mailinator.com'],
+        recipients: ['symon@example.com'],
       }
 
       const res = createSmtpTransport(mockCfg)
@@ -37,7 +37,7 @@ describe('Smtp test', () => {
         port: 587,
         username: 'me@symon.org',
         password: 'symonPass',
-        recipients: ['symon@mailinator.com'],
+        recipients: ['symon@example.com'],
       }
 
       expect(() => createSmtpTransport(mockCfg)).to.throw(
@@ -51,7 +51,7 @@ describe('Smtp test', () => {
         port: 0,
         username: 'me@symon.org',
         password: 'symonPass',
-        recipients: ['symon@mailinator.com'],
+        recipients: ['symon@example.com'],
       }
 
       expect(() => createSmtpTransport(mockCfg)).to.throw(
@@ -65,7 +65,7 @@ describe('Smtp test', () => {
         port: 587,
         username: '',
         password: 'symonPass',
-        recipients: ['symon@mailinator.com'],
+        recipients: ['symon@example.com'],
       }
 
       expect(() => createSmtpTransport(mockCfg)).to.throw(
@@ -79,7 +79,7 @@ describe('Smtp test', () => {
         port: 587,
         username: 'me@symon.org',
         password: '',
-        recipients: ['symon@mailinator.com'],
+        recipients: ['symon@example.com'],
       }
 
       expect(() => createSmtpTransport(mockCfg)).to.throw(
@@ -97,8 +97,8 @@ describe('Smtp test', () => {
       })
 
       const res = await sendSmtpMail(transport, {
-        from: 'me@mail.com',
-        to: 'symontest@mailinator.com',
+        from: 'me@example.com',
+        to: 'symontest@example.com',
         subject: 'unit test',
         html: '<p>A unit test</p>',
       })

--- a/test/utils/is-valid-url.test.ts
+++ b/test/utils/is-valid-url.test.ts
@@ -3,19 +3,19 @@ import { isValidURL } from './../../src/utils/is-valid-url'
 
 describe('check if URL is valid', () => {
   it('should return true if URL using http protocol', () => {
-    const valid = isValidURL('http://www.google.com')
+    const valid = isValidURL('http://www.example.com')
     expect(valid).to.be.a('boolean')
     expect(valid).to.be.equals(true)
   })
 
   it('should return true if URL using https protocol', () => {
-    const valid = isValidURL('https://www.google.com')
+    const valid = isValidURL('https://www.example.com')
     expect(valid).to.be.a('boolean')
     expect(valid).to.be.equals(true)
   })
 
   it('should return false if not using http or https protocol', () => {
-    const valid = isValidURL('www.google.com')
+    const valid = isValidURL('www.example.com')
     expect(valid).to.be.a('boolean')
     expect(valid).to.be.equals(false)
   })


### PR DESCRIPTION
example.com domain is intended for documentation and also described in [RFC 2606](https://tools.ietf.org/html/rfc2606) and [RFC 6761](https://tools.ietf.org/html/rfc6761). It makes user understand that the domain is only example, and it prevents accidentally get email or traffic from Monika.