### PR TITLE
Fix broken URL to edit on github

### DIFF
--- a/docs/src/siteConfig.js
+++ b/docs/src/siteConfig.js
@@ -1,6 +1,6 @@
 // List of projects/orgs using your project for the users page.
 export const siteConfig = {
-  editUrl: 'https://github.com/hyperjumptech/monika/edit/master/docs/src/pages',
+  editUrl: 'https://github.com/hyperjumptech/monika/edit/main/docs/src/pages',
   copyright: `Copyright © ${new Date().getFullYear()} Hyperjump Tech. All Rights Reserved.`,
   repoUrl: 'https://github.com/hyperjumptech/monika',
   algolia: {


### PR DESCRIPTION
right now all edit URL is pointing to master branch, since there is no master anymore, so its broken