### PR TITLE
Issue/136 example docs

### DIFF
--- a/docs/src/manifests/manifest.json
+++ b/docs/src/manifests/manifest.json
@@ -41,6 +41,37 @@
           "editUrl": "/guides/alerts.md"
         }
       ]
+    },
+    {
+      "title": "Examples",
+      "heading": true,
+      "routes": [
+        {
+          "title": "Minimal Configuration",
+          "path": "/guides/examples#minimal-configuration",
+          "editUrl": "/guides/examples.md"
+        },
+        {
+          "title": "Enabling Notification",
+          "path": "/guides/examples#enabling-notification",
+          "editUrl": "/guides/examples.md"
+        },
+        {
+          "title": "HTML Form Submission",
+          "path": "/guides/examples#html-form-submission-example",
+          "editUrl": "/guides/examples.md"
+        },
+        {
+          "title": "Multiple Request",
+          "path": "/guides/examples#multiple-request",
+          "editUrl": "/guides/examples.md"
+        },
+        {
+          "title": "Requests Chaining",
+          "path": "/guides/examples#requests-chaining",
+          "editUrl": "/guides/examples.md"
+        }
+      ]
     }
   ]
 }

--- a/docs/src/pages/guides/examples.md
+++ b/docs/src/pages/guides/examples.md
@@ -1,8 +1,67 @@
 # Examples
 
