### PR TITLE
chore: Change the link to download config sample from github

### DIFF
--- a/src/utils/parse-config.ts
+++ b/src/utils/parse-config.ts
@@ -13,7 +13,7 @@ export const parseConfig = async (configPath: string) => {
     return output
   } catch (error) {
     throw new Error(
-      'Config file not found! Copy example config from https://github.com/hyperjumptech/monika/blob/main/config.example.json'
+      'Config file not found! Copy example config from https://raw.githubusercontent.com/hyperjumptech/monika/main/config.example.json'
     )
   }
 }


### PR DESCRIPTION
Change url of example config file when there is no config file

### screenshot:
<img width="594" alt="Screen Shot 2021-03-18 at 09 16 03" src="https://user-images.githubusercontent.com/5974862/111563555-c0a34080-87ca-11eb-90f6-a5ab4fd5f5cc.png">
