### PR TITLE
Issue/143 opening monika config generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1761,6 +1761,11 @@
         }
       }
     },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+    },
     "degenerator": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
@@ -4646,6 +4651,16 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
+      }
+    },
+    "open": {
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.0.6.tgz",
+      "integrity": "sha512-vDOC0KwGabMPFtIpCO2QOnQeOz0N2rEkbuCuxICwLMUCrpv+A7NHrrzJ2dQReJmVluHhO4pYRh/Pn6s8t7Op6Q==",
+      "requires": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
       }
     },
     "opencollective-postinstall": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "mailgun-js": "^0.22.0",
     "node-notifier": "^9.0.1",
     "nodemailer": "^6.5.0",
+    "open": "^8.0.6",
     "pino": "6.11.2",
     "pino-pretty": "4.7.1",
     "smtp-server": "^3.8.0",

--- a/src/components/config/parse.ts
+++ b/src/components/config/parse.ts
@@ -40,7 +40,7 @@ export const parseConfig = (configPath: string): Config => {
   } catch (error) {
     if (error.code === 'ENOENT' && error.path === configPath) {
       throw new Error(
-        'JSON configuration file not found! Copy example config from https://raw.githubusercontent.com/hyperjumptech/monika/main/monika.example.json'
+        'Configuration file not found. By default, Monika looks for monika.json configuration file in the current directory.\n\nOtherwise, you can also specify a configuration file using -c flag as follows:\n\nmonika -c <path_to_configuration_file>\n\nYou can create a configuration file via web interface by opening this web app: https://hyperjumptech.github.io/monika-config-generator/'
       )
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { Command, flags } from '@oclif/command'
 import cli from 'cli-ux'
 import chalk from 'chalk'
 import boxen from 'boxen'
+import open from 'open'
 import { MailData, MailgunData, SMTPData, WebhookData } from './interfaces/data'
 import { looper } from './components/looper'
 import { printAllLogs } from './components/logger'
@@ -53,6 +54,10 @@ class Monika extends Command {
         'JSON configuration filename. If none is supplied, will look for monika.json in the current directory.',
       default: './monika.json',
       env: 'MONIKA_JSON_CONFIG',
+    }),
+
+    'create-config': flags.boolean({
+      description: 'open Monika Configuration Generator using default browser',
     }),
 
     logs: flags.boolean({
@@ -91,6 +96,14 @@ class Monika extends Command {
         log.info('Cancelled. Thank you.')
       }
       closeLog()
+      return
+    }
+
+    if (flags['create-config']) {
+      log.info(
+        'Opening Monika Configuration Generator in your default browser...'
+      )
+      await open('https://hyperjumptech.github.io/monika-config-generator/')
       return
     }
 


### PR DESCRIPTION
# Monika PR

## What does this PR solve?

This PR solves the first iteration of #143 to encourage users to open Monika Config Generator if they didn't have a configuration. This PR also adds a `--create-config` flag to let user open Monika Config Generator from the terminal.

## How does this PR solve the issue?

This PR modifies the `ENOENT` error message. Also, this PR installs a library called [open](https://github.com/sindresorhus/open) which enables opening a web page from a terminal, cross-platform.

## Screenshots

![image](https://user-images.githubusercontent.com/16670475/115337066-8f070600-a1ca-11eb-9b51-7f436c8ba369.png)

![image](https://user-images.githubusercontent.com/16670475/115337095-99290480-a1ca-11eb-9242-ecbd51d5ccbc.png)