+## Minimal Configuration
+
+Here is probe example with GET request to hit github.com:
+
+```json
+{
+  "probes": [
+    {
+      "requests": [
+        {
+          "url": "https://github.com"
+        }
+      ]
+    }
+  ]
+}
+```
+
+By default if you didn't define the method, it will be set as GET. Also, with this configuration you should be getting warnings for not defining notification channel and incident/recovery threshold.
+
+## Enabling Notification
+
+Here is probe example with GET request to hit Monika Landing Page:
+
+```json
+{
+  "notifications": [
+    {
+      "id": "unique-id-smtp",
+      "type": "smtp",
+      "data": {
+        "recipients": ["YOUR_EMAIL_ADDRESS_HERE"],
+        "hostname": "smtp.gmail.com",
+        "port": 587,
+        "username": "YOUR_GMAIL_ACCOUNT",
+        "password": "YOUR_GMAIL_PASSWORD_OR_APP_PASSWORD"
+      }
+    }
+  ],
+  "probes": [
+    {
+      "id": "1",
+      "name": "Monika Landing Page",
+      "description": "Landing page of awesome Monika",
+      "interval": 10,
+      "requests": [
+        {
+          "url": "https://hyperjumptech.github.io/monika",
+          "timeout": 7000
+        }
+      ],
+      "alerts": ["status-not-2xx"]
+    }
+  ]
+}
+```
+
+If the probe above has been alerted 5 times, which is the default incident/recovery threshold number, it will be sending a notification using the SMTP configuration. For more information about available notification channels, refer to [https://hyperjumptech.github.io/monika/guides/notifications](https://hyperjumptech.github.io/monika/guides/notifications).
+
 ## HTML-form-submission Example
 
-Here is probes example with POST request to simulate HTML form submission
+Here is probe example with POST request to simulate HTML form submission
 
 ```json
   "probes": [
@@ -30,31 +89,38 @@ Here is probes example with POST request to simulate HTML form submission
   ]
 ```
 
+The probe above will do a POST request to do an HTML form submission, with the defined request body. If the probe above has been alerted 3 times, it will not be sending any notifications because there are no notifications channel defined in the configuration.
+
 ## Multiple request
 
 Here is an example configuration with multiple requests:
 
 ```json
+{
   "probes": [
     {
       "id": "1",
       "name": "Probing Github",
       "description": "simulate html form submission",
       "interval": 10,
-      "requests": [{
-        "method": "GET",
-        "url": "https://github.com/",
-        "timeout": 7000,
-      },{
-        "method": "GET",
-        "url": "https://github.com/hyperjumptech",
-        "timeout": 7000,
-      }],
+      "requests": [
+        {
+          "method": "GET",
+          "url": "https://github.com/",
+          "timeout": 7000
+        },
+        {
+          "method": "GET",
+          "url": "https://github.com/hyperjumptech",
+          "timeout": 7000
+        }
+      ],
       "incidentThreshold": 3,
       "recoveryThreshold": 3,
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]
-    },
+    }
   ]
+}
 ```
 
 In the configuration above, "Probing Github" probe will execute a GET request to `https://github.com`. If there are no triggered alerts such as `status-not-2xx` or `response-time-greater-than-200-ms`, it will execute a GET request to `https://github.com/hyperjumptech`.
@@ -73,31 +139,38 @@ Here is an example on how you could get previous request(s) response data into y
 {{ response.[2].headers.SetCookie[0] }} ==> Get first cookie from third request response
 ```
 
+Please refer to [Probe Response Anatomy](https://hyperjumptech.github.io/monika/guides/probes#probe-response-anatomy) in order to know which value could be used from the response body for the next request(s).
+
 ### Pass Response Data as Path/Query Parameters
 
 Here is an example of passing previous request(s) response into the path/query parameters:
 
 ```json
+{
   "probes": [
     {
       "id": "1",
       "name": "Probing Github",
       "description": "simulate html form submission",
       "interval": 10,
-      "requests": [{
-        "method": "GET",
-        "url": "https://reqres.in/api/users",
-        "timeout": 7000,
-      },{
-        "method": "GET",
-        "url": "https://reqres.in/api/users/{{ responses.[0].data.data.[0].id }}",
-        "timeout": 7000,
-      }],
+      "requests": [
+        {
+          "method": "GET",
+          "url": "https://reqres.in/api/users",
+          "timeout": 7000
+        },
+        {
+          "method": "GET",
+          "url": "https://reqres.in/api/users/{{ responses.[0].data.data.[0].id }}",
+          "timeout": 7000
+        }
+      ],
       "incidentThreshold": 3,
       "recoveryThreshold": 3,
       "alerts": ["status-not-2xx", "response-time-greater-than-2000-ms"]
-    },
+    }
   ]
+}
 ```
 
 In the configuration above, the first request will execute fetch all users available. If there are no triggered alerts, the response returned from the first request is ready to be used by the second request using values from `{{ responses.[0].data }}`. An example of the first request response should be like this:

--- a/docs/src/pages/guides/examples.md
+++ b/docs/src/pages/guides/examples.md
@@ -2,7 +2,7 @@
 
 ## Minimal Configuration
 
-Here is probe example with GET request to hit github.com:
+Here is a probe example with GET request to hit github.com:
 
 ```json
 {
@@ -18,11 +18,11 @@ Here is probe example with GET request to hit github.com:
 }
 ```
 
-By default if you didn't define the method, it will be set as GET. Also, with this configuration you should be getting warnings for not defining notification channel and incident/recovery threshold.
+By default if you didn't define the method, it will be set as GET. Please note that with this configuration, you will not get any notifications when github.com is down since the notifications configuration is not defined.
 
 ## Enabling Notification
 
-Here is probe example with GET request to hit Monika Landing Page:
+Here is a probe example to monitor Monika landing page:
 
 ```json
 {
@@ -57,9 +57,9 @@ Here is probe example with GET request to hit Monika Landing Page:
 }
 ```
 
-If the probe above has been alerted 5 times, which is the default incident/recovery threshold number, it will be sending a notification using the SMTP configuration. For more information about available notification channels, refer to [https://hyperjumptech.github.io/monika/guides/notifications](https://hyperjumptech.github.io/monika/guides/notifications).
+Using the above configuration, Monika will check the landing page every 10 seconds and will send a notification by email when the landing page is down 5 times in a row. For more information about available notification channels, refer to [Notifications](https://hyperjumptech.github.io/monika/guides/notifications).
 
-## HTML-form-submission Example
+## HTML Form Submission Example
 
 Here is probe example with POST request to simulate HTML form submission
 
@@ -84,16 +84,13 @@ Here is probe example with POST request to simulate HTML form submission
             "password": "somepassword"
           }
         }
-      ],
-      "incidentThreshold": 3,
-      "recoveryThreshold": 3,
-      "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]
+      ]
     }
   ]
 }
 ```
 
