### PR TITLE
Ability to Use Previous Request(s) Response in Chaining Requests

### DIFF
--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -130,11 +130,13 @@ In the configuration above, "Probing Github" probe will execute a GET request to
 
 If there is a case where executing GET request to `https://github.com` triggered an alert, the next request will not be executed.
 
-### Chaining Request
+### Requests Chaining
 
-Monika supports chaining request, which enables you to use previous request(s) response. For example, after executing a GET request to certain API, the next request could use the previous request(s) response into their path/query parameters.
+Monika supports requests chaining, which enables you to do multiple request and use previous request(s) response for other request. For example, after executing a GET request to certain API, the next request could use the previous request(s) response into their path/query parameters or headers.
 
-Here is an example configuration of chaining requests:
+#### Pass Response as Path/Query Parameters
+
+Here is an example of passing previous request(s) response into the path/query parameters:
 
 ```json
   "probes": [
@@ -151,10 +153,6 @@ Here is an example configuration of chaining requests:
         "method": "GET",
         "url": "https://reqres.in/api/users/{{ responses.[0].data.data.[0].id }}",
         "timeout": 7000,
-      },{
-        "method": "GET",
-        "url": "https://reqres.in/api/users/{{ responses.[0].data.data.[1].id }}",
-        "timeout": 7000,
       }],
       "incidentThreshold": 3,
       "recoveryThreshold": 3,
@@ -163,11 +161,67 @@ Here is an example configuration of chaining requests:
   ]
 ```
 
-In the configuration above, the process is explained below:
+In the configuration above, the first request will execute fetch all users available. If there are no triggered alerts, the response returned from the first request is ready to be used by the second request using `{{ responses.[0].data }}`. An example of the first request response should be like this:
 
-- First request should fetch a list of users.
-- If there are no alerts triggered, in the next request, it will fetch the first user by ID that has been fetched from the first request response.
-- If there are no alerts triggered, in the next request, it will fetch the second user by ID that has been fetched from the first request response.
+```json
+{
+  "page": 2,
+  "per_page": 6,
+  "total": 12,
+  "total_pages": 2,
+  "data": [
+    {
+        "id": 7,
+        "email": "michael.lawson@reqres.in",
+        "first_name": "Michael",
+        "last_name": "Lawson",
+        "avatar": "https://reqres.in/img/faces/7-image.jpg"
+    },
+    ...
+  ]
+```
+
+So, in order to access the ID of the user, we need to define in the config.json as `{{ responses.[0].data.data.[0].id }}` to get the first user ID from the first response. What if we want to get the `page` data? Simply just define it as `{{ responses.[0].data.page }}`.
+
+#### Pass Response as Headers value
+
+Here is an example of passing previous request(s) response into the headers:
+
+```json
+  "probes": [
+    {
+      "id": "1",
+      "name": "Probing Github",
+      "description": "simulate html form submission",
+      "interval": 10,
+      "requests": [{
+        "method": "POST",
+        "url": "https://reqres.in/api/login",
+        "timeout": 7000,
+        "body": {
+          "email": "eve.holt@reqres.in",
+          "password": "cityslicka"
+        }
+      },{
+        "method": "POST",
+        "url": "https://reqres.in/api/users/",
+        "timeout": 7000,
+        "body": {
+            "name": "morpheus",
+            "job": "leader"
+        },
+        "headers": {
+          "Authorization": "Bearer {{ responses.[0].data.token }}"
+        }
+      }],
+      "incidentThreshold": 3,
+      "recoveryThreshold": 3,
+      "alerts": ["status-not-2xx", "response-time-greater-than-2000-ms"]
+    },
+  ]
+```
+
+In example above, the first request will do the login process. After the first request returns the token, the token is being used for Authorization header in order to execute the second request.
 
 #### Response Anatomy
 

--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -134,7 +134,35 @@ If there is a case where executing GET request to `https://github.com` triggered
 
 Monika supports requests chaining, which enables you to do multiple request and use previous request(s) response for other request. For example, after executing a GET request to certain API, the next request could use the previous request(s) response into their path/query parameters or headers.
 
