### PR TITLE
Added: check configuration from URL periodically

### DIFF
--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -97,8 +97,17 @@ export const setupConfigFromFile = async (path: string, watch: boolean) => {
   }
 }
 
-export const setupConfigFromUrl = async (url: string) => {
+export const setupConfigFromUrl = async (
+  url: string,
+  checkingInterval: number
+) => {
   const fetched = await fetchConfig(url)
   await handshakeAndValidate(fetched)
   cfg = fetched
+
+  setInterval(async () => {
+    const fetched = await fetchConfig(url)
+    await handshakeAndValidate(fetched)
+    updateConfig(fetched)
+  }, checkingInterval * 1000)
 }

--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -60,7 +60,7 @@ export const updateConfig = (data: Config) => {
   cfg = data
   cfg.version = cfg.version || md5Hash(cfg)
 
-  if (cfg.version !== lastVersion) {
+  if (cfg.version !== lastVersion && lastVersion !== undefined) {
     emitter.emit(CONFIG_UPDATED, cfg)
     log.warn('config file update detected')
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,9 +62,10 @@ class Monika extends Command {
 
   static examples = [
     'monika',
-    'monika --1ogs',
+    'monika --logs',
     'monika -r 1 --id 1,2,5,7',
     'monika --create-config',
+    'monika --config https://raw.githubusercontent.com/hyperjumptech/monika/main/monika.example.json --config-interval 900',
   ]
 
   static flags = {
@@ -81,6 +82,13 @@ class Monika extends Command {
 
     'create-config': flags.boolean({
       description: 'open Monika Configuration Generator using default browser',
+    }),
+
+    'config-interval': flags.integer({
+      description:
+        'The interval (in seconds) for periodic config checking if url is used as config source',
+      default: 900,
+      dependsOn: ['config'],
     }),
 
     logs: flags.boolean({
@@ -144,7 +152,7 @@ class Monika extends Command {
 
     try {
       if (isUrl(flags.config)) {
-        await setupConfigFromUrl(flags.config)
+        await setupConfigFromUrl(flags.config, flags['config-interval'])
       } else {
         const watchConfigFile = !(
           process.env.CI ||


### PR DESCRIPTION
This PR implements issue #232 

- [x] Monika should check the config file in remote URL (if using remote URL config) periodically.
- [x] The interval should be configured through the CLI flag --config-interval with values in seconds and default 900.

**How to test?**

- run `./bin/run --config <configuration url> --config-interval <chosen interval in seconds>`