### PR TITLE
feat: append /v1/monika to reporter so that user can use the base url only

### DIFF
--- a/src/components/reporter/index.ts
+++ b/src/components/reporter/index.ts
@@ -53,7 +53,7 @@ export type SymonResponse = {
 export const handshake = (config: Config): Promise<SymonResponse> => {
   return axios
     .post(
-      `${config.symon!.url}/handshake`,
+      `${config.symon!.url}/v1/monika/handshake`,
       {
         instanceId: config.symon!.id,
         hostname: os.hostname(),
@@ -85,7 +85,7 @@ export const report = ({
 }): Promise<SymonResponse> => {
   return axios
     .post(
-      `${url}/report`,
+      `${url}/v1/monika/report`,
       {
         monika_instance_id: instanceId,
         config_version: configVersion,


### PR DESCRIPTION
# Monika PR

## What does this PR solve?

This PR fixes #226 

## How does this PR solve the problem?

This PR appends the /v1/monika to the reporter function (handshake and report), so that user could define the configuration using the base url only

## How to test this PR?

Run monika using this config:
```
{
  "symon": {
    "url": "http://localhost:8080",
    "key": "<LOCAL_API_KEY>",
    "id": "monika-nico-local",
    "interval": 30000
  },
  "probes": [
    {
      "id": "8fd91b50-f97c-4251-9a47-04afe2480fda",
      "name": "hyperjump.tech",
      "description": "hyperjump.tech landing page",
      "interval": 10,
      "requests": [
        {
          "url": "https://hyperjump.tech",
          "body": {},
          "timeout": 10000,
          "headers": {},
          "method": "GET"
        }
      ],
      "incidentThreshold": 5,
      "recoveryThreshold": 5,
      "alerts": ["status-not-2xx", "response-time-greater-than-2000-ms"]
    },
    {
      "id": "11f12dd6-b63e-425f-b11f-5a996b5866cf",
      "name": "monika.hyperjump.tech",
      "description": "monika.hyperjump.tech landing page",
      "interval": 10,
      "requests": [
        {
          "url": "https://monika.hyperjump.tech",
          "body": {},
          "timeout": 10000,
          "headers": {},
          "method": "GET"
        }
      ],
      "incidentThreshold": 5,
      "recoveryThreshold": 5,
      "alerts": ["status-not-2xx", "response-time-greater-than-2000-ms"]
    },
    {
      "id": "bf670c51-3eea-4b27-8ea5-c4e41e81f138",
      "name": "whatsapp.hyperjump.tech",
      "description": "whatsapp.hyperjump.tech landing page",
      "interval": 10,
      "requests": [
        {
          "url": "https://whatsapp.hyperjump.tech",
          "body": {},
          "timeout": 10000,
          "headers": {},
          "method": "GET"
        }
      ],
      "incidentThreshold": 5,
      "recoveryThreshold": 5,
      "alerts": ["status-not-2xx", "response-time-greater-than-2000-ms"]
    }
  ]
}

```