### PR TITLE
fix: monika version in docker is not the latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14-alpine
 
 WORKDIR /monika
 
-COPY package*.json .
+COPY package*.json ./
 
 RUN npm ci
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN npm ci
 
 COPY . .
 
+RUN npm run prepack
+
 RUN npm pack
 
 RUN npm install -g --unsafe-perm ./hyperjumptech-monika-*.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,19 @@
 FROM node:14-alpine
 
-RUN mkdir /config
+WORKDIR /monika
 
-RUN npm i -g --unsafe-perm @hyperjumptech/monika
+COPY package*.json .
+
+RUN npm ci
+
+COPY . .
+
+RUN npm pack
+
+RUN npm install -g --unsafe-perm ./hyperjumptech-monika-*.tgz
+
+WORKDIR /
+
+RUN mkdir /config
 
 CMD [ "monika", "-c", "/config/config.json" ]


### PR DESCRIPTION
This PR fixes issue #123 

The issue happened because docker publish and npm publish run around the same time, so the version of monika from npm got at the time of building image is still the previous one.


### How this PR solve that issue?

I changed the `npm install -g ...` process to install from source code, not from the npm repository