### PR TITLE
Allow Multiple Request in One Probe for Request Chaining

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -6,18 +6,20 @@
       "name": "Example",
       "description": "Probe",
       "interval": 10,
-      "request": {
-        "method": "GET",
-        "url": "https://github.com",
-        "timeout": 7000,
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "GET",
+          "url": "https://github.com",
+          "timeout": 7000,
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "incidentThreshold": 3,
       "recoveryThreshold": 3,
       "alerts": ["status-not-2xx", "response-time-greater-than-400-ms"]

--- a/config_sample/config.sendgrid.example.json
+++ b/config_sample/config.sendgrid.example.json
@@ -11,9 +11,11 @@
   ],
   "probes": [
     {
-      "request": {
-        "url": "https://github.com"
-      }
+      "requests": [
+        {
+          "url": "https://github.com"
+        }
+      ]
     }
   ]
 }

--- a/config_sample/config.slack.example.json
+++ b/config_sample/config.slack.example.json
@@ -10,9 +10,11 @@
   ],
   "probes": [
     {
-      "request": {
-        "url": "https://github.com"
-      }
+      "requests": [
+        {
+          "url": "https://github.com"
+        }
+      ]
     }
   ]
 }

--- a/config_sample/config.smtp-gmail.example.json
+++ b/config_sample/config.smtp-gmail.example.json
@@ -14,9 +14,11 @@
   ],
   "probes": [
     {
-      "request": {
-        "url": "https://github.com"
-      }
+      "requests": [
+        {
+          "url": "https://github.com"
+        }
+      ]
     }
   ]
 }

--- a/config_sample/config.webhook.example.json
+++ b/config_sample/config.webhook.example.json
@@ -10,9 +10,11 @@
   ],
   "probes": [
     {
-      "request": {
-        "url": "https://github.com"
-      }
+      "requests": [
+        {
+          "url": "https://github.com"
+        }
+      ]
     }
   ]
 }

--- a/config_sample/config.whatsapp.example.json
+++ b/config_sample/config.whatsapp.example.json
@@ -13,9 +13,11 @@
   ],
   "probes": [
     {
-      "request": {
-        "url": "https://github.com"
-      }
+      "requests": [
+        {
+          "url": "https://github.com"
+        }
+      ]
     }
   ]
 }

--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -9,7 +9,7 @@ Probes are the heart of the monitoring requests. Probes are arrays of request ob
       "name": "Name of the probe",
       "description": "Probe to check GET time",
       "interval": 10,
-      "request": { },
+      "requests": [{ }],
       "alerts": []
     },
     {
@@ -17,7 +17,7 @@ Probes are the heart of the monitoring requests. Probes are arrays of request ob
       "name": "Name of the probe 2",
       "description": "Probe to check GET health",
       "interval": 10,
-      "request": { },
+      "requests": [{ }],
       "alerts": []
     }
   ]
@@ -36,7 +36,7 @@ An actual probe request may be something like below.
       "name": "Example: get Time",
       "description": "Probe",
       "interval": 10,
-      "request": {
+      "requests": [{
         "method": "POST",
         "url": "https://mybackend.org/user/login",
         "timeout": 7000,
@@ -47,7 +47,7 @@ An actual probe request may be something like below.
           "username": "someusername",
           "password": "somepassword"
         }
-      },
+      }],
       "incidentThreshold": 3,
       "recoveryThreshold": 3,
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]
@@ -80,7 +80,7 @@ Here is probes example with POST request to simulate HTML form submission
       "name": "HTML form submission",
       "description": "simulate html form submission",
       "interval": 10,
-      "request": {
+      "requests": [{
         "method": "POST",
         "url": "http://www.foo.com/login.php",
         "timeout": 7000,
@@ -91,7 +91,7 @@ Here is probes example with POST request to simulate HTML form submission
           "username": "someusername",
           "password": "somepassword"
         }
-      },
+      }],
       "incidentThreshold": 3,
       "recoveryThreshold": 3,
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]

--- a/docs/src/pages/quick-start.md
+++ b/docs/src/pages/quick-start.md
@@ -28,10 +28,12 @@ Follow the following steps to quickly monitor this Monica website and to get not
          "name": "Monika Landing Page",
          "description": "Landing page of awesome Monika",
          "interval": 10,