-The probe above will do a POST request to do an HTML form submission, with the defined request body. If the probe above has been alerted 3 times, it will not be sending any notifications because there are no notifications channel defined in the configuration.
+Using the configuration above, Monika will send a POST request to http://www.foo.com/login.php with the defined request's body.
 
 ## Multiple request
 
@@ -127,7 +124,7 @@ Here is an example configuration with multiple requests:
 }
 ```
 
-In the configuration above, "Probing Github" probe will execute a GET request to `https://github.com`. If there are no triggered alerts such as `status-not-2xx` or `response-time-greater-than-200-ms`, it will execute a GET request to `https://github.com/hyperjumptech`.
+In the configuration above, Monika will first check `https://github.com/` then `https://github.com/hyperjumptech`. If the status code of `https://github.com/` is not 2xx (e.g., 200, 201), Monika **will not** check `https://github.com/hyperjumptech`.
 
 If there is a case where executing GET request to `https://github.com` triggered an alert, the next request will not be executed.
 
@@ -143,11 +140,15 @@ Here is an example on how you could get previous request(s) response data into y
 {{ response.[2].headers.SetCookie[0] }} ==> Get first cookie from third request response
 ```
 
+In the example above, `response.[0]` refers to the response from the first request in the probe, `response.[1]` refers to the response from the second request in the probe, and so on. Please note that you can only use the response from previous requests in the same probe.
+
 Please refer to [Probe Response Anatomy](https://hyperjumptech.github.io/monika/guides/probes#probe-response-anatomy) in order to know which value could be used from the response body for the next request(s).
+
+In the sections below, you can find several examples of configuration file which contains chaining requests.
 
 ### Pass Response Data as Path/Query Parameters
 
-Here is an example of passing previous request(s) response into the path/query parameters:
+Here is an example of using previous request's response in the path/query parameters:
 
 ```json
 {
@@ -177,7 +178,9 @@ Here is an example of passing previous request(s) response into the path/query p
 }
 ```
 
-In the configuration above, the first request will execute fetch all users available. If there are no triggered alerts, the response returned from the first request is ready to be used by the second request using values from `{{ responses.[0].data }}`. An example of the first request response should be like this:
+In the configuration above, the first request will fetch all users from `https://reqres.in/api/users`. Then in the second request, Monika will fetch the details of the first user from the first request. If there are no triggered alerts, the response returned from the first request is ready to be used by the second request using values from `{{ responses.[0].data }}`.
+
+Let's say the response from fetching all users in JSON format as follows:
 
 ```json
 {
@@ -198,11 +201,11 @@ In the configuration above, the first request will execute fetch all users avail
 }
 ```
 
-So, in order to access the ID of the user, we need to define in the config.json as `{{ responses.[0].data.data.[0].id }}` to get the first user ID from the first response. What if we want to get the `page` data? Simply just define it as `{{ responses.[0].data.page }}`.
+To use the user ID of the first user in the second request, we define the url of the second request as `{{ responses.[0].data.data.[0].id }}`.
 
 ### Pass Response Data as Headers value
 
-Here is an example of passing previous request(s) response into the headers:
+Here is an example of using previous request's response in the headers:
 
 ```json
 {
@@ -243,4 +246,4 @@ Here is an example of passing previous request(s) response into the headers:
 }
 ```
 
-In example above, the first request will do the login process. If there are no triggered alerts, the first request will return the token, and the token will be used for Authorization header in order to execute the second request.
+Using the above configuration, Monika will perform login request in the first request, then use the returned token in the Authorization header of the second request.

