### PR TITLE
added: google analytics with consent

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8385,6 +8385,11 @@
         "supports-color": "^6.1.0"
       }
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10768,6 +10773,15 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-cookie-consent": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/react-cookie-consent/-/react-cookie-consent-6.2.4.tgz",
+      "integrity": "sha512-h6coYS6P1Vv/CLL6tn6mBivtERPkKNo7ilY3vLjNnRD8bsc4+XHT3t27fqceyyW5cT1nKVO5zCdO8UFCjpBnTw==",
+      "requires": {
+        "js-cookie": "^2.2.1",
+        "prop-types": "^15.7.2"
       }
     },
     "react-dom": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -46,6 +46,7 @@
     "node-fetch": "^2.6.1",
     "prismjs": "^1.21.0",
     "react": "^16.13.1",
+    "react-cookie-consent": "^6.2.4",
     "react-dom": "^16.13.1",
     "react-icons": "^3.11.0",
     "react-live": "^2.2.2",

--- a/docs/src/lib/gtag.js
+++ b/docs/src/lib/gtag.js
@@ -1,0 +1,42 @@
+/**********************************************************************************
+ * MIT License                                                                    *
+ *                                                                                *
+ * Copyright (c) 2021 Hyperjump Technology                                        *
+ *                                                                                *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy   *
+ * of this software and associated documentation files (the "Software"), to deal  *
+ * in the Software without restriction, including without limitation the rights   *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      *
+ * copies of the Software, and to permit persons to whom the Software is          *
+ * furnished to do so, subject to the following conditions:                       *
+ *                                                                                *
+ * The above copyright notice and this permission notice shall be included in all *
+ * copies or substantial portions of the Software.                                *
+ *                                                                                *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  *
+ * SOFTWARE.                                                                      *
+ **********************************************************************************/
+
+export const GA_TRACKING_ID = 'G-W999ZM71FP'
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = (url) => {
+  window[`ga-disable-${GA_TRACKING_ID}`] = false
+  window.gtag('config', GA_TRACKING_ID, {
+    page_path: url,
+  })
+}
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }) => {
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  })
+}

--- a/docs/src/pages/_app.js
+++ b/docs/src/pages/_app.js
@@ -22,11 +22,14 @@
  * SOFTWARE.                                                                      *
  **********************************************************************************/
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import '@docsearch/react/dist/style.css'
 import '../styles/index.css'
 import Head from 'next/head'
 import { SearchProvider } from 'components/useSearch'
+import CookieConsent, { getCookieConsentValue } from 'react-cookie-consent'
+import { useRouter } from 'next/router'
+import * as gtag from '../lib/gtag'
 
 function loadScript(src, attrs = {}) {
   if (typeof document !== 'undefined') {
@@ -43,6 +46,21 @@ function MyApp({ Component, pageProps }) {
   React.useEffect(() => {
     loadScript('https://buttons.github.io/buttons.js')
   }, [])
+
+  const router = useRouter()
+  useEffect(() => {
+    const handleRouteChange = (url) => {
+      if (getCookieConsentValue() === 'true') {
+        //isConsentAllowed
+        gtag.pageview(url)
+      }
+    }
+
+    router.events.on('routeChangeComplete', handleRouteChange)
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange)
+    }
+  }, [router.events])
 
   return (
     <>
@@ -74,6 +92,9 @@ function MyApp({ Component, pageProps }) {
         />
       </Head>
       <SearchProvider>
+        <CookieConsent enableDeclineButton>
+          This website uses cookies to enhance the user experience.
+        </CookieConsent>
         <Component {...pageProps} />
       </SearchProvider>
     </>

--- a/docs/src/pages/_document.js
+++ b/docs/src/pages/_document.js
@@ -1,5 +1,7 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
+import { GA_TRACKING_ID } from '../lib/gtag'
 
+const isGATrackingDisabled = 'true'
 class MyDocument extends Document {
   static async getInitialProps(ctx) {
     const initialProps = await Document.getInitialProps(ctx)
@@ -9,7 +11,26 @@ class MyDocument extends Document {
   render() {
     return (
       <Html>
-        <Head />
+        <Head>
+          {/* Global Site Tag (gtag.js) - Google Analytics */}
+          <script
+            async
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+          />
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+            window['ga-disable-${GA_TRACKING_ID}'] = ${isGATrackingDisabled};
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_TRACKING_ID}', {
+              page_path: window.location.pathname,
+            });
+          `,
+            }}
+          />
+        </Head>
         <body className="font-sans antialiased text-gray-900">
           <Main />
           <NextScript />


### PR DESCRIPTION
Implementing issue #264 

- by default, analytics is disallowed
- after user agree to use cookie, then the analytics is running on every route change

### Screenshot

<img width="1239" alt="Screen Shot 2021-07-05 at 15 05 18" src="https://user-images.githubusercontent.com/5974862/124438495-75756380-dda2-11eb-8afd-7f2bde6de16e.png">


### How to test

1. open http://localhost:3000
2. don't click on cookies consent (or click decline. It's the same)
3. see developer console on tab network > Other
4. go to other page and see there is `no` call on url `collect?v=2...` (https://www.google-analytics.com/g/collect?v=2...)
5. clear cookies (or you can open http://localhost:3000 on new incognito)
6. accept cookie consent
7. see developer console on tab network > Other
8. go to other page and see there is `a` call on url `collect?v=2...` (https://www.google-analytics.com/g/collect?v=2...)