### PR TITLE
Add Changelog for 1.3.6 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.6] - 2021-06-02
+
+### Added
+
+- Add Monika Whatsapp Notifier documentation (#209)
+
+### Changed
+
+- Monika now does not save response body to database by default to save space (#198)
+- Improved How-To Documentation (#205)
+
+### Fixed
+
+- Improved Probe ID checking when ID is user specified (#200)
+- Fixed DB error when URL is unreachable (#201)
+- Fixed sending incident notification to monika notification failure (#207)
+
 ## [1.3.5] - 2021-05-21
 
 ## Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperjumptech/monika",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hyperjumptech/monika",
   "description": "Synthetic monitoring made easy",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "license": "MIT",
   "author": "@hyperjumptech",
   "main": "lib/index.js",


### PR DESCRIPTION
## [1.3.6] - 2021-06-02

### Added

- Add Monika Whatsapp Notifier documentation (#209)

### Changed

- Monika now does not save response body to database (#198)
- Improved How-To Documentation (#205)

### Fixed

- Fix Looping by ID when ID is not present (#200)
- DB error when URL is unreachable (#201)
- Failed on sending incident notification to monika notification (#207)