--- a/docs/src/pages/guides/examples.md
+++ b/docs/src/pages/guides/examples.md
@@ -64,29 +64,33 @@ If the probe above has been alerted 5 times, which is the default incident/recov
 Here is probe example with POST request to simulate HTML form submission
 
 ```json
+{
   "probes": [
     {
       "id": "1",
       "name": "HTML form submission",
       "description": "simulate html form submission",
       "interval": 10,
-      "requests": [{
-        "method": "POST",
-        "url": "http://www.foo.com/login.php",
-        "timeout": 7000,
-        "headers": {
-          "Content-Type": "application/x-www-form-urlencoded"
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
+      "requests": [
+        {
+          "method": "POST",
+          "url": "http://www.foo.com/login.php",
+          "timeout": 7000,
+          "headers": {
+            "Content-Type": "application/x-www-form-urlencoded"
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
         }
-      }],
+      ],
       "incidentThreshold": 3,
       "recoveryThreshold": 3,
       "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]
-    },
+    }
   ]
+}
 ```
 
 The probe above will do a POST request to do an HTML form submission, with the defined request body. If the probe above has been alerted 3 times, it will not be sending any notifications because there are no notifications channel defined in the configuration.
@@ -191,6 +195,7 @@ In the configuration above, the first request will execute fetch all users avail
     },
     ...
   ]
+}
 ```
 
 So, in order to access the ID of the user, we need to define in the config.json as `{{ responses.[0].data.data.[0].id }}` to get the first user ID from the first response. What if we want to get the `page` data? Simply just define it as `{{ responses.[0].data.page }}`.
@@ -200,37 +205,42 @@ So, in order to access the ID of the user, we need to define in the config.json 
 Here is an example of passing previous request(s) response into the headers:
 
 ```json
