### PR TITLE
Improve Error Logs when Reading JSON Configuration File

### DIFF
--- a/src/utils/parse-config.ts
+++ b/src/utils/parse-config.ts
@@ -1,19 +1,31 @@
-import { readFileSync } from 'fs'
-import { Config } from '../interfaces/config'
+import { Config } from './../interfaces/config'
+import { readFile } from 'fs'
+import { promisify } from 'util'
 
 export const parseConfig = async (configPath: string) => {
+  // Read file from configPath
   try {
     // Read file from configPath
-    const config: string = readFileSync(configPath).toString()
+    const readFileAsync = promisify(readFile)
+    const config: Buffer = await readFileAsync(configPath)
 
     // Parse the content
-    const output: Config = JSON.parse(config)
+    const configString: string = await config.toString()
+    const output: Config = await JSON.parse(configString)
 
     // Return the output as string
     return output
   } catch (error) {
-    throw new Error(
-      'Config file not found! Copy example config from https://raw.githubusercontent.com/hyperjumptech/monika/main/config.example.json'
-    )
+    if (error.code === 'ENOENT' && error.path === configPath) {
+      throw new Error(
+        'JSON configuration file not found! Copy example config from https://raw.githubusercontent.com/hyperjumptech/monika/main/config.example.json'
+      )
+    }
+
+    if (error.name === 'SyntaxError') {
+      throw new Error('JSON configuration file is in invalid JSON format!')
+    }
+
+    throw new Error(error.message)
   }
 }


### PR DESCRIPTION
This PR fixes #74 , which is to fix error displayed when JSON configuration file is in invalid format.

![image](https://user-images.githubusercontent.com/16670475/112092189-9934e500-8bc9-11eb-8825-800e80524802.png)
