### PR TITLE
Fix: Test Error When Use Smaller Width Console

### DIFF
--- a/src/utils/validate-config.ts
+++ b/src/utils/validate-config.ts
@@ -165,7 +165,6 @@ export const validateConfig = async (configuration: Config) => {
         margin: 1,
         borderStyle: 'bold',
         borderColor: 'yellow',
-        align: 'center',
       })
     )
   }


### PR DESCRIPTION
## What does this PR solve?

Fixes #109 :

When I ran Monika without notifications in windowed terminal, and the window width is not full-screen, it will throw an error `RangeError: Invalid count value`

## How do you implement this?

Remove align center

## How do I test this?

1. Run `npm run test`