+{
   "probes": [
     {
       "id": "1",
       "name": "Probing Github",
       "description": "simulate html form submission",
       "interval": 10,
-      "requests": [{
-        "method": "POST",
-        "url": "https://reqres.in/api/login",
-        "timeout": 7000,
-        "body": {
-          "email": "eve.holt@reqres.in",
-          "password": "cityslicka"
-        }
-      },{
-        "method": "POST",
-        "url": "https://reqres.in/api/users/",
-        "timeout": 7000,
-        "body": {
+      "requests": [
+        {
+          "method": "POST",
+          "url": "https://reqres.in/api/login",
+          "timeout": 7000,
+          "body": {
+            "email": "eve.holt@reqres.in",
+            "password": "cityslicka"
+          }
+        },
+        {
+          "method": "POST",
+          "url": "https://reqres.in/api/users/",
+          "timeout": 7000,
+          "body": {
             "name": "morpheus",
             "job": "leader"
-        },
-        "headers": {
-          "Authorization": "Bearer {{ responses.[0].data.token }}"
+          },
+          "headers": {
+            "Authorization": "Bearer {{ responses.[0].data.token }}"
+          }
         }
-      }],
+      ],
       "incidentThreshold": 3,
       "recoveryThreshold": 3,
       "alerts": ["status-not-2xx", "response-time-greater-than-2000-ms"]
-    },
+    }
   ]
+}
 ```
 
 In example above, the first request will do the login process. If there are no triggered alerts, the first request will return the token, and the token will be used for Authorization header in order to execute the second request.

--- a/docs/src/pages/guides/examples.md
+++ b/docs/src/pages/guides/examples.md
@@ -1,0 +1,163 @@
+# Examples
+
+## HTML-form-submission Example
+
+Here is probes example with POST request to simulate HTML form submission
+
+```json
+  "probes": [
+    {
+      "id": "1",
+      "name": "HTML form submission",
+      "description": "simulate html form submission",
+      "interval": 10,
+      "requests": [{
+        "method": "POST",
+        "url": "http://www.foo.com/login.php",
+        "timeout": 7000,
+        "headers": {
+          "Content-Type": "application/x-www-form-urlencoded"
+        },
+        "body": {
+          "username": "someusername",
+          "password": "somepassword"
+        }
+      }],
+      "incidentThreshold": 3,
+      "recoveryThreshold": 3,
+      "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]
+    },
+  ]
+```
+
+## Multiple request
+
+Here is an example configuration with multiple requests:
+
+```json
+  "probes": [
+    {
+      "id": "1",
+      "name": "Probing Github",
+      "description": "simulate html form submission",
+      "interval": 10,
+      "requests": [{
+        "method": "GET",
+        "url": "https://github.com/",
+        "timeout": 7000,
+      },{
+        "method": "GET",
+        "url": "https://github.com/hyperjumptech",
+        "timeout": 7000,
+      }],
+      "incidentThreshold": 3,
+      "recoveryThreshold": 3,
+      "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]
+    },
+  ]
+```
+
+In the configuration above, "Probing Github" probe will execute a GET request to `https://github.com`. If there are no triggered alerts such as `status-not-2xx` or `response-time-greater-than-200-ms`, it will execute a GET request to `https://github.com/hyperjumptech`.
+
+If there is a case where executing GET request to `https://github.com` triggered an alert, the next request will not be executed.
+
+## Requests Chaining
+
+Monika supports requests chaining, which enables you to do multiple request and use previous request(s) response for other request. For example, after executing a GET request to certain API, the next request could use the previous request(s) response into their path/query parameters or headers.
+
+Here is an example on how you could get previous request(s) response data into your next request:
+
+```
+{{ response.[0].status }} ==> Get status code from first request response
+{{ response.[1].data.token }} ==> Get token from second request response
+{{ response.[2].headers.SetCookie[0] }} ==> Get first cookie from third request response
+```
+
+### Pass Response Data as Path/Query Parameters
+
+Here is an example of passing previous request(s) response into the path/query parameters:
+
+```json
+  "probes": [
+    {
+      "id": "1",
+      "name": "Probing Github",
+      "description": "simulate html form submission",
+      "interval": 10,
+      "requests": [{
+        "method": "GET",
+        "url": "https://reqres.in/api/users",
+        "timeout": 7000,
+      },{
+        "method": "GET",
+        "url": "https://reqres.in/api/users/{{ responses.[0].data.data.[0].id }}",
+        "timeout": 7000,
+      }],
+      "incidentThreshold": 3,
+      "recoveryThreshold": 3,
+      "alerts": ["status-not-2xx", "response-time-greater-than-2000-ms"]
+    },
+  ]
+```
+
+In the configuration above, the first request will execute fetch all users available. If there are no triggered alerts, the response returned from the first request is ready to be used by the second request using values from `{{ responses.[0].data }}`. An example of the first request response should be like this:
+
+```json
+{
+  "page": 2,
+  "per_page": 6,
+  "total": 12,
+  "total_pages": 2,
+  "data": [
+    {
+        "id": 7,
+        "email": "michael.lawson@reqres.in",
+        "first_name": "Michael",
+        "last_name": "Lawson",
+        "avatar": "https://reqres.in/img/faces/7-image.jpg"
+    },
+    ...
+  ]
+```
+
+So, in order to access the ID of the user, we need to define in the config.json as `{{ responses.[0].data.data.[0].id }}` to get the first user ID from the first response. What if we want to get the `page` data? Simply just define it as `{{ responses.[0].data.page }}`.
+
+### Pass Response Data as Headers value
+
+Here is an example of passing previous request(s) response into the headers:
+
+```json
+  "probes": [
+    {
+      "id": "1",
+      "name": "Probing Github",
+      "description": "simulate html form submission",
+      "interval": 10,
+      "requests": [{
+        "method": "POST",
+        "url": "https://reqres.in/api/login",
+        "timeout": 7000,
+        "body": {
+          "email": "eve.holt@reqres.in",
+          "password": "cityslicka"
+        }
+      },{
+        "method": "POST",
+        "url": "https://reqres.in/api/users/",
+        "timeout": 7000,
+        "body": {
+            "name": "morpheus",
+            "job": "leader"
+        },
+        "headers": {
+          "Authorization": "Bearer {{ responses.[0].data.token }}"
+        }
+      }],
+      "incidentThreshold": 3,
+      "recoveryThreshold": 3,
+      "alerts": ["status-not-2xx", "response-time-greater-than-2000-ms"]
+    },
+  ]
+```
+
+In example above, the first request will do the login process. If there are no triggered alerts, the first request will return the token, and the token will be used for Authorization header in order to execute the second request.

