### PR TITLE
fix: fatal error when config is updated

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -256,7 +256,7 @@ class Monika extends Command {
 
         // Stop, destroy, and clear all previous cron tasks
         scheduledTasks.forEach((task) => {
-          task.destroy()
+          task.stop()
         })
         scheduledTasks = []
 


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  

There is a bug in this PR https://github.com/hyperjumptech/monika/pull/354 that when a config is updated, monika will throw fatal error like screenshot below
![Screen Shot 2021-08-27 at 10 04 02](https://user-images.githubusercontent.com/22452017/131065467-3b4b3bcf-d044-46ce-8d70-ef86a7602ae8.png).


## How did you implement / how did you fix it  

The error happens because inexistent method (`.destroy()`) is called for stopping `node-cron` `SceduledTask`

The [docs](https://github.com/node-cron/node-cron#destroy) and the interface as defined in [@types/node-cron](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node-cron/index.d.ts#L15) seems to be not valid or I miss something.

To fix the issue, I change `.destroy()` call to `.stop()`


## How to test  
1. Run monika with any config
2. Update config when monika is running
3. Error shouldn't happen

