### PR TITLE
(ISSUE 175) Add Monika notification channel

### DIFF
--- a/src/components/config/validate.ts
+++ b/src/components/config/validate.ts
@@ -34,6 +34,7 @@ import {
   WhatsappData,
   TeamsData,
   DiscordData,
+  MonikaNotifData,
 } from '../../interfaces/data'
 import { Config } from '../../interfaces/config'
 import { RequestConfig } from '../../interfaces/request'
@@ -94,6 +95,11 @@ const SENDGRID_NO_APIKEY = setInvalidResponse('API key not found')
 
 // Teams
 const TEAMS_NO_URL = setInvalidResponse('Teams Webhook URL not found')
+
+// Teams
+const MONIKA_NOTIF_NO_URL = setInvalidResponse(
+  'Monika Notification Webhook URL not found'
+)
 
 // Webhook
 const WEBHOOK_NO_URL = setInvalidResponse('URL not found')
@@ -173,6 +179,12 @@ function validateNotification(notifications: Notification[]): Validation {
 
       case 'teams': {
         if (!(data as TeamsData).url) return TEAMS_NO_URL
+
+        break
+      }
+
+      case 'monika-notif': {
+        if (!(data as MonikaNotifData).url) return MONIKA_NOTIF_NO_URL
 
         break
       }

--- a/src/components/notification/channel/monika-notif.ts
+++ b/src/components/notification/channel/monika-notif.ts
@@ -22,39 +22,20 @@
  * SOFTWARE.                                                                      *
  **********************************************************************************/
 
-import {
-  MailgunData,
-  SendgridData,
-  SMTPData,
-  TelegramData,
-  WebhookData,
-  WhatsappData,
-  TeamsData,
-  DiscordData,
-  MonikaNotifData,
-} from './data'
+import axios from 'axios'
 
-export interface Notification {
-  id: string
-  type:
-    | 'smtp'
-    | 'mailgun'
-    | 'sendgrid'
-    | 'webhook'
-    | 'slack'
-    | 'whatsapp'
-    | 'teams'
-    | 'telegram'
-    | 'discord'
-    | 'monika-notif'
-  data:
-    | MailgunData
-    | SMTPData
-    | SendgridData
-    | WebhookData
-    | WhatsappData
-    | TeamsData
-    | TelegramData
-    | DiscordData
-    | MonikaNotifData
+import { MonikaNotifData } from '../../../interfaces/data'
+
+export const sendMonikaNotif = async (data: MonikaNotifData) => {
+  try {
+    const res = await axios({
+      method: 'POST',
+      url: data.url,
+      data: data.body,
+    })
+
+    return res
+  } catch (error) {
+    throw error
+  }
 }

--- a/src/components/notification/index.ts
+++ b/src/components/notification/index.ts
@@ -63,10 +63,10 @@ export async function sendAlerts({
   url: string
   status: string
   incidentThreshold: number
-  probeName: string
-  probeId: string
-  statusCode: number
-  responseTime: number
+  probeName?: string
+  probeId?: string
+  statusCode?: number
+  responseTime?: number
 }): Promise<
   Array<{
     alert: string

--- a/src/components/notification/index.ts
+++ b/src/components/notification/index.ts
@@ -30,6 +30,7 @@ import {
   WebhookData,
   WhatsappData,
   DiscordData,
+  MonikaNotifData,
 } from '../../interfaces/data'
 import { Notification } from '../../interfaces/notification'
 import getIp from '../../utils/ip'
@@ -42,6 +43,7 @@ import { sendTelegram } from './channel/telegram'
 import { sendWebhook } from './channel/webhook'
 import { sendWhatsapp } from './channel/whatsapp'
 import { sendDiscord } from './channel/discord'
+import { sendMonikaNotif } from './channel/monika-notif'
 
 export type ValidateResponseStatus = { alert: string; status: boolean }
 
@@ -51,12 +53,20 @@ export async function sendAlerts({
   url,
   status,
   incidentThreshold,
+  probeName,
+  probeId,
+  statusCode,
+  responseTime,
 }: {
   validation: ValidateResponseStatus
   notifications: Notification[]
   url: string
   status: string
   incidentThreshold: number
+  probeName: string
+  probeId: string
+  statusCode: number
+  responseTime: number
 }): Promise<
   Array<{
     alert: string
@@ -185,6 +195,24 @@ export async function sendAlerts({
             },
           } as TeamsData).then(() => ({
             notification: 'teams',
+            alert: validation.alert,
+            url,
+          }))
+        }
+        case 'monika-notif': {
+          return sendMonikaNotif({
+            ...notification.data,
+            body: {
+              type: status === 'DOWN' ? 'incident' : 'recovery',
+              probe_url: url,
+              probe_name: probeName,
+              ip_address: ipAddress,
+              monika_id: probeId,
+              status_code: statusCode,
+              response_time: responseTime,
+            },
+          } as MonikaNotifData).then(() => ({
+            notification: 'monika-notif',
             alert: validation.alert,
             url,
           }))

--- a/src/components/notification/validator.ts
+++ b/src/components/notification/validator.ts
@@ -95,3 +95,9 @@ export const dataDiscordSchemaValidator = dataBaseEmailSchemaValidator(
 ).keys({
   url: Joi.string().uri().required().label('Discord URL'),
 })
+
+export const dataMonikaNotifSchemaValidator = dataBaseEmailSchemaValidator(
+  'MonikaNotif'
+).keys({
+  url: Joi.string().uri().required().label('Monika Notification URL'),
+})

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -102,6 +102,10 @@ export async function doProbe(
           url: probe.requests[requestIndex].url ?? '',
           status: status.isDown ? 'DOWN' : 'UP',
           incidentThreshold: probe.incidentThreshold,
+          probeName: probe.name,
+          probeId: probe.id,
+          statusCode: probeRes.status,
+          responseTime: probeRes.config.extraData?.responseTime as number,
         })
       }
     })

