### PR TITLE
Fix response time display error when not 2xx

### DIFF
--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -66,7 +66,7 @@ export async function doProbe(
     id: probe.id,
     responseCode: 0,
     url: '',
-    method: 'GET',
+    method: 'GET', // GET must be pre-filled here since method '' (empty) is undefined
     responseTime: 0,
     alert: {
       flag: '',

--- a/src/components/probe/probing.ts
+++ b/src/components/probe/probing.ts
@@ -66,31 +66,28 @@ export async function probing(
     })
     return res as AxiosResponseWithExtraData
   } catch (error) {
-    let errStatus
+    let errResponseCode
     let errData
     let errHdr
 
     if (error.response) {
       // Axios doesn't always return error response
-      errStatus = error.response.status
+      errResponseCode = error.response.status
       errData = error.response.data
       errHdr = error.response.headers
     } else {
-      errStatus = 500 // TODO: how to detect timeouts?
+      errResponseCode = 500 // TODO: how to detect timeouts?
       errData = ''
       errHdr = ''
     }
 
     return {
       data: errData,
-      status: errStatus,
+      status: errResponseCode,
       statusText: 'ERROR',
       headers: errHdr,
-      config: '',
-      extraData: {
-        requestStartedAt: 0,
-        responseTime: 0,
-      },
+      config: error.config, // get the response from error.config instead of error.response.xxx as -
+      extraData: error.config.extraData, // the response data lives in the data.config space
     } as AxiosResponseWithExtraData
   }
 }

--- a/src/constants/event-emitter.ts
+++ b/src/constants/event-emitter.ts
@@ -30,6 +30,7 @@
 // item  : is the "item" that the listener will be processing/handling
 // state : is the state of that item, is it ready? is it received?
 
+export const CONFIG_SANITIZED = 'CONFIG_SANITIZED'
 export const PROBE_RESPONSE_RECEIVED = 'PROBE_RESPONSE_RECEIVED'
 export const PROBE_RESPONSE_VALIDATED = 'PROBE_RESPONSE_VALIDATED'
 export const PROBE_ALERTS_READY = 'PROBE_ALERTS_READY'

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import { notificationChecker } from './components/notification/checker'
 import { terminationNotif } from './components/notification/termination'
 import { resetProbeStatuses } from './components/notification/process-server-status'
 import {
+  CONFIG_SANITIZED,
   PROBE_RESPONSE_RECEIVED,
   PROBE_RESPONSE_VALIDATED,
   PROBE_ALERTS_READY,
@@ -220,7 +221,7 @@ class Monika extends Command {
       } = new PrometheusCollector()
 
       // register prometheus metric collectors
-      em.on('SANITIZED_CONFIG', registerCollectorFromProbes)
+      em.on(CONFIG_SANITIZED, registerCollectorFromProbes)
       // collect prometheus metrics
       em.on(PROBE_RESPONSE_RECEIVED, collectProbeRequestMetrics)
 
@@ -277,7 +278,7 @@ class Monika extends Command {
 
         // emit the sanitized probe
         if (sanitizedProbe) {
-          em.emit('SANITIZED_CONFIG', sanitizedProbe)
+          em.emit(CONFIG_SANITIZED, sanitizedProbe)
         }
 
         abortCurrentLooper = idFeeder(
@@ -396,7 +397,7 @@ em.addListener('TERMINATE_EVENT', async (data) => {
 })
 
 // Subscribe to Sanitize Config
-em.addListener('SANITIZED_CONFIG', function () {
+em.addListener(CONFIG_SANITIZED, function () {
   // TODO: Add function here
 })
 


### PR DESCRIPTION
# Monika Pull Request 

## What feature/issue does this PR fix
1. Closing #313 

## How did you implement / how did you fix it  
1.  The response time data lives in the config.extraData rather than than in error.response.
2. So returning config.extraData instead when not 2xx
3. Add some documentation and update the sanitize event definition

## How to test  
1. see Issue #313 for how to reproduce

## Screenshot before fix vs after fix
![image](https://user-images.githubusercontent.com/964106/128659602-5f48f471-0678-44ad-8446-78580db69a89.png)

