### PR TITLE
Remove configuration renewal from the report flow and update log database

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -557,11 +557,14 @@
         "@types/node": "*"
       }
     },
-    "@types/uuid": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
-      "dev": true
+    "@types/sqlite3": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/sqlite3/-/sqlite3-3.1.7.tgz",
+      "integrity": "sha512-8FHV/8Uzd7IwdHm5mvmF2Aif4aC/gjrt4axWD9SmfaxITnOjtOhCbOSTuqv/VbH1uq0QrwlaTj9aTz3gmR6u4w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.34.0",
@@ -752,6 +755,13 @@
       "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
       "requires": {
         "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+        }
       }
     },
     "ansi-regex": {
@@ -5792,6 +5802,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "sqlite": {
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/sqlite/-/sqlite-4.0.21.tgz",
+      "integrity": "sha512-HIqObuvz+Vx8BXWzIhR12fJMjiE37Mdfupg2Ok0f8MChSqALXj7FgpZauj1pJoSY6qsDYmp/+/ZgSn3l8yutoA=="
+    },
     "sqlite3": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.2.tgz",
@@ -6180,11 +6195,6 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
-    "type-fest": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-      "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
-    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -6228,11 +6238,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     "pino": "6.11.2",
     "pino-pretty": "4.7.1",
     "smtp-server": "^3.8.0",
+    "sqlite": "^4.0.21",
     "sqlite3": "^5.0.2",
-    "tslib": "^1.14.1",
-    "uuid": "^8.3.2"
+    "tslib": "^1.14.1"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.26.0",
@@ -65,7 +65,7 @@
     "@types/pako": "^1.0.1",
     "@types/pino": "^6.3.6",
     "@types/smtp-server": "^3.5.6",
-    "@types/uuid": "^8.3.0",
+    "@types/sqlite3": "^3.1.7",
     "chai": "^4.3.4",
     "chai-spies": "^1.0.0",
     "cross-env": "^7.0.3",

--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -69,13 +69,14 @@ export const setupConfigFromFile = async (path: string) => {
   if (parsed.monikaHQ && parsed.monikaHQ.url && parsed.monikaHQ.key) {
     try {
       const {
-        data: { probes, notifications },
+        data: { probes, notifications, version },
       } = await handshake(parsed)
+      parsed.version = version
       if (probes) parsed.probes = probes
       if (notifications) parsed.notifications = notifications
     } catch (error) {
       log.warn(
-        ` ›   Warning: Please check your monika-hq server, it does not return valid configuration. Monika will use configuration from ${path}.`
+        ` ›   Warning: Can't do handshake with Symon. Monika will use configuration from ${path}.`
       )
     }
   }

--- a/src/components/logger/index.ts
+++ b/src/components/logger/index.ts
@@ -86,13 +86,13 @@ export async function probeLog({
 export async function printAllLogs() {
   const data = await getAllLogs()
 
-  data.forEach((data: any) => {
+  data.forEach((row) => {
     log.info({
       type: 'PLAIN',
-      msg: `${data.id} id: ${data.probe_id} status: ${chalk.keyword(
-        getStatusColor(data.status_code)
-      )(data.status_code)} - ${data.probe_url}, ${
-        data.response_time || '- '
+      msg: `${row.id} id: ${row.probe_id} status: ${chalk.keyword(
+        getStatusColor(row.response_status)
+      )(String(row.response_status))} - ${row.request_url}, ${
+        row.response_time || '- '
       }ms`,
     })
   })

--- a/src/components/logger/migrations/20210504091802.sql
+++ b/src/components/logger/migrations/20210504091802.sql
@@ -1,0 +1,20 @@
+-- Drop Table
+DROP TABLE IF EXISTS history;
+-- Create Table
+CREATE TABLE history (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  created_at TEXT NOT NULL,
+  probe_id TEXT NOT NULL,
+  probe_name TEXT,
+  request_method TEXT NOT NULL,
+  request_url TEXT NOT NULL,
+  request_header TEXT,
+  request_body TEXT,
+  response_status INTEGER NOT NULL,
+  response_header TEXT,
+  response_body TEXT,
+  response_time INTEGER NOT NULL,
+  response_size INTEGER,
+  error TEXT,
+  reported INTEGER DEFAULT 0
+)

--- a/src/components/reporter/index.ts
+++ b/src/components/reporter/index.ts
@@ -24,13 +24,12 @@
 
 import axios from 'axios'
 import pako from 'pako'
-import { v4 as uuidv4 } from 'uuid'
 
 import { Config } from '../../interfaces/config'
 import { Probe } from '../../interfaces/probe'
 import { Notification } from '../../interfaces/notification'
 import getIp from '../../utils/ip'
-import { HistoryReportLogType } from '../logger/history'
+import { HistoryLog } from '../logger/history'
 
 export interface HQConfig {
   id: string
@@ -71,17 +70,28 @@ export const handshake = (config: Config): Promise<HQResponse> => {
     .then((res) => res.data)
 }
 
-export const report = (
-  url: string,
-  key: string,
-  configVersion: string,
-  data: HistoryReportLogType[]
-): Promise<HQResponse> => {
+type ReportData = (Omit<HistoryLog, 'id' | 'created_at' | 'reported'> & {
+  timestamp: number
+})[]
+
+export const report = ({
+  url,
+  key,
+  instanceId,
+  configVersion,
+  data,
+}: {
+  url: string
+  key: string
+  instanceId: string
+  configVersion: string
+  data: ReportData
+}): Promise<HQResponse> => {
   return axios
     .post(
       `${url}/report`,
       {
-        instance_id: uuidv4(),
+        monika_instance_id: instanceId,
         config_version: configVersion,
         data,
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,11 +93,11 @@ class Monika extends Command {
 
   async run() {
     const { flags } = this.parse(Monika)
-    openLogfile()
+    await openLogfile()
 
     if (flags.logs) {
-      printAllLogs()
-      closeLog()
+      await printAllLogs()
+      await closeLog()
       return
     }
 
@@ -106,12 +106,12 @@ class Monika extends Command {
         'Are you sure you want to flush all logs in monika-logs.db (Y/n)?'
       )
       if (ans === 'Y') {
-        flushAllLogs()
+        await flushAllLogs()
         log.info('Records flushed, thank you.')
       } else {
         log.info('Cancelled. Thank you.')
       }
-      closeLog()
+      await closeLog()
       return
     }
 
@@ -151,7 +151,7 @@ class Monika extends Command {
         abortCurrentLooper = loopProbes(config)
       }
     } catch (error) {
-      closeLog()
+      await closeLog()
       this.error(error?.message, { exit: 1 })
     }
   }

--- a/src/looper.ts
+++ b/src/looper.ts
@@ -25,7 +25,6 @@
 import { Config } from './interfaces/config'
 import { Probe } from './interfaces/probe'
 import { report } from './components/reporter'
-import { updateConfig } from './components/config'
 import {
   getUnreportedLogs,
   setLogsAsReported,
@@ -114,13 +113,13 @@ export function loopReport(getConfig: () => Config) {
       try {
         const unreportedLogs = await getUnreportedLogs()
 
-        const { data } = await report(url, key, version || '', unreportedLogs)
-
-        updateConfig(data)
+        await report(url, key, version || '', unreportedLogs)
 
         await setLogsAsReported(unreportedLogs.map((log) => log.id))
       } catch (error) {
-        log.error(error?.message)
+        log.warn(
+          " ›   Warning: Can't report history to Symon. " + error.message
+        )
       }
     }, interval)
   }


### PR DESCRIPTION
### what issue does this pr address?

implementing part of issue no #167
- remove configuration update from report flow
- update report request headers and payload in accordance with what Symon expect
- use [sqlite](https://www.npmjs.com/package/sqlite) library which adds ES6 promises and SQL-based migrations API to [sqlite3](https://www.npmjs.com/package/sqlite3).


**This PR need to be tested against this PR in Symon [https://github.com/hyperjumptech/symon/pull/164](https://github.com/hyperjumptech/symon/pull/164)**

### how DID you test?

- first, you need to create an API key in Symon database
- run Symon server
- run monika with this configuration
```json
{
  "monika-hq": {
    "url": "http://localhost:8080/v1/monika",
    "id": "<monika instance id>",
    "key": "<valid API key>",
    "interval": 5000
  },
  "probes": [
    {
      "requests": [
        {
          "url": "https://httpbin.org/get",
          "method": "GET"
        }
      ]
    }
  ]
}

```