--- a/src/interfaces/data.ts
+++ b/src/interfaces/data.ts
@@ -56,6 +56,21 @@ export interface WebhookData {
   body: WebhookDataBody
 }
 
+export interface MonikaNotifData {
+  url: string
+  body: MonikaNotifDataBody
+}
+
+export interface MonikaNotifDataBody {
+  type: 'start' | 'incident' | 'recovery'
+  probe_url: string
+  probe_name?: string
+  monika_id?: string
+  ip_address: string
+  response_time: number
+  status_code: number
+}
+
 export interface TelegramData {
   group_id: string
   bot_token: string

--- a/test/components/notification.test.ts
+++ b/test/components/notification.test.ts
@@ -67,10 +67,6 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'UP',
       incidentThreshold: 3,
-      probeName: 'mailgun test',
-      probeId: 'mailgun 1',
-      statusCode: 200,
-      responseTime: 50,
     })
     expect(sent).to.have.length(1)
   })
@@ -96,10 +92,6 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'DOWN',
       incidentThreshold: 3,
-      probeName: 'mailgun test',
-      probeId: 'mailgun 1',
-      statusCode: 400,
-      responseTime: 500,
     })
     expect(sent).to.have.length(1)
   })
@@ -125,10 +117,6 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'DOWN',
       incidentThreshold: 3,
-      probeName: 'mailgun test',
-      probeId: 'mailgun 1',
-      statusCode: 200,
-      responseTime: 500,
     })
     expect(mailgun.sendMailgun).to.have.been.called()
     expect(sent).to.have.length(1)
@@ -162,10 +150,6 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'DOWN',
       incidentThreshold: 3,
-      probeName: 'slack test',
-      probeId: 'slack 1',
-      statusCode: 200,
-      responseTime: 50,
     })
 
     expect(webhook.sendWebhook).to.have.been.called()
@@ -196,10 +180,6 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'DOWN',
       incidentThreshold: 3,
-      probeName: 'smtp test',
-      probeId: 'smtp 1',
-      statusCode: 200,
-      responseTime: 50,
     })
     expect(smtp.sendSmtpMail).to.have.been.called()
     expect(sent).to.have.length(1)
@@ -228,10 +208,6 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'DOWN',
       incidentThreshold: 3,
-      probeName: 'whatsapp test',
-      probeId: 'whatsapp 1',
-      statusCode: 200,
-      responseTime: 50,
     })
 
     expect(whatsapp.sendWhatsapp).to.have.been.called()
@@ -280,10 +256,6 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'DOWN',
       incidentThreshold: 3,
-      probeName: 'telegram test',
-      probeId: 'telegram 1',
-      statusCode: 200,
-      responseTime: 50,
     })
 
     expect(telegram.sendTelegram).to.have.been.called()
