### PR TITLE
fix: db error when URL is unreachable

### DIFF
--- a/src/components/logger/history.ts
+++ b/src/components/logger/history.ts
@@ -273,7 +273,7 @@ export async function saveProbeRequestLog({
       requestConfig.method,
       requestConfig.url,
       JSON.stringify(requestConfig.headers),
-      requestConfig.body,
+      JSON.stringify(requestConfig.body),
       probeRes.status,
       JSON.stringify(probeRes.headers),
       typeof probeRes.data === 'string'

--- a/src/components/logger/index.ts
+++ b/src/components/logger/index.ts
@@ -54,15 +54,17 @@ export function getStatusColor(statusCode: number) {
 export async function probeLog({
   checkOrder,
   probe,
+  requestIndex,
   probeRes,
   alerts,
-  err,
+  error,
 }: {
   checkOrder: number
   probe: Probe
+  requestIndex: number
   probeRes: AxiosResponseWithExtraData
   alerts?: string[]
-  err?: string
+  error?: string
 }) {
   log.info({
     type: 'PROBE',
@@ -80,7 +82,13 @@ export async function probeLog({
     }
   }
 
-  await saveProbeRequestLog(probe, probeRes, alerts, err)
+  await saveProbeRequestLog({
+    probe,
+    requestIndex,
+    probeRes,
+    alerts,
+    error,
+  })
 }
 
 /**

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -60,6 +60,7 @@ export async function doProbe(
       await probeLog({
         checkOrder,
         probe,
+        requestIndex,
         probeRes,
         alerts: validatedResp
           .filter((item) => item.status)
@@ -124,6 +125,6 @@ export async function doProbe(
       }
     })
   } catch (error) {
-    probeLog({ checkOrder, probe, probeRes, err: error })
+    probeLog({ checkOrder, probe, requestIndex, probeRes, err: error })
   }
 }

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -125,6 +125,6 @@ export async function doProbe(
       }
     })
   } catch (error) {
-    probeLog({ checkOrder, probe, requestIndex, probeRes, err: error })
+    probeLog({ checkOrder, probe, requestIndex, probeRes, error })
   }
 }


### PR DESCRIPTION
This PR fixes #199 

### Problem

When the URL cannot be reached, there is an error.

```
2021-05-25T23:46:36.406Z Error: Can't insert data into monika-log.db. SQLITE_CONSTRAINT: NOT NULL constraint failed: probe_requests.request_method
```

### How does this PR solve the problem?

- Change the source of request config data for logging to original config from json file, instead of using config from returned response by axios
- Added default value for data that might be empty