-         "request": {
-           "url": "https://hyperjumptech.github.io/monika",
-           "timeout": 7000
-         },
+         "requests": [
+           {
+             "url": "https://hyperjumptech.github.io/monika",
+             "timeout": 7000
+           }
+         ],
          "alerts": ["status-not-2xx"]
        }
      ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,12 +115,14 @@ class Monika extends Command {
           console.log(`    Name: ${probe.name}`)
           console.log(`    Description: ${probe.description}`)
           console.log(`    Interval: ${probe.interval}`)
-          console.log(`    Request Method: ${probe.request.method}`)
-          console.log(`    Request URL: ${probe.request.url}`)
-          console.log(
-            `    Request Headers: ${JSON.stringify(probe.request.headers)}`
-          )
-          console.log(`    Request Body: ${JSON.stringify(probe.request.body)}`)
+          probe.requests.forEach((request) => {
+            console.log(`    Request Method: ${request.method}`)
+            console.log(`    Request URL: ${request.url}`)
+            console.log(
+              `    Request Headers: ${JSON.stringify(request.headers)}`
+            )
+            console.log(`    Request Body: ${JSON.stringify(request.body)}`)
+          })
           console.log(`    Alerts: ${probe.alerts.join(', ')}`)
         })
         console.log('')

--- a/src/interfaces/probe.ts
+++ b/src/interfaces/probe.ts
@@ -29,7 +29,7 @@ export interface Probe {
   name: string
   description?: string
   interval?: number
-  request: RequestConfig
+  requests: RequestConfig[]
   incidentThreshold: number
   recoveryThreshold: number
   alerts: string[]

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -103,11 +103,13 @@ export async function flushAllLogs() {
  *
  * @param {object} probe is the probe config
  * @param {object} probeRes this is the response time of the probe
+ * @param {number} requestIndex is the request index from a probe
  * @param {string} errorResp if there was an error, it will be stored here
  */
 export async function saveLog(
   probe: Probe,
   probeRes: AxiosResponseWithExtraData,
+  requestIndex: number,
   errorResp: string
 ) {
   const insertSQL = `INSERT into history (probe_id, created_at, status_code, probe_name, probe_url, response_time, error_resp) 
@@ -120,7 +122,7 @@ export async function saveLog(
     created,
     probeRes.status,
     probe.name,
-    probe.request.url,
+    probe.requests[requestIndex].url,
     probeRes.config.extraData?.responseTime,
     errorResp,
   ]

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -55,22 +55,29 @@ export function getStatusColor(statusCode: number) {
  * @param {AxiosResponseWithExtraData} probRes is result of the probing
  * @param {string} err if theres any error, catch it here
  */
-export async function probeLog(
-  checkOrder: number,
-  probe: Probe,
-  probRes: AxiosResponseWithExtraData,
+export async function probeLog({
+  checkOrder,
+  probe,
+  probeRes,
+  requestIndex,
+  err,
+}: {
+  checkOrder: number
+  probe: Probe
+  probeRes: AxiosResponseWithExtraData
+  requestIndex: number
   err: string
-) {
+}) {
   log.info({
     type: 'PROBE',
     checkOrder,
     probeId: probe.id,
-    url: probe.request.url,
-    statusCode: probRes.status,
-    responseTime: probRes.config.extraData?.responseTime,
+    url: probe.requests[requestIndex].url,
+    statusCode: probeRes.status,
+    responseTime: probeRes.config.extraData?.responseTime,
   })
 
-  await saveLog(probe, probRes, err)
+  await saveLog(probe, probeRes, requestIndex, err)
 }
 
 export async function printAllLogs() {

--- a/src/utils/probing.ts
+++ b/src/utils/probing.ts
@@ -22,14 +22,14 @@
  * SOFTWARE.                                                                      *
  **********************************************************************************/
 
+import { RequestConfig } from './../interfaces/request'
 import { request } from './request'
-import { Probe } from '../interfaces/probe'
 import { AxiosResponseWithExtraData } from '../interfaces/request'
 
-export async function probing(probe: Probe) {
+export async function probing(requestConfig: RequestConfig) {
   try {
     const res = await request({
-      ...probe.request,
+      ...requestConfig,
     })
     return res as AxiosResponseWithExtraData
   } catch (error) {

--- a/src/utils/process-server-status.ts
+++ b/src/utils/process-server-status.ts
@@ -163,6 +163,7 @@ export const processProbeStatus = ({
   checkOrder,
   probe,
   probeRes,
+  requestIndex,
   validatedResp,
   incidentThreshold,
   recoveryThreshold,
@@ -170,6 +171,7 @@ export const processProbeStatus = ({
   checkOrder: number
   probe: Probe
   probeRes: AxiosResponseWithExtraData
+  requestIndex: number
   validatedResp: ValidateResponseStatus[]
   incidentThreshold: number
   recoveryThreshold: number
@@ -252,7 +254,7 @@ export const processProbeStatus = ({
             consecutiveTrue: updatedStatus.consecutiveTrue,
             probeId: probe.id,
             checkOrder,
-            url: probe.request?.url,
+            url: probe.requests[requestIndex].url,
             statusCode: probeRes.status,
             responseTime: probeRes.config.extraData?.responseTime,
           })

--- a/src/utils/validate-config.ts
+++ b/src/utils/validate-config.ts
@@ -74,9 +74,9 @@ const PROBE_NO_NAME = {
   valid: false,
   message: 'Probe name should not be empty',
 }
-const PROBE_NO_REQUEST = {
+const PROBE_NO_REQUESTS = {
   valid: false,
-  message: 'Probe request should not be empty',
+  message: 'Probe requests does not exists or has length lower than 1!',
 }
 const PROBE_REQUEST_INVALID_URL = {
   valid: false,
@@ -236,14 +236,14 @@ export const validateConfig = async (configuration: Config) => {
       id,
       alerts,
       name,
-      request,
+      requests,
       incidentThreshold,
       recoveryThreshold,
     } = probe as Probe
 
     if (!name) return PROBE_NO_NAME
 
-    if (!request) return PROBE_NO_REQUEST
+    if ((requests?.length ?? 0) === 0) return PROBE_NO_REQUESTS
 
     if ((alerts?.length ?? 0) === 0) return PROBE_NO_ALERT
 
@@ -257,18 +257,20 @@ export const validateConfig = async (configuration: Config) => {
       )
 
     // Check probe request properties
-    const { url, method } = request as RequestConfig
+    for (const request of requests) {
+      const { url, method } = request as RequestConfig
 
-    if (url && !isValidURL(url)) return PROBE_REQUEST_INVALID_URL
+      if (url && !isValidURL(url)) return PROBE_REQUEST_INVALID_URL
 
-    if (method && ['GET', 'POST'].indexOf(method) < 0)
-      return PROBE_REQUEST_INVALID_METHOD
+      if (method && ['GET', 'POST'].indexOf(method) < 0)
+        return PROBE_REQUEST_INVALID_METHOD
 
-    // Check probe alert properties
-    for (const alert of alerts) {
-      const check = getCheckResponseFn(alert)
-      if (!check) {
-        return PROBE_ALERT_INVALID
+      // Check probe alert properties
+      for (const alert of alerts) {
+        const check = getCheckResponseFn(alert)
+        if (!check) {
+          return PROBE_ALERT_INVALID
+        }
       }
     }
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -96,7 +96,9 @@ describe('monika', () => {
       ])
     )
     .catch((error) => {
-      expect(error.message).to.contain('Probe request should not be empty')
+      expect(error.message).to.contain(
+        'Probe requests does not exists or has length lower than 1!'
+      )
     })
     .it('runs with config without probe request')
 

--- a/test/testConfigs/invalidNotificationType.json
+++ b/test/testConfigs/invalidNotificationType.json
@@ -12,17 +12,19 @@
       "name": "Example",
       "description": "Probe",
       "interval": 0,
-      "request": {
-        "method": "POST",
-        "url": "https://something/login",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "POST",
+          "url": "https://something/login",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "incidentThreshold": 2,
       "recoveryThreshold": 2,
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]

--- a/test/testConfigs/mailgun/mailgunconfig.json
+++ b/test/testConfigs/mailgun/mailgunconfig.json
@@ -16,17 +16,19 @@
       "name": "Example",
       "description": "Probe",
       "interval": 0,
-      "request": {
-        "method": "POST",
-        "url": "https://something/login",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "POST",
+          "url": "https://something/login",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "incidentThreshold": 2,
       "recoveryThreshold": 2,
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]

--- a/test/testConfigs/mailgun/mailgunconfigNoRecipients.json
+++ b/test/testConfigs/mailgun/mailgunconfigNoRecipients.json
@@ -15,17 +15,19 @@
       "name": "Example",
       "description": "Probe",
       "interval": 0,
-      "request": {
-        "method": "POST",
-        "url": "https://something/login",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "POST",
+          "url": "https://something/login",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]
     }
   ]

--- a/test/testConfigs/noInterval.json
+++ b/test/testConfigs/noInterval.json
@@ -14,17 +14,19 @@
       "id": "1",
       "name": "Example",
       "description": "Probe",
-      "request": {
-        "method": "POST",
-        "url": "https://something/login",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "POST",
+          "url": "https://something/login",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "incidentThreshold": 2,
       "recoveryThreshold": 2,
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]

--- a/test/testConfigs/noNotifications.json
+++ b/test/testConfigs/noNotifications.json
@@ -5,17 +5,19 @@
       "name": "something",
       "description": "some description",
       "interval": 0,
-      "request": {
-        "method": "POST",
-        "url": "https://something/login",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "POST",
+          "url": "https://something/login",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "incidentThreshold": 2,
       "recoveryThreshold": 2,
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]

--- a/test/testConfigs/probes/duplicateProbeId.json
+++ b/test/testConfigs/probes/duplicateProbeId.json
@@ -14,34 +14,38 @@
       "id": "1",
       "name": "Example 1",
       "description": "Probe",
-      "request": {
-        "method": "GET",
-        "url": "http://www.example.com",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "GET",
+          "url": "http://www.example.com",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "alerts": ["status-not-2xx"]
     },
     {
       "id": "1",
       "name": "Example 2",
       "description": "Probe",
-      "request": {
-        "method": "GET",
-        "url": "http://www.example.com",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "GET",
+          "url": "http://www.example.com",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "alerts": ["status-not-2xx"]
     }
   ]

--- a/test/testConfigs/probes/invalidProbeRequestAlert.json
+++ b/test/testConfigs/probes/invalidProbeRequestAlert.json
@@ -14,17 +14,19 @@
       "id": "1",
       "name": "Example",
       "description": "Probe",
-      "request": {
-        "method": "GET",
-        "url": "https://something/something",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "GET",
+          "url": "https://something/something",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "incidentThreshold": 2,
       "recoveryThreshold": 2,
       "alerts": ["status-not-2xx", "response-time-lower-than-200-ms"]

--- a/test/testConfigs/probes/invalidProbeRequestMethod.json
+++ b/test/testConfigs/probes/invalidProbeRequestMethod.json
@@ -14,17 +14,19 @@
       "id": "1",
       "name": "Example",
       "description": "Probe",
-      "request": {
-        "method": "PATCH",
-        "url": "https://something/something",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "PATCH",
+          "url": "https://something/something",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "incidentThreshold": 2,
       "recoveryThreshold": 2,
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]

--- a/test/testConfigs/probes/invalidProbeRequestURL.json
+++ b/test/testConfigs/probes/invalidProbeRequestURL.json
@@ -14,17 +14,19 @@
       "id": "1",
       "name": "Example",
       "description": "Probe",
-      "request": {
-        "method": "POST",
-        "url": "something/something",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "POST",
+          "url": "something/something",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "incidentThreshold": 2,
       "recoveryThreshold": 2,
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]

--- a/test/testConfigs/probes/noProbeAlerts.json
+++ b/test/testConfigs/probes/noProbeAlerts.json
@@ -14,17 +14,19 @@
       "id": "1",
       "name": "Example",
       "description": "Probe",
-      "request": {
-        "method": "POST",
-        "url": "https://something/login",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "POST",
+          "url": "https://something/login",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      }
+      ]
     }
   ]
 }

--- a/test/testConfigs/probes/noProbeName.json
+++ b/test/testConfigs/probes/noProbeName.json
@@ -13,17 +13,19 @@
     {
       "id": "1",
       "description": "Probe",
-      "request": {
-        "method": "POST",
-        "url": "https://something/login",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "POST",
+          "url": "https://something/login",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]
     }
   ]

--- a/test/testConfigs/sendgrid/sendgridconfig.json
+++ b/test/testConfigs/sendgrid/sendgridconfig.json
@@ -15,17 +15,19 @@
       "name": "Example",
       "description": "Probe",
       "interval": 0,
-      "request": {
-        "method": "POST",
-        "url": "https://something/login",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "POST",
+          "url": "https://something/login",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "incidentThreshold": 2,
       "recoveryThreshold": 2,
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]

--- a/test/testConfigs/sendgrid/sendgridconfigNoRecipients.json
+++ b/test/testConfigs/sendgrid/sendgridconfigNoRecipients.json
@@ -14,17 +14,19 @@
       "name": "Example",
       "description": "Probe",
       "interval": 0,
-      "request": {
-        "method": "POST",
-        "url": "https://something/login",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "POST",
+          "url": "https://something/login",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]
     }
   ]

--- a/test/testConfigs/smtp/smtpconfig.json
+++ b/test/testConfigs/smtp/smtpconfig.json
@@ -18,17 +18,19 @@
       "name": "Example",
       "description": "Probe",
       "interval": 0,
-      "request": {
-        "method": "POST",
-        "url": "https://something/login",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "POST",
+          "url": "https://something/login",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "incidentThreshold": 2,
       "recoveryThreshold": 2,
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]

--- a/test/testConfigs/smtp/smtpconfigNoRecipients.json
+++ b/test/testConfigs/smtp/smtpconfigNoRecipients.json
@@ -17,17 +17,19 @@
       "name": "Example",
       "description": "Probe",
       "interval": 0,
-      "request": {
-        "method": "POST",
-        "url": "https://something/login",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "POST",
+          "url": "https://something/login",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]
     }
   ]

--- a/test/testConfigs/webhook/webhookconfig.json
+++ b/test/testConfigs/webhook/webhookconfig.json
@@ -15,17 +15,19 @@
       "name": "Example",
       "description": "Probe",
       "interval": 0,
-      "request": {
-        "method": "POST",
-        "url": "https://something/login",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "POST",
+          "url": "https://something/login",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "incidentThreshold": 2,
       "recoveryThreshold": 2,
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]

--- a/test/testConfigs/whatsapp/whatsappconfig.json
+++ b/test/testConfigs/whatsapp/whatsappconfig.json
@@ -17,17 +17,19 @@
       "id": "1",
       "name": "Example",
       "description": "Probe",
-      "request": {
-        "method": "POST",
-        "url": "https://something/login",
-        "headers": {
-          "Authorization": ""
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "POST",
+          "url": "https://something/login",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      },
+      ],
       "trueThreshold": 2,
       "falseThreshold": 2,
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]


### PR DESCRIPTION
# Monika PR

## What does this PR solve?

This PR solve first phase of issue #82 :

[x] The requests should be perform one after another.
[x] If a request fails (status-not-2xx or response-time-greater-than), the next requests should not be performed.
[x] Like before, the notifications are only sent when the alert has been triggered more than the incidentThreshold.

## How do you implement this?

I made changes to the `request` key in `probe` object, which is to change singular object into an array of objects and rename it to `requests`. Then, I configured the `components/http-probe` to probe URLs sequentially using `for await`

## How do I test this?

1. Use this configuration below:
```
{
  "notifications": [
    <YOUR_NOTIFICATION_SETTINGS_HERE>
  ],
  "probes": [
    {
      "id": "1",
      "name": "Example",
      "description": "Probe",
      "interval": 10,
      "requests": [
        {
          "method": "GET",
          "url": "https://github.com",
          "timeout": 7000
        },
        {
          "method": "GET",
          "url": "https://dennypradipta.com",
          "timeout": 7000
        },
        {
          "method": "GET",
          "url": "https://www.indorelawan.org",
          "timeout": 7000
        }
      ],
      "incidentThreshold": 3,
      "recoveryThreshold": 3,
      "alerts": ["status-not-2xx", "response-time-greater-than-300-ms"]
    }
  ]
}
```
2. Run MONIKA with configuration above

## Additional Context

Please bear in mind that this PR does not include the phase 2, which is to use the response body from previous requests. This only solve 3 points I mentioned at the "What does this PR solves?" section.

### Screenshots
![image](https://user-images.githubusercontent.com/16670475/112803386-6abd7b00-909d-11eb-83b4-2ad202a467b8.png)