@@ -310,10 +282,6 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'DOWN',
       incidentThreshold: 3,
-      probeName: 'discord test',
-      probeId: 'discord 1',
-      statusCode: 200,
-      responseTime: 50,
     })
 
     expect(discord.sendDiscord).to.have.been.called()

--- a/test/components/notification.test.ts
+++ b/test/components/notification.test.ts
@@ -29,6 +29,7 @@ import {
   WebhookData,
   WhatsappData,
   DiscordData,
+  MonikaNotifData,
 } from '../../src/interfaces/data'
 import * as mailgun from '../../src/components/notification/channel/mailgun'
 import * as webhook from '../../src/components/notification/channel/webhook'
@@ -37,6 +38,7 @@ import * as smtp from '../../src/components/notification/channel/smtp'
 import * as whatsapp from '../../src/components/notification/channel/whatsapp'
 import * as telegram from '../../src/components/notification/channel/telegram'
 import * as discord from '../../src/components/notification/channel/discord'
+import * as monikaNotif from '../../src/components/notification/channel/monika-notif'
 import { sendAlerts } from '../../src/components/notification'
 
 describe('send alerts', () => {
@@ -65,6 +67,10 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'UP',
       incidentThreshold: 3,
+      probeName: 'mailgun test',
+      probeId: 'mailgun 1',
+      statusCode: 200,
+      responseTime: 50,
     })
     expect(sent).to.have.length(1)
   })
@@ -90,6 +96,10 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'DOWN',
       incidentThreshold: 3,
+      probeName: 'mailgun test',
+      probeId: 'mailgun 1',
+      statusCode: 400,
+      responseTime: 500,
     })
     expect(sent).to.have.length(1)
   })
@@ -115,6 +125,10 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'DOWN',
       incidentThreshold: 3,
+      probeName: 'mailgun test',
+      probeId: 'mailgun 1',
+      statusCode: 200,
+      responseTime: 500,
     })
     expect(mailgun.sendMailgun).to.have.been.called()
     expect(sent).to.have.length(1)
@@ -148,6 +162,10 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'DOWN',
       incidentThreshold: 3,
+      probeName: 'slack test',
+      probeId: 'slack 1',
+      statusCode: 200,
+      responseTime: 50,
     })
 
     expect(webhook.sendWebhook).to.have.been.called()
@@ -178,6 +196,10 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'DOWN',
       incidentThreshold: 3,
+      probeName: 'smtp test',
+      probeId: 'smtp 1',
+      statusCode: 200,
+      responseTime: 50,
     })
     expect(smtp.sendSmtpMail).to.have.been.called()
     expect(sent).to.have.length(1)
@@ -206,6 +228,10 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'DOWN',
       incidentThreshold: 3,
+      probeName: 'whatsapp test',
+      probeId: 'whatsapp 1',
+      statusCode: 200,
+      responseTime: 50,
     })
 
     expect(whatsapp.sendWhatsapp).to.have.been.called()
@@ -254,6 +280,10 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'DOWN',
       incidentThreshold: 3,
+      probeName: 'telegram test',
+      probeId: 'telegram 1',
+      statusCode: 200,
+      responseTime: 50,
     })
 
     expect(telegram.sendTelegram).to.have.been.called()
@@ -280,9 +310,43 @@ describe('send alerts', () => {
       url: 'https://hyperjump.tech',
       status: 'DOWN',
       incidentThreshold: 3,
+      probeName: 'discord test',
+      probeId: 'discord 1',
+      statusCode: 200,
+      responseTime: 50,
     })
 
     expect(discord.sendDiscord).to.have.been.called()
+    expect(sent).to.have.length(1)
+  })
+
+  it('should send webhook monika-notif', async () => {
+    chai.spy.on(monikaNotif, 'sendMonikaNotif', () => Promise.resolve())
+
+    const sent = await sendAlerts({
+      validation: {
+        alert: 'status-not-2xx',
+        status: true,
+      },
+      notifications: [
+        {
+          id: 'one',
+          type: 'monika-notif',
+          data: {
+            url: 'xx',
+          } as MonikaNotifData,
+        },
+      ],
+      url: 'https://hyperjump.tech',
+      status: 'DOWN',
+      incidentThreshold: 3,
+      probeName: 'monika-notif test',
+      probeId: 'monika-notif 1',
+      statusCode: 200,
+      responseTime: 50,
+    })
+
+    expect(monikaNotif.sendMonikaNotif).to.have.been.called()
     expect(sent).to.have.length(1)
   })
 })

