### PR TITLE
docs: add explanation how to run in background

### DIFF
--- a/docs/src/pages/quick-start.md
+++ b/docs/src/pages/quick-start.md
@@ -129,7 +129,7 @@ npx @hyperjumptech/monika -c <path_to_configuration_json_file>
 
 ## Background run
 
-By default Monika will run in the foreground. Like other Node.js applications, there are several ways to run Monika in the background.
+By default Monika will run in the foreground. Like other Node.js applications, there are several ways to run Monika in the background on Unix, Linux, and macOS.
 
 ### Using `nohup`
 
@@ -147,7 +147,7 @@ By default Monika will run in the foreground. Like other Node.js applications, t
 
 ### Using `screen`
 
-- Run `screen`
+- Run `screen`. If you haven't installed it yet, you need to install it first. On Linux, please run `sudo apt install screen`. 
 - Run `monika -c config.json`
 - Press Ctrl+a then D. This will cause Monika to run on a different screen in the background.
 - To go back to the screen, run `screen -ls` to list the running screens. You will get an output similar to the following.

--- a/docs/src/pages/quick-start.md
+++ b/docs/src/pages/quick-start.md
@@ -147,7 +147,7 @@ By default Monika will run in the foreground. Like other Node.js applications, t
 
 ### Using `screen`
 
-- Run `screen`. If you haven't installed it yet, you need to install it first. On Linux, please run `sudo apt install screen`. 
+- Run `screen`. If you haven't installed it yet, you need to install it first. On Linux, please run `sudo apt install screen`.
 - Run `monika -c config.json`
 - Press Ctrl+a then D. This will cause Monika to run on a different screen in the background.
 - To go back to the screen, run `screen -ls` to list the running screens. You will get an output similar to the following.

--- a/docs/src/pages/quick-start.md
+++ b/docs/src/pages/quick-start.md
@@ -126,3 +126,39 @@ Or if you haven't installed Monika globally, you can run it without installing f
 ```bash
 npx @hyperjumptech/monika -c <path_to_configuration_json_file>
 ```
+
+## Background run
+
+By default Monika will run in the foreground. Like other Node.js applications, there are several ways to run Monika in the background.
+
+### Using `nohup`
+
+- On your terminal, run `nohup monika &`
+- You'll get an output similar to the following.
+
+  ```
+  [1] 93457
+  appending output to nohup.out
+  ```
+
+  In the above example, 93457 is the process ID (pid). And the output of Monika is written to `nohup.out` file.
+
+- To stop Monika, run `kill -9 <pid>`.
+
+### Using `screen`
+
+- Run `screen`
+- Run `monika -c config.json`
+- Press Ctrl+a then D. This will cause Monika to run on a different screen in the background.
+- To go back to the screen, run `screen -ls` to list the running screens. You will get an output similar to the following.
+
+  ```
+  There is a screen on:
+    9049.pts-0.the-server	(03/23/21 08:34:38)	(Detached)
+    1 Socket in /run/screen/S-server.
+  ```
+
+  `9049.pts-0.the-server` is the name of the screen.
+
+- Then run `screen -r <name_of_the_screen>`.
+- To stop Monika, hit Ctrl+c then Ctrl+d.


### PR DESCRIPTION
This PR adds a section in docs on how to run Monika in the background.