### PR TITLE
Removed No Threshold Warning from looper.ts

### DIFF
--- a/src/utils/looper.ts
+++ b/src/utils/looper.ts
@@ -18,11 +18,6 @@ async function doProbes(config: Config) {
         `id: ${item.id} - status: ${probRes.status} for: ${item.request.url} -- ${probRes.config.extraData?.responseTime}`
       )
 
-      if (!item.trueThreshold)
-        log(`No success threshold defined. Using the default threshold: 5`)
-      if (!item.falseThreshold)
-        log(`No failed threshold defined. Using the default threshold: 5`)
-
       const serverStatuses = processProbeStatus({
         probe: item,
         validatedResp,

--- a/src/utils/validate-config.ts
+++ b/src/utils/validate-config.ts
@@ -1,5 +1,6 @@
-import { getCheckResponseFn } from './alert'
 /* eslint-disable complexity */
+import { warn } from 'console'
+import { getCheckResponseFn } from './alert'
 import { Notification } from '../interfaces/notification'
 import {
   SMTPData,
@@ -165,13 +166,29 @@ export const validateConfig = async (configuration: Config) => {
 
   // Check probes properties
   for (const probe of data.probes) {
-    const { alerts, name, request } = probe as Probe
+    const {
+      id,
+      alerts,
+      name,
+      request,
+      trueThreshold,
+      falseThreshold,
+    } = probe as Probe
 
     if (!name) return PROBE_NO_NAME
 
     if (!request) return PROBE_NO_REQUEST
 
     if ((alerts?.length ?? 0) === 0) return PROBE_NO_ALERT
+
+    if (!trueThreshold)
+      warn(
+        `Warning: Probe ${id} has no trueThreshold configuration defined. Using the default threshold: 5`
+      )
+    if (!falseThreshold)
+      warn(
+        `Warning: Probe ${id} has no falseThreshold configuration defined. Using the default threshold: 5`
+      )
 
     // Check probe request properties
     const { url, method } = request as RequestConfig


### PR DESCRIPTION
This PR fixes #59 which is to solve displaying No Threshold warning only once instead of each probing.

Before:
![image](https://user-images.githubusercontent.com/16670475/111749484-70100e00-88c4-11eb-9fe7-1a8f7e70fad8.png)

After:
![image](https://user-images.githubusercontent.com/16670475/111749460-6a1a2d00-88c4-11eb-89ec-9c5eb72ec6fc.png)