--- a/docs/src/pages/guides/examples.md
+++ b/docs/src/pages/guides/examples.md
@@ -18,7 +18,7 @@ Here is a probe example with GET request to hit github.com:
 }
 ```
 
-By default if you didn't define the method, it will be set as GET. Please note that with this configuration, you will not get any notifications when github.com is down since the notifications configuration is not defined.
+By default if you didn't define the method, it will be set as GET. Please note that with this configuration, you will not get any notifications when github.com is down since the notification configuration is not defined.
 
 ## Enabling Notification
 
@@ -126,11 +126,11 @@ Here is an example configuration with multiple requests:
 
 In the configuration above, Monika will first check `https://github.com/` then `https://github.com/hyperjumptech`. If the status code of `https://github.com/` is not 2xx (e.g., 200, 201), Monika **will not** check `https://github.com/hyperjumptech`.
 
-If there is a case where executing GET request to `https://github.com` triggered an alert, the next request will not be executed.
+If there is a case where executing GET request to `https://github.com` triggers an alert, the next request will not be executed.
 
 ## Requests Chaining
 
-Monika supports requests chaining, which enables you to do multiple request and use previous request(s) response for other request. For example, after executing a GET request to certain API, the next request could use the previous request(s) response into their path/query parameters or headers.
+Monika supports request chaining, which enables you to do multiple requests and the ability to use past responses from earlier requests. For example, after executing a GET request to certain API, the next request could use the previous request(s) response into their path/query parameters or headers.
 
 Here is an example on how you could get previous request(s) response data into your next request:
 

--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -81,23 +81,28 @@ Below is the default response when Probe has successfully requested the URL:
   "config": {
     "url": "https://reqres.in/api/users",
     "method": "GET",
-    ...
+    "data": "{'test':'test'}",
+    "headers": {
+      "Accept": "application/json, text/plain, */*",
+      "User-Agent": "axios/0.21.1"
+    },
+    "body": { "test": "test" },
   },