--- a/test/components/notification/checker.monika-notif.test.ts
+++ b/test/components/notification/checker.monika-notif.test.ts
@@ -1,0 +1,61 @@
+import chai, { expect } from 'chai'
+import spies from 'chai-spies'
+
+import {
+  errorMessage,
+  notificationChecker,
+} from '../../../src/components/notification/checker'
+import { MonikaNotifData } from '../../../src/interfaces/data'
+import { Notification } from '../../../src/interfaces/notification'
+
+chai.use(spies)
+
+describe('notificationChecker - MonikaNotification', () => {
+  afterEach(() => {
+    chai.spy.restore()
+  })
+
+  const notificationConfig = {
+    id: 'monika-notif',
+    type: 'monika-notif',
+  } as Notification
+
+  it('should handle validation error - without URL', async () => {
+    try {
+      await notificationChecker([
+        {
+          ...notificationConfig,
+          data: {} as MonikaNotifData,
+        },
+      ])
+    } catch (error) {
+      const originalErrorMessage = '"Monika Notification URL" is required'
+      const { message } = errorMessage('Monika-Notif', originalErrorMessage)
+
+      expect(() => {
+        throw error
+      }).to.throw(message)
+    }
+  })
+
+  it('should handle validation error - invalid URL', async () => {
+    try {
+      await notificationChecker([
+        {
+          ...notificationConfig,
+          data: {
+            url: 'example',
+          } as MonikaNotifData,
+        },
+      ])
+    } catch (error) {
+      const originalErrorMessage =
+        '"Monika Notification URL" must be a valid uri'
+      const { message } = errorMessage('Monika-Notif', originalErrorMessage)
+
+      expect(() => {
+        throw error
+      }).to.throw(message)
+    }
+  })
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -331,4 +331,17 @@ describe('monika', () => {
       expect(error.message).to.contain('Teams Webhook URL not found')
     })
     .it('runs with teams config but without webhook url')
+
+  test
+    .stdout()
+    .do(() =>
+      cmd.run([
+        '--config',
+        resolve('./test/testConfigs/monika-notif/monikaNotifconfig.json'),
+        '--verbose',
+      ])
+    )
+    .it('runs with Monika-Notif config', (ctx) => {
+      expect(ctx.stdout).to.contain('URL:')
+    })
 })

--- a/test/testConfigs/fullConfig.json
+++ b/test/testConfigs/fullConfig.json
@@ -52,6 +52,13 @@
         "username": "someusername",
         "password": "somepassword"
       }
+    },
+    {
+      "id": "unique-id-monika-notif",
+      "type": "monika-notif",
+      "data": {
+        "url": "http://www.example.com"
+      }
     }
   ],
   "probes": [

--- a/test/testConfigs/monika-notif/monikaNotifconfig.json
+++ b/test/testConfigs/monika-notif/monikaNotifconfig.json
@@ -1,0 +1,35 @@
+{
+  "notifications": [
+    {
+      "id": "unique-id",
+      "type": "monika-notif",
+      "data": {
+        "url": "http://www.example.com"
+      }
+    }
+  ],
+  "probes": [
+    {
+      "id": "1",
+      "name": "Example",
+      "description": "Probe",
+      "interval": 0,
+      "requests": [
+        {
+          "method": "POST",
+          "url": "https://something/login",
+          "headers": {
+            "Authorization": ""
+          },
+          "body": {
+            "username": "someusername",
+            "password": "somepassword"
+          }
+        }
+      ],
+      "incidentThreshold": 2,
+      "recoveryThreshold": 2,
+      "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]
+    }
+  ]
+}


### PR DESCRIPTION
# Monika PR
## What issue is this PR trying to solve
To get notification via our MonikaNotificationEngine, we need to add a new notification channel called monika-notification. 

## How this PR solve the issue
By adding the monika-notif channel to send through MonikaNotificationEngine. 
Closes #175 

## How to test
1. add monika-notif config to monika.json configuration
```script
   {
      "id": "unique-id-monika",
      "type": "monika-notif",
      "data": {
        "url": "http://localhost:3000/api/notify?token=5179f5f4-5b68-409b-acd6-322939b36045"
      }
    }
```
2. run `npm start`

    