### PR TITLE
chore: Notify Hyperjump Teams channel when publish new version

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,11 +24,8 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: ${{ matrix.node-version }}
-            - run: npm ci
-            - run: npm run build --if-present
-            - run: npm test
             - name: Notify Teams
               uses: joelwmale/webhook-action@fd99bb3b8272237103e349e9bb4d9b0ead9a217c
               with:
-                url: ${{secrets.HYPERJUMP_TEAMS_SYMON_WEBHOOK}}
+                url: https://hyperjump.webhook.office.com/webhookb2/604ef4ce-d04b-4cc4-b65d-4b723b218ba7@9def1f60-dd5b-4bb2-ba50-ecbd7a895ce2/IncomingWebhook/ab51ac0ee3244d7aba2e07386bcf0c72/cc3e4e90-6e9b-403f-a5f9-5ebc600105c0
                 body: '{"sections": [{"activityTitle": "Monika NPM Release (hook test)", "activitySubtitle": "Version: x.y.z"}]}'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,4 +24,7 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: ${{ matrix.node-version }}
+            - run: npm ci
+            - run: npm run build --if-present
+            - run: npm test
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,3 +27,8 @@ jobs:
             - run: npm ci
             - run: npm run build --if-present
             - run: npm test
+            - name: Notify Teams
+              uses: joelwmale/webhook-action@fd99bb3b8272237103e349e9bb4d9b0ead9a217c
+              with:
+                url: ${{secrets.HYPERJUMP_TEAMS_SYMON_WEBHOOK}}
+                body: '{"sections": [{"activityTitle": "Monika NPM Release (hook test)", "activitySubtitle": "Version: x.y.z"}]}'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,8 +24,11 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: ${{ matrix.node-version }}
+            - name: get-npm-version
+              id: package-version
+              uses: martinbeentjes/npm-get-version-action@master
             - name: Notify Teams
               uses: joelwmale/webhook-action@fd99bb3b8272237103e349e9bb4d9b0ead9a217c
               with:
                 url: https://hyperjump.webhook.office.com/webhookb2/604ef4ce-d04b-4cc4-b65d-4b723b218ba7@9def1f60-dd5b-4bb2-ba50-ecbd7a895ce2/IncomingWebhook/ab51ac0ee3244d7aba2e07386bcf0c72/cc3e4e90-6e9b-403f-a5f9-5ebc600105c0
-                body: '{"sections": [{"activityTitle": "Monika NPM Release (hook test)", "activitySubtitle": "Version: x.y.z"}]}'
+                body: '{"title": "Monika NPM Release", "Text": "Version: ${{ steps.package-version.outputs.current-version}}"}'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,4 +27,3 @@ jobs:
             - run: npm ci
             - run: npm run build --if-present
             - run: npm test
-

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,11 +24,4 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: ${{ matrix.node-version }}
-            - name: get-npm-version
-              id: package-version
-              uses: martinbeentjes/npm-get-version-action@master
-            - name: Notify Teams
-              uses: joelwmale/webhook-action@fd99bb3b8272237103e349e9bb4d9b0ead9a217c
-              with:
-                url: https://hyperjump.webhook.office.com/webhookb2/604ef4ce-d04b-4cc4-b65d-4b723b218ba7@9def1f60-dd5b-4bb2-ba50-ecbd7a895ce2/IncomingWebhook/ab51ac0ee3244d7aba2e07386bcf0c72/cc3e4e90-6e9b-403f-a5f9-5ebc600105c0
-                body: '{"title": "Monika NPM Release", "Text": "Version: ${{ steps.package-version.outputs.current-version}}"}'
+

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,7 +43,12 @@ jobs:
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - uses: joelwmale/webhook-action@fd99bb3b8272237103e349e9bb4d9b0ead9a217c
+      - name: get-npm-version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@master
+      - name: Notify Teams
+        uses: joelwmale/webhook-action@fd99bb3b8272237103e349e9bb4d9b0ead9a217c
         with:
           url: ${{ secrets.HYPERJUMP_TEAMS_SYMON_WEBHOOK }}
-          body: '{"title": "Monika NPM Release", "summary": "Version: x.y.z"}'
+          body: '{"title": "Monika NPM Release", "Text": "Version: ${{ steps.package-version.outputs.current-version}}"}'
+      

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,7 +43,7 @@ jobs:
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - name: get-npm-version
+      - name: Get Package Version
         id: package-version
         uses: martinbeentjes/npm-get-version-action@master
       - name: Notify Teams

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,3 +43,7 @@ jobs:
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - uses: joelwmale/webhook-action@fd99bb3b8272237103e349e9bb4d9b0ead9a217c
+        with:
+          url: ${{ secrets.HYPERJUMP_TEAMS_SYMON_WEBHOOK }}
+          body: '{"title": "Monika NPM Release", "summary": "Version: x.y.z"}'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -49,6 +49,6 @@ jobs:
       - name: Notify Teams
         uses: joelwmale/webhook-action@fd99bb3b8272237103e349e9bb4d9b0ead9a217c
         with:
-          url: ${{ secrets.HYPERJUMP_TEAMS_SYMON_WEBHOOK }}
-          body: '{"title": "Monika NPM Release", "Text": "Version: ${{ steps.package-version.outputs.current-version}}"}'
+          url: ${{secrets.HYPERJUMP_TEAMS_SYMON_WEBHOOK}}
+          body: '{"title": "Monika NPM Release", "Text": "Version: ${{steps.package-version.outputs.current-version}}"}'
       


### PR DESCRIPTION
implementing issue #96 by adding command in `npm-publish.yml`:
- get package version
- webhook

### Example:
<img width="577" alt="Screen Shot 2021-03-26 at 17 25 46" src="https://user-images.githubusercontent.com/5974862/112620397-0f03af80-8e5b-11eb-915e-25a24dfedd84.png">