-  "request": { ... },
   "data": { ... }
 }
 ```
 
 Details of the field are give in the table below.
 
-| Topic      | Description                          |
-| :--------- | ------------------------------------ |
-| status     | HTTP Status Code (e.g 200, 403, 500) |
-| statusText | HTTP Status Code Explanation         |
-| config     | Request configuration                |
-| request    | Request body                         |
-| headers    | Response headers                     |
-| data       | Response body                        |
+| Topic      | Description                                                              |
+| :--------- | ------------------------------------------------------------------------ |
+| status     | HTTP Status Code (e.g 200, 403, 500)                                     |
+| statusText | HTTP Status Code Explanation (e.g OK, Forbidden, Internal Server Error)  |
+| config     | Request configuration (e.g URL, Method, Data, Headers, Body, etc.)       |
+| headers    | Response headers from the URL requested (e.g SetCookie, ETag, etc.)      |
+| data       | Response payload from the URL requested (e.g `token`, `results`, `data`) |
+
+Probe response data could be used for [Request Chaining](https://hyperjumptech.github.io/monika/guides/examples#requests-chaining).
 
 ## Execution order
 

--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -25,7 +25,7 @@ Probes are the heart of the monitoring requests. Probes are arrays of request ob
 
 Monika goes through each probe object, sends it out, and determines whether an alert or notification need to be sent out.
 
-## Request Anatomy
+## Probe Request Anatomy
 
 An actual probe request may be something like below.
 
@@ -69,74 +69,9 @@ Details of the field are give in the table below.
 | recoveryThreshold (optional) | Number of times an alert should return false before Monika sends notifications. For example, when recoveryThreshold is 3, Monika will only send notifications when the probed URL returns status 2xx 3 times in a row. After sending the notifications, Monika will not send notifications anymore until the alert status changes. Default value is 5.    |
 | alerts                       | The condition which will trigger an alert, and the subsequent notification method to send out the alert. See below for further details on alerts and notifications.                                                                                                                                                                                       |
 
-### HTML-form-submission Example
+## Probe Response Anatomy
 
-Here is probes example with POST request to simulate HTML form submission
-
-```json
-  "probes": [
-    {
-      "id": "1",
-      "name": "HTML form submission",
-      "description": "simulate html form submission",
-      "interval": 10,
-      "requests": [{
-        "method": "POST",
-        "url": "http://www.foo.com/login.php",
-        "timeout": 7000,
-        "headers": {
-          "Content-Type": "application/x-www-form-urlencoded"
-        },
-        "body": {
-          "username": "someusername",
-          "password": "somepassword"
-        }
-      }],
-      "incidentThreshold": 3,
-      "recoveryThreshold": 3,
-      "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]
-    },
-  ]
-```
-
-### Multiple request
-
-Here is an example configuration with multiple requests:
-
-```json
-  "probes": [
-    {
-      "id": "1",
-      "name": "Probing Github",
-      "description": "simulate html form submission",
-      "interval": 10,
-      "requests": [{
-        "method": "GET",
-        "url": "https://github.com/",
-        "timeout": 7000,
-      },{
-        "method": "GET",
-        "url": "https://github.com/hyperjumptech",
-        "timeout": 7000,
-      }],
-      "incidentThreshold": 3,
-      "recoveryThreshold": 3,
-      "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]
-    },
-  ]
-```
-
-In the configuration above, "Probing Github" probe will execute a GET request to `https://github.com`. If there are no triggered alerts such as `status-not-2xx` or `response-time-greater-than-200-ms`, it will execute a GET request to `https://github.com/hyperjumptech`.
-
-If there is a case where executing GET request to `https://github.com` triggered an alert, the next request will not be executed.
-
-### Requests Chaining
-
-Monika supports requests chaining, which enables you to do multiple request and use previous request(s) response for other request. For example, after executing a GET request to certain API, the next request could use the previous request(s) response into their path/query parameters or headers.
-
-#### Response Anatomy
-
-Monika uses [Axios](https://github.com/axios/axios) to do requests, so the response body is similar just like when you're using Axios. An actual response from a request may be something like below:
+Below is the default response when Probe has successfully requested the URL:
 
 ```json
 {
@@ -148,108 +83,21 @@ Monika uses [Axios](https://github.com/axios/axios) to do requests, so the respo
     "method": "GET",
     ...
   },
-  "headers": { ... },
   "request": { ... },
   "data": { ... }
 }
 ```
 
-Here is an example on how you could get previous request(s) response data into your next request:
+Details of the field are give in the table below.
 
-```
-{{ response.[0].status }} ==> Get status code from first request response
-{{ response.[1].data.token }} ==> Get token from second request response
-{{ response.[2].headers.SetCookie[0] }} ==> Get first cookie from third request response
-```
-
-#### Pass Response Data as Path/Query Parameters
-
-Here is an example of passing previous request(s) response into the path/query parameters:
-
-```json
-  "probes": [
-    {
-      "id": "1",
-      "name": "Probing Github",
-      "description": "simulate html form submission",
-      "interval": 10,
-      "requests": [{
-        "method": "GET",
-        "url": "https://reqres.in/api/users",
-        "timeout": 7000,
-      },{
-        "method": "GET",
-        "url": "https://reqres.in/api/users/{{ responses.[0].data.data.[0].id }}",
-        "timeout": 7000,
-      }],
-      "incidentThreshold": 3,
-      "recoveryThreshold": 3,
-      "alerts": ["status-not-2xx", "response-time-greater-than-2000-ms"]
-    },
-  ]
-```
-
-In the configuration above, the first request will execute fetch all users available. If there are no triggered alerts, the response returned from the first request is ready to be used by the second request using values from `{{ responses.[0].data }}`. An example of the first request response should be like this:
-
-```json
-{
-  "page": 2,
-  "per_page": 6,
-  "total": 12,
-  "total_pages": 2,
-  "data": [
-    {
-        "id": 7,
-        "email": "michael.lawson@reqres.in",
-        "first_name": "Michael",
-        "last_name": "Lawson",
-        "avatar": "https://reqres.in/img/faces/7-image.jpg"
-    },
-    ...
-  ]
-```
-
-So, in order to access the ID of the user, we need to define in the monika.json as `{{ responses.[0].data.data.[0].id }}` to get the first user ID from the first response. What if we want to get the `page` data? Simply just define it as `{{ responses.[0].data.page }}`.
-
-#### Pass Response Data as Headers value
-
-Here is an example of passing previous request(s) response into the headers:
-
-```json
-  "probes": [
-    {
-      "id": "1",
-      "name": "Probing Github",
-      "description": "simulate html form submission",
-      "interval": 10,
-      "requests": [{
-        "method": "POST",
-        "url": "https://reqres.in/api/login",
-        "timeout": 7000,
-        "body": {
-          "email": "eve.holt@reqres.in",
-          "password": "cityslicka"
-        }
-      },{
-        "method": "POST",
-        "url": "https://reqres.in/api/users/",
-        "timeout": 7000,
-        "body": {
-            "name": "morpheus",
-            "job": "leader"
-        },
-        "headers": {
-          "Authorization": "Bearer {{ responses.[0].data.token }}"
-        }
-      }],
-      "incidentThreshold": 3,
-      "recoveryThreshold": 3,
-      "alerts": ["status-not-2xx", "response-time-greater-than-2000-ms"]
-    },
-  ]
-```
-
-In example above, the first request will do the login process. If there are no triggered alerts, the first request will return the token, and the token will be used for Authorization header in order to execute the second request.
+| Topic      | Description                          |
+| :--------- | ------------------------------------ |
+| status     | HTTP Status Code (e.g 200, 403, 500) |
+| statusText | HTTP Status Code Explanation         |
+| config     | Request configuration                |
+| request    | Request body                         |
+| headers    | Response headers                     |
+| data       | Response body                        |
 
 ## Execution order
 

--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -71,7 +71,7 @@ Details of the field are give in the table below.
 
 ## Probe Response Anatomy
 
-Below is the default response when Probe has successfully requested the URL:
+The default shape of a response when Monika has successfully fetched a request is as the following.
 
 ```json
 {
@@ -92,15 +92,15 @@ Below is the default response when Probe has successfully requested the URL:
 }
 ```
 
-Details of the field are give in the table below.
+Details of the fields are shown in the table below.
 
-| Topic      | Description                                                              |
-| :--------- | ------------------------------------------------------------------------ |
-| status     | HTTP Status Code (e.g 200, 403, 500)                                     |
-| statusText | HTTP Status Code Explanation (e.g OK, Forbidden, Internal Server Error)  |
-| config     | Request configuration (e.g URL, Method, Data, Headers, Body, etc.)       |
-| headers    | Response headers from the URL requested (e.g SetCookie, ETag, etc.)      |
-| data       | Response payload from the URL requested (e.g `token`, `results`, `data`) |
+| Topic      | Description                                                             |
+| :--------- | ----------------------------------------------------------------------- |
+| status     | HTTP Status Code (e.g 200, 403, 500)                                    |
+| statusText | HTTP Status Code Explanation (e.g OK, Forbidden, Internal Server Error) |
+| config     | Request configuration (e.g URL, Method, Data, Headers, Body, etc.)      |
+| headers    | Response headers from the fetched request (e.g SetCookie, ETag, etc.).  |
+| data       | Response payload from the fetched request (e.g token, results, data).   |
 
 Probe response data could be used for [Request Chaining](https://hyperjumptech.github.io/monika/guides/examples#requests-chaining).
 


### PR DESCRIPTION
This PR resolves #136 which is to create an "Examples" section in the docs

![image](https://user-images.githubusercontent.com/16670475/115212400-a989a280-a12a-11eb-989b-63a5cd2bed7c.png)
