### PR TITLE
fix: Initial report to symon fails if the logs db is big

### DIFF
--- a/src/components/reporter/index.ts
+++ b/src/components/reporter/index.ts
@@ -109,8 +109,10 @@ export const getLogsAndReport = async () => {
   if (config.symon) {
     const { url, key, id: instanceId } = config.symon
 
+    const limit = parseInt(process.env.MONIKA_REPORT_LIMIT || '100', 10)
+
     try {
-      const unreportedLog = await getUnreportedLogs()
+      const unreportedLog = await getUnreportedLogs(limit)
       const requests = unreportedLog.requests.map(({ id: _, ...rest }) => rest)
       const notifications = unreportedLog.notifications.map(
         ({ id: _, ...rest }) => rest


### PR DESCRIPTION
### Problem

This PR fixes issue https://github.com/hyperjumptech/monika/issues/225

When monika run with symon configuration and the unreported data is too big, it will fail.


### How does this PR solve the problem?

- set the limit for amount of data to report per request (default to 100)
- when monika is started, it will first send all unreported data in batches before setting interval