### PR TITLE
Fixed: Updated alerts is not displayed when config is updated with new alert options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3287,6 +3287,15 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3882,6 +3891,15 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -4821,18 +4839,11 @@
         "os-tmpdir": "^1.0.0"
       }
     },
-    "p-event": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
-      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
-      "requires": {
-        "p-timeout": "^3.1.0"
-      }
-    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-limit": {
       "version": "2.3.0",
@@ -4859,14 +4870,6 @@
       "dev": true,
       "requires": {
         "aggregate-error": "^3.0.0"
-      }
-    },
-    "p-timeout": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "requires": {
-        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -5334,9 +5337,9 @@
       },
       "dependencies": {
         "hosted-git-info": {
-          "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
           "dev": true
         },
         "load-json-file": {
@@ -5624,12 +5627,18 @@
       }
     },
     "rxjs": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
-      "integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
-      "dev": true,
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.1.0.tgz",
+      "integrity": "sha512-gCFO5iHIbRPwznl6hAYuwNFld8W4S2shtSJIqG27ReWXo9IWrCyEICxUA+6vJHwSR/OakoenC4QsDxq50tzYmw==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "~2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
       }
     },
     "safe-buffer": {
@@ -6327,9 +6336,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
     "node-notifier": "^9.0.1",
     "nodemailer": "^6.5.0",
     "open": "^8.0.6",
-    "p-event": "^4.2.0",
     "pako": "^2.0.3",
     "pino": "6.11.2",
     "pino-pretty": "4.7.1",
+    "rxjs": "^7.1.0",
     "smtp-server": "^3.8.0",
     "sqlite": "^4.0.21",
     "sqlite3": "^5.0.2",
@@ -85,7 +85,7 @@
     "nyc": "^14.1.1",
     "prettier": "2.2.1",
     "ts-node": "^8.10.2",
-    "typescript": "^3.9.9"
+    "typescript": "^4.3.4"
   },
   "prettier": {
     "trailingComma": "es5",

--- a/src/components/notification/process-server-status.ts
+++ b/src/components/notification/process-server-status.ts
@@ -28,10 +28,16 @@ import { ValidateResponseStatus } from './alert'
 import { log } from '../../utils/pino'
 import { AxiosResponseWithExtraData } from '../../interfaces/request'
 import { setAlert } from '../../components/logger'
-
 import { printProbeLog } from '../../components/logger'
+import { config$ } from '../config'
 
-const PROBE_STATUSES: ProbeStatus[] = []
+let PROBE_STATUSES: ProbeStatus[] = []
+
+// reset PROBE_STATUSES on new config
+config$.subscribe(() => {
+  PROBE_STATUSES = []
+})
+
 const INIT_PROBE_STATUS_DETAILS: StatusDetails = {
   alert: '',
   state: 'INIT',

--- a/src/looper.ts
+++ b/src/looper.ts
@@ -165,8 +165,8 @@ export function idFeeder(
   return abort
 }
 
-export async function loopReport(getConfig: () => Config) {
-  const { symon } = getConfig()
+export async function loopReport(config: Config) {
+  const { symon } = config
 
   if (symon) {
     // Send previously unreported logs to symon


### PR DESCRIPTION
This PR fixes issue #233

## How does this PR fix the issue?

- reset saved probes status every time config changes

## How to test?

1. run monika with this config
```json
{
  "probes": [
    {
      "id": "httpbin",
      "name": "probe httpbin",
      "requests": [
        {
          "url": "https://httpbin.org/status/200",
          "method": "GET"
        }
      ],
      "alerts": [
        "status-not-2xx",
        "response-time-greater-than-750-ms"
      ]
    }
  ]
}
```
2. While monika is running, update the alerts option:
```json
{
  "probes": [
    {
      "id": "httpbin",
      "name": "probe httpbin",
      "requests": [
        {
          "url": "https://httpbin.org/status/200",
          "method": "GET"
        }
      ],
      "alerts": [
        "status-not-2xx",
        "response-time-greater-than-1-ms"
      ]
    }
  ]
}
```
3. Look at the log, the "response-time-greater-than-1-ms" alert should be displayed correctly


## Additional note:

In this PR I use rxjs to handle events with Observable. For now I mark it as draft because I need to hear feedback whether this is a right approach or not.