-#### Pass Response as Path/Query Parameters
+#### Response Anatomy
+
+Monika uses [Axios](https://github.com/axios/axios) to do requests, so the response body is similar just like when you're using Axios. An actual response from a request may be something like below:
+
+```json
+{
+  "status": 200,
+  "statusText": "OK",
+  "headers": { ... },
+  "config": {
+    "url": "https://reqres.in/api/users",
+    "method": "GET",
+    ...
+  },
+  "headers": { ... },
+  "request": { ... },
+  "data": { ... }
+}
+```
+
+Here is an example on how you could get previous request(s) response data into your next request:
+
+```
+{{ response.[0].status }} ==> Get status code from first request response
+{{ response.[1].data.token }} ==> Get token from second request response
+{{ response.[2].headers.SetCookie[0] }} ==> Get first cookie from third request response
+```
+
+#### Pass Response Data as Path/Query Parameters
 
 Here is an example of passing previous request(s) response into the path/query parameters:
 
@@ -161,7 +189,7 @@ Here is an example of passing previous request(s) response into the path/query p
   ]
 ```
 
-In the configuration above, the first request will execute fetch all users available. If there are no triggered alerts, the response returned from the first request is ready to be used by the second request using `{{ responses.[0].data }}`. An example of the first request response should be like this:
+In the configuration above, the first request will execute fetch all users available. If there are no triggered alerts, the response returned from the first request is ready to be used by the second request using values from `{{ responses.[0].data }}`. An example of the first request response should be like this:
 
 ```json
 {
@@ -183,7 +211,7 @@ In the configuration above, the first request will execute fetch all users avail
 
 So, in order to access the ID of the user, we need to define in the config.json as `{{ responses.[0].data.data.[0].id }}` to get the first user ID from the first response. What if we want to get the `page` data? Simply just define it as `{{ responses.[0].data.page }}`.
 
-#### Pass Response as Headers value
+#### Pass Response Data as Headers value
 
 Here is an example of passing previous request(s) response into the headers:
 
@@ -221,27 +249,7 @@ Here is an example of passing previous request(s) response into the headers:
   ]
 ```
 
-In example above, the first request will do the login process. After the first request returns the token, the token is being used for Authorization header in order to execute the second request.
-
-#### Response Anatomy
-
-Monika uses [Axios](https://github.com/axios/axios) to do requests, so the response body is similar just like when you're using Axios. An actual response from a request may be something like below:
-
-```json
-{
-  "status": 200,
-  "statusText": "OK",
-  "headers": { ... },
-  "config": {
-    "url": "https://reqres.in/api/users",
-    "method": "GET",
-    ...
-  },
-  "headers": { ... },
-  "request": { ... },
-  "data": { ... }
-}
-```
+In example above, the first request will do the login process. If there are no triggered alerts, the first request will return the token, and the token will be used for Authorization header in order to execute the second request.
 
 ## Execution order
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2778,6 +2778,18 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -4244,6 +4256,11 @@
           }
         }
       }
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "nested-error-stacks": {
       "version": "2.1.0",
@@ -6109,6 +6126,12 @@
       "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
       "dev": true
     },
+    "uglify-js": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.3.tgz",
+      "integrity": "sha512-otIc7O9LyxpUcQoXzj2hL4LPWKklO6LJWoJUzNa8A17Xgi4fOeDC8FBDOLHnC/Slo1CQgsZMcM6as0M76BZaig==",
+      "optional": true
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -6232,6 +6255,11 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "boxen": "^5.0.0",
     "cli-table3": "^0.6.0",
     "cli-ux": "^5.5.1",
+    "handlebars": "^4.7.7",
     "mailgun-js": "^0.22.0",
     "node-notifier": "^9.0.1",
     "nodemailer": "^6.5.0",

--- a/src/components/http-probe/index.ts
+++ b/src/components/http-probe/index.ts
@@ -49,8 +49,13 @@ export async function doProbe(
   let requestIndex = 0
 
   try {
+    const responses: Array<AxiosResponseWithExtraData> = []
     for await (const request of probe.requests) {
-      probeRes = await probing(request)
+      probeRes = await probing(request, responses)
+
+      // Add to an array to be accessed by another request
+      responses.push(probeRes)
+
       validatedResp = validateResponse(probe.alerts, probeRes)
       await probeLog({ checkOrder, probe, probeRes, requestIndex, err: '' })
 

--- a/src/interfaces/request.ts
+++ b/src/interfaces/request.ts
@@ -38,6 +38,7 @@ export interface AxiosResponseWithExtraData extends AxiosResponse {
 }
 
 export interface RequestConfig extends Omit<AxiosRequestConfig, 'data'> {
+  url: string
   body: JSON
   timeout: number
 }

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -122,7 +122,7 @@ export async function saveLog(
     created,
     probeRes.status,
     probe.name,
-    probe.requests[requestIndex].url,
+    probeRes.config.url,
     probeRes.config.extraData?.responseTime,
     errorResp,
   ]

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -72,7 +72,7 @@ export async function probeLog({
     type: 'PROBE',
     checkOrder,
     probeId: probe.id,
-    url: probe.requests[requestIndex].url,
+    url: probeRes.config.url,
     statusCode: probeRes.status,
     responseTime: probeRes.config.extraData?.responseTime,
   })

--- a/src/utils/probing.ts
+++ b/src/utils/probing.ts
@@ -25,11 +25,20 @@
 import { RequestConfig } from './../interfaces/request'
 import { request } from './request'
 import { AxiosResponseWithExtraData } from '../interfaces/request'
+import * as Handlebars from 'handlebars'
 
-export async function probing(requestConfig: RequestConfig) {
+export async function probing(
+  requestConfig: RequestConfig,
+  responses: Array<AxiosResponseWithExtraData>
+) {
   try {
+    const requestURL = requestConfig.url
+    const template = Handlebars.compile(requestURL)
+    const renderedURL = template({ responses })
+
     const res = await request({
       ...requestConfig,
+      url: renderedURL,
     })
     return res as AxiosResponseWithExtraData
   } catch (error) {

--- a/src/utils/probing.ts
+++ b/src/utils/probing.ts
@@ -32,10 +32,34 @@ export async function probing(
   responses: Array<AxiosResponseWithExtraData>
 ) {
   try {
-    const requestURL = requestConfig.url
-    const template = Handlebars.compile(requestURL)
-    const renderedURL = template({ responses })
+    // Compile URL using handlebars to render URLs that uses previous responses data
+    const { url } = requestConfig
+    const requestURL = url
+    const renderURL = Handlebars.compile(requestURL)
+    const renderedURL = renderURL({ responses })
 
+    // Compile headers using handlebars to render URLs that uses previous responses data.
+    // In some case such as value is not string, it will be returned as is without being compiled.
+    // If the request does not have any headers, then it should skip this process.
+    let { headers } = requestConfig
+    if (headers) {
+      for await (const header of Object.keys(headers)) {
+        try {
+          const rawHeader = headers[header]
+          const renderHeader = Handlebars.compile(rawHeader)
+          const renderedHeader = renderHeader({ responses })
+
+          headers = {
+            ...headers,
+            [header]: renderedHeader,
+          }
+        } catch (_) {
+          headers = { ...headers }
+        }
+      }
+    }
+
+    // Do the request using compiled URL and compiled headers (if exists)
     const res = await request({
       ...requestConfig,
       url: renderedURL,

--- a/src/utils/validate-config.ts
+++ b/src/utils/validate-config.ts
@@ -78,6 +78,10 @@ const PROBE_NO_REQUESTS = {
   valid: false,
   message: 'Probe requests does not exists or has length lower than 1!',
 }
+const PROBE_REQUEST_NO_URL = {
+  valid: false,
+  message: 'Probe request URL does not exists',
+}
 const PROBE_REQUEST_INVALID_URL = {
   valid: false,
   message: 'Probe request URL should start with http:// or https://',
@@ -258,6 +262,8 @@ export const validateConfig = async (configuration: Config) => {
     // Check probe request properties
     for (const request of requests) {
       const { url, method } = request as RequestConfig
+
+      if (!url) return PROBE_REQUEST_NO_URL
 
       if (url && !isValidURL(url)) return PROBE_REQUEST_INVALID_URL
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -175,6 +175,30 @@ describe('monika', () => {
     })
     .it('runs with config with duplicate probe id')
 
+  test
+    .stdout()
+    .do(() =>
+      cmd.run([
+        '--config',
+        resolve('./test/testConfigs/probes/multipleProbeRequests.json'),
+      ])
+    )
+    .it('runs with multiple probe requests config', (ctx) => {
+      expect(ctx.stdout).to.contain('Starting Monika.')
+    })
+
+  test
+    .stdout()
+    .do(() =>
+      cmd.run([
+        '--config',
+        resolve('./test/testConfigs/probes/chainingRequests.json'),
+      ])
+    )
+    .it('runs with chaining probe requests config', (ctx) => {
+      expect(ctx.stdout).to.contain('Starting Monika.')
+    })
+
   // Mailgun Tests
   test
     .stdout()

--- a/test/testConfigs/probes/chainingRequests.json
+++ b/test/testConfigs/probes/chainingRequests.json
@@ -1,0 +1,31 @@
+{
+  "notifications": [],
+  "probes": [
+    {
+      "id": "1",
+      "name": "Probing Github",
+      "description": "simulate html form submission",
+      "interval": 10,
+      "requests": [
+        {
+          "method": "GET",
+          "url": "https://reqres.in/api/users",
+          "timeout": 7000
+        },
+        {
+          "method": "GET",
+          "url": "https://reqres.in/api/users/{{ responses.[0].data.data.[0].id }}",
+          "timeout": 7000
+        },
+        {
+          "method": "GET",
+          "url": "https://reqres.in/api/users/{{ responses.[0].data.data.[1].id }}",
+          "timeout": 7000
+        }
+      ],
+      "incidentThreshold": 3,
+      "recoveryThreshold": 3,
+      "alerts": ["status-not-2xx", "response-time-greater-than-2000-ms"]
+    }
+  ]
+}

--- a/test/testConfigs/probes/multipleProbeRequests.json
+++ b/test/testConfigs/probes/multipleProbeRequests.json
@@ -1,0 +1,26 @@
+{
+  "notifications": [],
+  "probes": [
+    {
+      "id": "1",
+      "name": "Probing Github",
+      "description": "simulate html form submission",
+      "interval": 10,
+      "requests": [
+        {
+          "method": "GET",
+          "url": "https://github.com/",
+          "timeout": 7000
+        },
+        {
+          "method": "GET",
+          "url": "https://github.com/hyperjumptech",
+          "timeout": 7000
+        }
+      ],
+      "incidentThreshold": 3,
+      "recoveryThreshold": 3,
+      "alerts": ["status-not-2xx", "response-time-greater-than-2000-ms"]
+    }
+  ]
+}


### PR DESCRIPTION
# Monika PR

## What does this PR solve?

This PR will hopefully fixed #82 

- [x] Make sure a request can use a piece of data from JSON response of the previous request, e.g., "Bearer {{ responses.[0].data.jwt }}".
- [x] Make sure a request can use a piece of data from the request of the previous request, e.g., "url": "{{ responses.[2].config.baseURL }}images/profile/.

## How does this PR solves it?

This PR adds an empty array called responses, which will be used for storing response data every time any probe is doing request. Then, URLs and Headers that has the type `string`, will be compiled using Handlebars.

Handlebars will compile `{{ }}` texts in the config.json file, which allowing request to get data from stored responses.

## How to Test this PR?

1. Use this probe configuration:
```json
  "probes": [
    {
      "id": "1",
      "name": "Probing Github",
      "description": "simulate html form submission",
      "interval": 10,
      "requests": [{
        "method": "GET",
        "url": "https://reqres.in/api/users",
        "timeout": 7000,
      },{
        "method": "GET",
        "url": "https://reqres.in/api/users/{{ responses.[0].data.data.[0].id }}",
        "timeout": 7000,
      }],
      "incidentThreshold": 3,
      "recoveryThreshold": 3,
      "alerts": ["status-not-2xx", "response-time-greater-than-2000-ms"]
    },
  ]
