### PR TITLE
Feat/193 do not save responsebody

### DIFF
--- a/.github/pr_bug_template.md
+++ b/.github/pr_bug_template.md
@@ -1,0 +1,16 @@
+# Monika Pull Request (PR)  
+
+## What bug/issue does this PR fix  
+1.  
+
+## How do to reproduce the bug  
+1.  
+
+## Expected behaviour  
+1. 
+2.  
+  
+## How to test
+1.  
+2.  
+

--- a/.github/pr_feat_template.md
+++ b/.github/pr_feat_template.md
@@ -1,0 +1,13 @@
+# Monika Pull Request (PR)  
+
+## What feature/issue does this PR add  
+1. 
+
+## How did you implement / how did you fix it  
+1.  
+
+## How to test  
+1. 
+2. 
+3. 
+

--- a/.gitignore
+++ b/.gitignore
@@ -161,7 +161,7 @@ dist
 
 ### vscode ###
 .vscode/*
-!.vscode/settings.json
+.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json

--- a/docs/src/pages/guides/alerts.md
+++ b/docs/src/pages/guides/alerts.md
@@ -33,7 +33,7 @@ To measure response time. The time value and unit can be changed.
 | :------------------------------------ | ---------------------------------------------------------------------------------------- |
 | response-time-greater-than-`200`-`ms` | Condition met if the response time from the probes URL is greater than 200 milliseconds. |
 
-- The time value can be changed to any positif integer value. In above example, the value is `200`.
+- The time value can be changed to any positive integer value. In above example, the value is `200`.
 - The time unit can be changed to `s` second. In above example, the unit is `ms` for milliseconds.
 
 Example changed time value and unit:

--- a/docs/src/pages/guides/examples.md
+++ b/docs/src/pages/guides/examples.md
@@ -108,12 +108,14 @@ Here is an example configuration with multiple requests:
         {
           "method": "GET",
           "url": "https://github.com/",
-          "timeout": 7000
+          "timeout": 7000,
+          "saveBody": false
         },
         {
           "method": "GET",
           "url": "https://github.com/hyperjumptech",
-          "timeout": 7000
+          "timeout": 7000,
+          "saveBody": true
         }
       ],
       "incidentThreshold": 3,

--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -40,6 +40,7 @@ An actual probe request may be something like below.
         "method": "POST",
         "url": "https://mybackend.org/user/login",
         "timeout": 7000,
+        "saveBody": true,
         "headers": {
           "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkhlbGxvIGZyb20gSHlwZXJqdW1wIiwiaWF0IjoxNTE2MjM5MDIyfQ.T2SbP1G39CMD4MMfkOZYGFgNIQgNkyi0sPdiFi_DfVA"
         },
@@ -68,6 +69,7 @@ Details of the field are give in the table below.
 | incidentThreshold (optional) | Number of times an alert should return true before Monika sends notifications. For example, when incidentThreshold is 3, Monika will only send notifications when the probed URL returns non-2xx status 3 times in a row. After sending the notifications, Monika will not send notifications anymore until the alert status changes. Default value is 5. |
 | recoveryThreshold (optional) | Number of times an alert should return false before Monika sends notifications. For example, when recoveryThreshold is 3, Monika will only send notifications when the probed URL returns status 2xx 3 times in a row. After sending the notifications, Monika will not send notifications anymore until the alert status changes. Default value is 5.    |
 | alerts                       | The condition which will trigger an alert, and the subsequent notification method to send out the alert. See below for further details on alerts and notifications.                                                                                                                                                                                       |
+| saveBody (optional)          | When set to true, the response body of the request is stored internally. The default is off when not defined. This is to keep the log files size small as some responses can be sizeable. The setting is for each probe request.                                                                                                                          |
 
 ## Probe Response Anatomy
 
@@ -106,9 +108,9 @@ Probe response data could be used for [Request Chaining](https://hyperjumptech.g
 
 ## Execution order
 
-In a configuration with multiple probes, `Monika` will perform the requests in sequence in the order that they are entered, one after another.
+In a configuration with multiple probes, `Monika` will perform the requests in sequence in the order that they are entered, one after another. When the `--id` flag is used, the sequence of IDs are executed as entered.
 
-On completion, `Monika` will sleep until the next interval to start again. At the top of the `monika.json` file there is an `interval` setting. The execution will be restarted after every `interval`. If interval is shorter than the amount of time to dispatch all the requests, then `Monika` will immediately repeat after the last probe response and any notification alerts sent.
+On completion, `Monika` will sleep until the next interval to start again. At the top of the `monika.json` file there is an `interval` setting. The execution will be restarted after every `interval`. If interval is shorter than the amount of time to dispatch all the requests, then `Monika` will immediately repeat after the last probe response and any notification alerts sent. When the `--repeat` flag is set, the test is looped specified by the user.
 
 ## Further reading
 

--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -69,7 +69,7 @@ Details of the field are give in the table below.
 | incidentThreshold (optional) | Number of times an alert should return true before Monika sends notifications. For example, when incidentThreshold is 3, Monika will only send notifications when the probed URL returns non-2xx status 3 times in a row. After sending the notifications, Monika will not send notifications anymore until the alert status changes. Default value is 5. |
 | recoveryThreshold (optional) | Number of times an alert should return false before Monika sends notifications. For example, when recoveryThreshold is 3, Monika will only send notifications when the probed URL returns status 2xx 3 times in a row. After sending the notifications, Monika will not send notifications anymore until the alert status changes. Default value is 5.    |
 | alerts                       | The condition which will trigger an alert, and the subsequent notification method to send out the alert. See below for further details on alerts and notifications.                                                                                                                                                                                       |
-| saveBody (optional)          | When set to true, the response body of the request is stored internally. The default is off when not defined. This is to keep the log files size small as some responses can be sizeable. The setting is for each probe request.                                                                                                                          |
+| saveBody (optional)          | When set to true, the response body of the request is stored in the internal database. The default is off when not defined. This is to keep the log files size small as some responses can be sizeable. The setting is for each probe request.                                                                                                            |
 
 ## Probe Response Anatomy
 
@@ -110,7 +110,7 @@ Probe response data could be used for [Request Chaining](https://hyperjumptech.g
 
 In a configuration with multiple probes, `Monika` will perform the requests in sequence in the order that they are entered, one after another. When the `--id` flag is used, the sequence of IDs are executed as entered.
 
-On completion, `Monika` will sleep until the next interval to start again. At the top of the `monika.json` file there is an `interval` setting. The execution will be restarted after every `interval`. If interval is shorter than the amount of time to dispatch all the requests, then `Monika` will immediately repeat after the last probe response and any notification alerts sent. When the `--repeat` flag is set, the test is looped specified by the user.
+On completion, `Monika` will sleep until the next interval to start again. At the top of the `monika.json` file there is an `interval` setting. The execution will be restarted after every `interval`. If interval is shorter than the amount of time to dispatch all the requests, then `Monika` will immediately repeat after the last probe response and any notification alerts sent. When the `--repeat` flag is set with a value, Monika will not run indefinitely, instead, it will stop after executing the probes as many times as specified.
 
 ## Further reading
 

--- a/src/components/logger/index.ts
+++ b/src/components/logger/index.ts
@@ -76,8 +76,7 @@ export async function probeLog({
 
   for (const rq of probe.requests) {
     if (rq?.saveBody !== true ?? undefined) {
-      // if not saved, flush .data
-      probeRes.data = ''
+      probeRes.data = '' // if not saved, flush .data
     }
   }
 

--- a/src/components/logger/index.ts
+++ b/src/components/logger/index.ts
@@ -74,6 +74,13 @@ export async function probeLog({
     responseLength: probeRes.headers['content-length'],
   })
 
+  for (const rq of probe.requests) {
+    if (rq?.saveBody !== true ?? undefined) {
+      // if not saved, flush .data
+      probeRes.data = ''
+    }
+  }
+
   await saveProbeRequestLog(probe, probeRes, alerts, err)
 }
 

--- a/src/interfaces/request.ts
+++ b/src/interfaces/request.ts
@@ -38,6 +38,7 @@ export interface AxiosResponseWithExtraData extends AxiosResponse {
 }
 
 export interface RequestConfig extends Omit<AxiosRequestConfig, 'data'> {
+  saveBody: boolean
   url: string
   body: JSON
   timeout: number

--- a/src/interfaces/request.ts
+++ b/src/interfaces/request.ts
@@ -38,7 +38,7 @@ export interface AxiosResponseWithExtraData extends AxiosResponse {
 }
 
 export interface RequestConfig extends Omit<AxiosRequestConfig, 'data'> {
-  saveBody: boolean
+  saveBody?: boolean
   url: string
   body: JSON
   timeout: number


### PR DESCRIPTION
## PR

## What this PR add
1. Implements issue #193 
2. To keep log sizes down, response body will not be automatically saved

## How was it implemented
1. Checks for saveBody flag when about to save logs to db
2. If flag is not true, or not defined, the .body is cleared with empty string

## Testing
1. Run the test with saveBody true or false
2. Check the sqlite3 log database that response_body column matches the setting
3. You can use the following config
```json 
    "id": "3",
      "name": "Github",
      "description": "Get github status time",
      "interval": 5,
      "requests": [
        {
          "url": "http://github.com",
          "saveBody": true
        }
      ],
      "incidentThreshold": 3,
      "recoveryThreshold": 3,
      "alerts": ["status-not-2xx", "response-time-greater-than-500-ms"]
```
