### PR TITLE
Enable Sending Notifications via Microsoft Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ To start monitoring URLs, you need to create a configuration file (JSON file). T
 - [config.webhook.example.json](https://github.com/hyperjumptech/monika/blob/main/config_sample/config.webhook.example.json)
 - [config.slack.example.json](https://github.com/hyperjumptech/monika/blob/main/config_sample/config.slack.example.json)
 - [config.whatsapp.example.json](https://github.com/hyperjumptech/monika/blob/main/config_sample/config.whatsapp.example.json)
+- [config.teams.example.json](https://github.com/hyperjumptech/monika/blob/main/config_sample/config.teams.example.json)
 - [config.example.json](https://github.com/hyperjumptech/monika/blob/main/config.example.json)
 
 When you have created the configuration file, you can run `monika` as follows

--- a/config_sample/config.teams.example.json
+++ b/config_sample/config.teams.example.json
@@ -1,0 +1,20 @@
+{
+  "notifications": [
+    {
+      "id": "unique-id-teams",
+      "type": "teams",
+      "data": {
+        "url": "https://YOUR_TEAMS_WEBHOOK_URL"
+      }
+    }
+  ],
+  "probes": [
+    {
+      "requests": [
+        {
+          "url": "https://github.com"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/src/pages/guides/notifications.md
+++ b/docs/src/pages/guides/notifications.md
@@ -15,8 +15,9 @@ At this moment, Monika support these channel of notifications (You can use just 
 4. Sendgrid
 5. Slack
 6. Whatsapp
+7. Microsoft Teams
 
-We are working on more notifications like Microsoft Teams, Telegram, and many more. You can help!
+We are working on more notifications like Telegram, and many more. You can help!
 
 ## Configurations
 
@@ -225,5 +226,25 @@ Monika supports Whatsapp notification. To enable notification via whatsapp, you 
 | Url          | The URL of your whatsapp api server                                                       | `https://yourwhatsappapiserver.com` |
 | Username     | Your whatsapp api user name                                                               | `username`                          |
 | Userpassword | Your whatsapp api user password                                                           | `userpassword`                      |
+
+## Microsoft Teams
+
+Monika supports sending notifications via Microsoft Teams. In order to be able to send notifications via Microsoft Teams, you may need to add Connectors and webhooks to your channel. Please refer to [Microsoft Teams Documentation](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using) to enable connectors and webhooks.
+
+```json
+{
+  "id": "unique-id-teams",
+  "type": "teams",
+  "data": {
+    "url": "https://YOUR_TEAMS_WEBHOOK_URL"
+  }
+}
+```
+
+| Key  | Description                                                      | Example                                 |
+| ---- | ---------------------------------------------------------------- | --------------------------------------- |
+| ID   | Notification identity number                                     | `Webhook12345`                          |
+| Type | Notification types                                               | `webhook`                               |
+| Url  | The URL of the server that will receive the webhook notification | `https://<company>.webhook.office.com/` |
 
 Keep watch on these pages, new notification methods are being developed.

--- a/docs/src/pages/guides/notifications.md
+++ b/docs/src/pages/guides/notifications.md
@@ -241,10 +241,10 @@ Monika supports sending notifications via Microsoft Teams. In order to be able t
 }
 ```
 
-| Key  | Description                                                      | Example                                 |
-| ---- | ---------------------------------------------------------------- | --------------------------------------- |
-| ID   | Notification identity number                                     | `Webhook12345`                          |
-| Type | Notification types                                               | `webhook`                               |
-| Url  | The URL of the server that will receive the webhook notification | `https://<company>.webhook.office.com/` |
+| Key  | Description                             | Example                                 |
+| ---- | --------------------------------------- | --------------------------------------- |
+| ID   | Notification identity number            | `Webhook12345`                          |
+| Type | Notification types                      | `webhook`                               |
+| Url  | The URL of your Microsoft Teams Webhook | `https://<company>.webhook.office.com/` |
 
 Keep watch on these pages, new notification methods are being developed.

--- a/src/components/http-probe/index.ts
+++ b/src/components/http-probe/index.ts
@@ -62,7 +62,9 @@ export async function doProbe(
       // Exit the loop if there is any triggers triggered
       if (validatedResp.filter((item) => item.status).length > 0) break
 
-      requestIndex += 1
+      if (probe.requests.length > 1) {
+        requestIndex += 1
+      }
     }
 
     const serverStatuses = processProbeStatus({

--- a/src/components/notification/channel/teams.ts
+++ b/src/components/notification/channel/teams.ts
@@ -24,6 +24,7 @@
 
 import axios from 'axios'
 import { TeamsData } from './../../../interfaces/data'
+import { AxiosResponseWithExtraData } from '../../../interfaces/request'
 
 export const sendTeams = async (data: TeamsData) => {
   try {
@@ -32,36 +33,55 @@ export const sendTeams = async (data: TeamsData) => {
     const notifType = data.body.status === 'UP' ? 'RECOVERY' : 'INCIDENT'
     const notifColor = data.body.status === 'UP' ? '8CC152' : 'DF202E'
 
-    const res = await axios({
-      method: 'POST',
-      url: data.url,
-      data: {
-        '@type': 'MessageCard',
-        themeColor: notifColor,
-        summary: `New ${notifType} notification from Monika`,
-        sections: [
-          {
-            activityTitle: `New ${notifType} notification from Monika`,
-            activitySubtitle: `${data.body.alert} for URL [${data.body.url}](${data.body.url}) at ${data.body.time}`,
-            facts: [
-              {
-                name: 'Alert',
-                value: data.body.alert,
-              },
-              {
-                name: 'URL',
-                value: `[${data.body.url}](${data.body.url})`,
-              },
-              {
-                name: 'Time',
-                value: data.body.time,
-              },
-            ],
-            markdown: true,
-          },
-        ],
-      },
-    })
+    let res: AxiosResponseWithExtraData
+    if (data.body.status === 'INIT') {
+      res = await axios({
+        method: 'POST',
+        url: data.url,
+        data: {
+          '@type': 'MessageCard',
+          themeColor: '3BAFDA',
+          summary: data.body.alert,
+          sections: [
+            {
+              activityTitle: data.body.alert,
+              markdown: true,
+            },
+          ],
+        },
+      })
+    } else {
+      res = await axios({
+        method: 'POST',
+        url: data.url,
+        data: {
+          '@type': 'MessageCard',
+          themeColor: notifColor,
+          summary: `New ${notifType} notification from Monika`,
+          sections: [
+            {
+              activityTitle: `New ${notifType} notification from Monika`,
+              activitySubtitle: `${data.body.alert} for URL [${data.body.url}](${data.body.url}) at ${data.body.time}`,
+              facts: [
+                {
+                  name: 'Alert',
+                  value: data.body.alert,
+                },
+                {
+                  name: 'URL',
+                  value: `[${data.body.url}](${data.body.url})`,
+                },
+                {
+                  name: 'Time',
+                  value: data.body.time,
+                },
+              ],
+              markdown: true,
+            },
+          ],
+        },
+      })
+    }
 
     return res
   } catch (error) {

--- a/src/components/notification/channel/teams.ts
+++ b/src/components/notification/channel/teams.ts
@@ -1,0 +1,70 @@
+/**********************************************************************************
+ * MIT License                                                                    *
+ *                                                                                *
+ * Copyright (c) 2021 Hyperjump Technology                                        *
+ *                                                                                *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy   *
+ * of this software and associated documentation files (the "Software"), to deal  *
+ * in the Software without restriction, including without limitation the rights   *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      *
+ * copies of the Software, and to permit persons to whom the Software is          *
+ * furnished to do so, subject to the following conditions:                       *
+ *                                                                                *
+ * The above copyright notice and this permission notice shall be included in all *
+ * copies or substantial portions of the Software.                                *
+ *                                                                                *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  *
+ * SOFTWARE.                                                                      *
+ **********************************************************************************/
+
+import axios from 'axios'
+import { TeamsData } from './../../../interfaces/data'
+
+export const sendTeams = async (data: TeamsData) => {
+  try {
+    if (!data.url) throw new Error(`Teams Webhook URL is not provided`)
+
+    const notifType = data.body.status === 'UP' ? 'RECOVERY' : 'INCIDENT'
+    const notifColor = data.body.status === 'UP' ? '8CC152' : 'DF202E'
+
+    const res = await axios({
+      method: 'POST',
+      url: data.url,
+      data: {
+        '@type': 'MessageCard',
+        themeColor: notifColor,
+        summary: `New ${notifType} notification from Monika`,
+        sections: [
+          {
+            activityTitle: `New ${notifType} notification from Monika`,
+            activitySubtitle: `${data.body.alert} for URL [${data.body.url}](${data.body.url}) at ${data.body.time}`,
+            facts: [
+              {
+                name: 'Alert',
+                value: data.body.alert,
+              },
+              {
+                name: 'URL',
+                value: `[${data.body.url}](${data.body.url})`,
+              },
+              {
+                name: 'Time',
+                value: data.body.time,
+              },
+            ],
+            markdown: true,
+          },
+        ],
+      },
+    })
+
+    return res
+  } catch (error) {
+    throw error
+  }
+}

--- a/src/components/notification/checker.ts
+++ b/src/components/notification/checker.ts
@@ -145,7 +145,7 @@ const teamsNotificationInitialChecker = async (data: TeamsData) => {
       },
     })
   } catch (error) {
-    throw errorMessage('Slack', error?.message)
+    throw errorMessage('Teams', error?.message)
   }
 }
 

--- a/src/components/notification/index.ts
+++ b/src/components/notification/index.ts
@@ -27,6 +27,7 @@ import {
   WebhookData,
   MailgunData,
   WhatsappData,
+  TeamsData,
 } from '../../interfaces/data'
 import { Notification } from '../../interfaces/notification'
 import getIp from '../../utils/ip'
@@ -34,6 +35,7 @@ import { sendMailgun } from './channel/mailgun'
 import { createSmtpTransport, sendSmtpMail } from './channel/smtp'
 import { sendWebhook } from './channel/webhook'
 import { sendSlack } from './channel/slack'
+import { sendTeams } from './channel/teams'
 import { sendWhatsapp } from './channel/whatsapp'
 import { getMessageForAlert } from './alert-message'
 
@@ -136,6 +138,21 @@ export async function sendAlerts({
           const data = notification.data as WhatsappData
           return sendWhatsapp(data, validation.alert).then(() => ({
             notification: 'whatsapp',
+            alert: validation.alert,
+            url,
+          }))
+        }
+        case 'teams': {
+          return sendTeams({
+            ...notification.data,
+            body: {
+              alert: validation.alert,
+              url,
+              time: new Date().toLocaleString(),
+              status,
+            },
+          } as TeamsData).then(() => ({
+            notification: 'teams',
             alert: validation.alert,
             url,
           }))

--- a/src/interfaces/data.ts
+++ b/src/interfaces/data.ts
@@ -42,6 +42,15 @@ export interface SMTPData extends MailData {
   password: string
 }
 
+export interface TeamsData {
+  url: string
+  body: TeamsDataBody
+}
+
+export interface TeamsDataBody extends WebhookDataBody {
+  status: string
+}
+
 export interface WebhookData {
   url: string
   body: WebhookDataBody

--- a/src/interfaces/notification.ts
+++ b/src/interfaces/notification.ts
@@ -28,10 +28,24 @@ import {
   SendgridData,
   WebhookData,
   WhatsappData,
+  TeamsData,
 } from './data'
 
 export interface Notification {
   id: string
-  type: 'smtp' | 'mailgun' | 'sendgrid' | 'webhook' | 'slack' | 'whatsapp'
-  data: MailgunData | SMTPData | SendgridData | WebhookData | WhatsappData
+  type:
+    | 'smtp'
+    | 'mailgun'
+    | 'sendgrid'
+    | 'webhook'
+    | 'slack'
+    | 'whatsapp'
+    | 'teams'
+  data:
+    | MailgunData
+    | SMTPData
+    | SendgridData
+    | WebhookData
+    | WhatsappData
+    | TeamsData
 }

--- a/src/utils/validate-config.ts
+++ b/src/utils/validate-config.ts
@@ -33,6 +33,7 @@ import {
   WebhookData,
   MailData,
   WhatsappData,
+  TeamsData,
 } from './../interfaces/data'
 import { Config } from '../interfaces/config'
 import { RequestConfig } from './../interfaces/request'
@@ -96,6 +97,9 @@ const MAILGUN_NO_DOMAIN = setInvalidResponse('Domain not found')
 
 // Sendgrid
 const SENDGRID_NO_APIKEY = setInvalidResponse('API key not found')
+
+// Teams
+const TEAMS_NO_URL = setInvalidResponse('Teams Webhook URL not found')
 
 // Webhook
 const WEBHOOK_NO_URL = setInvalidResponse('URL not found')
@@ -246,6 +250,20 @@ export const validateConfig = async (configuration: Config) => {
               username,
               password,
             } as WhatsappData,
+          } as Notification)
+
+          break
+        }
+        case 'teams': {
+          if (!(data as TeamsData).url) return TEAMS_NO_URL
+
+          const { url } = data as TeamsData
+          resultNotif.push({
+            id: id,
+            type: type,
+            data: {
+              url,
+            } as TeamsData,
           } as Notification)
 
           break

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -302,4 +302,32 @@ describe('monika', () => {
       expect(ctx.stdout).to.contain('URL:')
       expect(ctx.stdout).to.contain('Method:')
     })
+
+  // Teams Tests
+  test
+    .stdout()
+    .do(() =>
+      cmd.run([
+        '--config',
+        resolve('./test/testConfigs/teams/teamsconfig.json'),
+        '--verbose',
+      ])
+    )
+    .it('runs with Teams config', (ctx) => {
+      expect(ctx.stdout).to.contain('URL:')
+      expect(ctx.stdout).to.contain('Method:')
+    })
+
+  test
+    .stderr()
+    .do(() =>
+      cmd.run([
+        '--config',
+        resolve('./test/testConfigs/teams/teamsconfigNoURL.json'),
+      ])
+    )
+    .catch((error) => {
+      expect(error.message).to.contain('Teams Webhook URL not found')
+    })
+    .it('runs with teams config but without webhook url')
 })

--- a/test/testConfigs/teams/teamsconfig.json
+++ b/test/testConfigs/teams/teamsconfig.json
@@ -1,0 +1,20 @@
+{
+  "notifications": [
+    {
+      "id": "unique-id-teams",
+      "type": "teams",
+      "data": {
+        "url": "https://YOUR_TEAMS_WEBHOOK_URL"
+      }
+    }
+  ],
+  "probes": [
+    {
+      "requests": [
+        {
+          "url": "https://github.com"
+        }
+      ]
+    }
+  ]
+}

--- a/test/testConfigs/teams/teamsconfigNoURL.json
+++ b/test/testConfigs/teams/teamsconfigNoURL.json
@@ -1,0 +1,18 @@
+{
+  "notifications": [
+    {
+      "id": "unique-id-teams",
+      "type": "teams",
+      "data": {}
+    }
+  ],
+  "probes": [
+    {
+      "requests": [
+        {
+          "url": "https://github.com"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Monika PR

## What does this PR solve?

This PR fixes #115 which is to implement Microsoft Teams notifications

## How does this PR solves the problem?

I added a notification system for using Microsoft Teams by creating an empty teams with one channel, added a Connector called Incoming Webhook to the channel, saved the Webhook URL generated from the connector, and lastly push a request to the Webhook URL.

## How to Test

1. Refer to this guide on how to getting the Webhook URL: [https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using)
2. Copy the `config.teams.example.json` from `config_sample/`
3. Change the YOUR_TEAMS_WEBHOOK_URL to your Teams Webhook URL
4. Run monika with your desired URL to probe and alerts

## Screenshots

Below are the screenshot where there are incident and recovery.

![image](https://user-images.githubusercontent.com/16670475/113252835-92efe880-92ee-11eb-9a31-a015d80be585.png)


## Additional Context

If you find that creating a team to test the webhook a hassle and wasting too much time, PM me and I'll give you my test Webhook URL and I'll invite you to the team.
