### PR TITLE
Added: send status-update notification via monika-notif channel

### DIFF
--- a/src/components/notification/index.ts
+++ b/src/components/notification/index.ts
@@ -174,11 +174,30 @@ export async function sendNotifications(
                 alert: message.summary,
                 url: message.meta.url,
                 time: message.meta.time,
-                monika: `${message.meta.privateIpAddress} (local), ${
-                  message.meta.publicIpAddress
-                    ? `${message.meta.publicIpAddress} (public)`
-                    : ''
-                } ${message.meta.hostname} (hostname)`,
+                monika: `${message.meta.hostname} (${[
+                  message.meta.publicIpAddress,
+                  message.meta.privateIpAddress,
+                ]
+                  .filter(Boolean)
+                  .join('/')})`,
+              }
+            } else if (message.meta.type === 'status-update') {
+              body = {
+                type: message.meta.type,
+                time: message.meta.time,
+                monika: `${message.meta.hostname} (${[
+                  message.meta.publicIpAddress,
+                  message.meta.privateIpAddress,
+                ]
+                  .filter(Boolean)
+                  .join('/')})`,
+                numberOfProbes: String(message.meta.numberOfProbes),
+                averageResponseTime: String(message.meta.averageResponseTime),
+                numberOfIncidents: String(message.meta.numberOfIncidents),
+                numberOfRecoveries: String(message.meta.numberOfRecoveries),
+                numberOfSentNotifications: String(
+                  message.meta.numberOfSentNotifications
+                ),
               }
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { Command, flags } from '@oclif/command'
 import boxen from 'boxen'
 import chalk from 'chalk'
 import cli from 'cli-ux'
+import format from 'date-fns/format'
 import fs from 'fs'
 import cron, { ScheduledTask } from 'node-cron'
 import { hostname } from 'os'
@@ -506,7 +507,7 @@ Please refer to the Monika documentations on how to how to configure notificatio
 
     await sendNotifications(notifications, {
       subject: `Monika Status`,
-      body: `Status Update ${new Date().toUTCString()}
+      body: `Status Update ${format(new Date(), 'yyyy-MM-dd HH:mm:ss XXX')}
 
 Host: ${hostname()} (${[publicIpAddress, getIp()].filter(Boolean).join('/')})
 Number of probes: ${summary.numberOfProbes}
@@ -517,7 +518,7 @@ Notifications: ${summary.numberOfSentNotifications}`,
       summary: `There are ${summary.numberOfIncidents} incidents and ${summary.numberOfRecoveries} recoveries in the last 24 hours.`,
       meta: {
         type: 'status-update' as const,
-        time: new Date().toUTCString(),
+        time: format(new Date(), 'yyyy-MM-dd HH:mm:ss XXX'),
         hostname: hostname(),
         privateIpAddress: getIp(),
         publicIpAddress,

--- a/src/interfaces/data.ts
+++ b/src/interfaces/data.ts
@@ -61,6 +61,7 @@ export interface MonikaNotifData {
 export type MonikaNotifDataBody =
   | MonikaAlertNotifDataBody
   | MonikaStartAndTerminationNotifDataBody
+  | MonikaStatusUpdateNotifDataBody
 
 interface MonikaAlertNotifDataBody {
   type: 'incident' | 'recovery'
@@ -73,6 +74,17 @@ interface MonikaAlertNotifDataBody {
 interface MonikaStartAndTerminationNotifDataBody {
   type: 'start' | 'termination'
   ip_address: string
+}
+
+interface MonikaStatusUpdateNotifDataBody {
+  type: 'status-update'
+  time: string
+  monika: string
+  numberOfProbes: string
+  averageResponseTime: string
+  numberOfIncidents: string
+  numberOfRecoveries: string
+  numberOfSentNotifications: string
 }
 
 export interface TelegramData {


### PR DESCRIPTION
# Monika Pull Request (PR)  
closes #361 


## How to test  
1. Run monika with whatsapp notification,
2. add status notification property

 
   example: 
```json
{
  "notifications": [
    {
      "id": "monika-webhook",
      "type": "monika-notif",
      "data": {
        "url": "https://whatsapp.hyperjump.tech/api/notify?token=<your-token>"
      }
    }
  ],
  "probes": [
  
  ],
  "status-notification": "* * * * *"
}
```

![WhatsApp Image 2021-08-31 at 10 02 33](https://user-images.githubusercontent.com/22452017/131435331-e6b68727-62a0-45ea-b4e3-3e2344d35ef5.jpeg)