```
2. Run monika. Does it work? If it does, then move to next step.
3. Try these config:
```json
  "probes": [
    {
      "id": "1",
      "name": "Probing Github",
      "description": "simulate html form submission",
      "interval": 10,
      "requests": [{
        "method": "POST",
        "url": "https://reqres.in/api/login",
        "timeout": 7000,
        "body": {
          "email": "eve.holt@reqres.in",
          "password": "cityslicka"
        }
      },{
        "method": "POST",
        "url": "https://reqres.in/api/users/",
        "timeout": 7000,
        "body": {
            "name": "morpheus",
            "job": "leader"
        },
        "headers": {
          "Authorization": "Bearer {{ responses.[0].data.token }}"
        }
      }],
      "incidentThreshold": 3,
      "recoveryThreshold": 3,
      "alerts": ["status-not-2xx", "response-time-greater-than-2000-ms"]
    },
  ]
```
4. You may need to open `src/utils/probing.ts` and add `console.log(headers)` in line 61 to confirm that the headers is using data from the previous request response. 
5. Run monika. Does the second request uses Authorization: Bearer <Token> header? If yes, then you can approve this PR.

## Screenshots

![image](https://user-images.githubusercontent.com/16670475/113089186-55695d80-9211-11eb-9b3a-2c1f13101ec0.png)
![image](https://user-images.githubusercontent.com/16670475/113089114-2bb03680-9211-11eb-9891-9c9f6e5a9a5a.png)

## Additional Context

N/A
