### PR TITLE
fix: [issue-190] flushing logs in nomika-logs.db doesn't reduce the d…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "version": "1.3.3",
   "license": "MIT",
   "author": "@hyperjumptech",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "src/index.js",
   "bin": {
     "monika": "./bin/run"
   },
@@ -21,7 +20,6 @@
     "preinstall": "node scripts/preinstall.js",
     "pretest": "npm run check-format",
     "posttest": "eslint . --ext .ts --config .eslintrc",
-    "prepack": "rm -rf lib && tsc -b && oclif-dev readme",
     "start": "./bin/run",
     "test": "cross-env NODE_ENV=test nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
     "version": "oclif-dev readme && git add README.md",
@@ -94,8 +92,11 @@
   },
   "files": [
     "/bin",
-    "/lib",
-    "/scripts"
+    "/config_sample",
+    "/docs",
+    "/scripts",
+    "/src",
+    "/test"
   ],
   "homepage": "https://github.com/https://github.com/hyperjumptech/monika",
   "bugs": "https://github.com/https://github.com/hyperjumptech/monika/issues",

--- a/package.json
+++ b/package.json
@@ -95,8 +95,7 @@
     "/config_sample",
     "/docs",
     "/scripts",
-    "/src",
-    "/test"
+    "/src"
   ],
   "homepage": "https://github.com/https://github.com/hyperjumptech/monika",
   "bugs": "https://github.com/https://github.com/hyperjumptech/monika/issues",

--- a/src/components/logger/history.ts
+++ b/src/components/logger/history.ts
@@ -115,6 +115,11 @@ export async function flushAllLogs() {
     db.run(dropAlertsTableSQL),
     db.run(dropNotificationsTableSQL),
     db.run(dropMigrationsTableSQL),
+
+    // The VACUUM command cleans the main database by copying its contents to a temporary database file and reloading the original database file from the copy.
+    // This eliminates free pages, aligns table data to be contiguous, and otherwise cleans up the database file structure.
+    // When VACUUMing a database, as much as twice the size of the original database file is required in free disk space.
+    db.run('vacuum'),
   ])
 
   await migrate()


### PR DESCRIPTION
From [issue  190](https://github.com/hyperjumptech/monika/issues/190):

Flushing the logs using monika --flush doesn't reduce the db size.

**To Reproduce**
Steps to reproduce the behavior:

1. Run Monika for a while until the size of the monika-logs.db is big enough.
2. Stop Monika.
3. Run monika --flush


**Expected behavior**

The size of the monika-logs.db file should be reduced.


Local test:

![image](https://user-images.githubusercontent.com/19143644/118767026-67798b00-b8a7-11eb-95e5-88d75779c202.png)
