### PR TITLE
Changed:  Remove 'subject' property from alert config

### DIFF
--- a/docs/src/pages/guides/alerts.md
+++ b/docs/src/pages/guides/alerts.md
@@ -8,63 +8,30 @@ Alerts are the types of condition that will trigger Monika to send notification.
       "id": "1",
       "name": "Name of the probe",
       ...
-      "alerts": ["status-not-2xx", "response-time-greater-than-200-ms"]
+      "alerts": [
+        {
+          "query": "response.status != 200",
+          "message": "HTTP Status code is {{ response.status }}, expecting 200"
+        }
+      ]
     },
   ]
 ```
 
-## Alerts formats
+## Alert Query
 
-You can configure alerts either in string format or object format for more advanced case and flexible use:
-
-### 1. Alert in string format
-
-This is the initial format used by Monika. It supports 2 types of alerts conditions:
-
-**HTTP Code**
-
-To measure returned HTTP code.
-
-| Value          | Description                                                                                   |
-| :------------- | --------------------------------------------------------------------------------------------- |
-| status-not-2xx | Condition met if the returned http code from the probes is less than 200 or greater than 299. |
-
-**Response Time**
-
-To measure response time. The time value and unit can be changed.
-
-| Value                                 | Description                                                                              |
-| :------------------------------------ | ---------------------------------------------------------------------------------------- |
-| response-time-greater-than-`200`-`ms` | Condition met if the response time from the probes URL is greater than 200 milliseconds. |
-
-- The time value can be changed to any positive integer value. In above example, the value is `200`.
-- The time unit can be changed to `s` second. In above example, the unit is `ms` for milliseconds.
-
-Example changed time value and unit:
-
-```
-response-time-greater-than-1-s
-```
-
-means Monika will send notification if the response of the probes URL is received after 1 second.
-
-### 2. Alert in object format
-
-This is the new format for more complex condition. Use this one if the previous format doesn't cater to your need.
-
-Define alert like so
+Query contains any arbitrary expression that will trigger alert when it returns a truthy value
 
 ```json
   "alerts" : [
     {
       "query": "response.status == 500",
-      "subject": "Subject for notification purpose",
-      "message": "Message for notification purpose"
+      ...
     }
   ]
 ```
 
-The response object can be queried in the `query` property of the alert. Alert will be triggered when the query is returning truthy value.
+Inside the query expression you can get the response object.
 
 These are values that are available:
 
@@ -82,8 +49,7 @@ For example, to trigger alert when content-type is not json you may use
   "alerts" : [
     {
       "query": "response.headers['content-type'] != \"application/json\"",
-      "subject": "Invalid Content-Type",
-      "message": "The url does not return response with expected content-type."
+      ...
     }
   ]
 ```
@@ -95,8 +61,7 @@ Or to query value inside the body
   "alerts" : [
     {
       "query": "response.body.data.todos[0].title != \"Drink water\"",
-      "subject": "Invalid order of data",
-      "message": "'Drink water' should always be the first in the list"
+      ...
     }
   ]
 ```
@@ -163,6 +128,21 @@ There are also several helper functions available:
 - **size(collection)**: Gets length of array or string values.
 
   example: `size(response.body.data.items)` gets the count of items.
+
+## Alert Message
+
+```json
+  "alerts": [
+    {
+      "query": "response.status != 200",
+      "message": "HTTP Status code is {{ response.status }}, expecting 200"
+    }
+  ]
+```
+
+This is the message that is used in the sent notification.
+
+Inside the message string, you can also get the response object similar to query by surrounding the expression with double curly braces like the example above.
 
 ## Further reading
 

--- a/monika.example.yml
+++ b/monika.example.yml
@@ -44,10 +44,8 @@ probes:
 #         saveBody: true
 #     alerts:
 #       - query: response.status == 500
-#         subject: response status
 #         message: response status message
 #       - query: response.time > 150
-#         subject: response time
 #         message: response time message
 #     incidentThreshold: 3
 #     recoveryThreshold: 3
@@ -68,7 +66,6 @@ probes:
 #         timeout: 6000
 #     alerts:
 #       - query: response.status == 500
-#         subject: response status
 #         message: response status message
 #     incidentThreshold: 3
 #     recoveryThreshold: 3

--- a/src/components/notification/alert-message.ts
+++ b/src/components/notification/alert-message.ts
@@ -43,11 +43,8 @@ export function getMessageForAlert({
   probeState: string
   response: AxiosResponseWithExtraData
 }): NotificationMessage {
-  const getSubject = (alert: ProbeAlert, probeState: string) => {
+  const getSubject = (probeState: string) => {
     const recoveryOrIncident = probeState === 'UP' ? 'Recovery' : 'Incident'
-
-    if (alert.subject)
-      return `[${recoveryOrIncident.toUpperCase()}] ${alert.subject}`
 
     return `New ${recoveryOrIncident} from Monika`
   }
@@ -93,7 +90,7 @@ Time: ${meta.time}
 From: ${getMonikaInstance()}`
 
   const message = {
-    subject: getSubject(alert, probeState),
+    subject: getSubject(probeState),
     body: bodyString,
     summary: getExpectedMessage(alert, response),
     meta,

--- a/src/index.ts
+++ b/src/index.ts
@@ -506,7 +506,7 @@ Please refer to the Monika documentations on how to how to configure notificatio
             probeState: 'invalid',
             notifications: notifications ?? [],
             validation: {
-              alert: { query: '', subject: '', message: '' },
+              alert: { query: '', message: '' },
               hasSomethingToReport: true,
               response: {
                 status: 500,

--- a/src/interfaces/probe.ts
+++ b/src/interfaces/probe.ts
@@ -26,8 +26,7 @@ import { RequestConfig } from './request'
 
 export interface ProbeAlert {
   query: string
-  subject: string
-  message: string
+  message?: string
 }
 
 export interface Probe {

--- a/src/looper.ts
+++ b/src/looper.ts
@@ -67,12 +67,10 @@ export function sanitizeProbe(probe: Probe, id: string): Probe {
     probe.alerts = [
       {
         query: 'response.status < 200 or response.status > 299',
-        subject: '',
         message: 'HTTP Status is {{ response.status }}, expecting 200',
       },
       {
         query: 'response.time > 2000',
-        subject: '',
         message:
           'Response time is {{ response.time }}ms, expecting less than 2000ms',
       },

--- a/src/plugins/validate-response/__tests__/index.test.ts
+++ b/src/plugins/validate-response/__tests__/index.test.ts
@@ -30,10 +30,9 @@ describe('validateResponse', () => {
   const mockedAlerts = [
     {
       query: 'response.status < 200 or response.status > 299',
-      subject: '',
       message: '',
     },
-    { query: 'response.time > 10', subject: '', message: '' },
+    { query: 'response.time > 10', message: '' },
   ]
 
   const generateMockedResponse = (status: number, responseTime: number) => {
@@ -56,7 +55,6 @@ describe('validateResponse', () => {
       {
         alert: {
           query: 'response.status < 200 or response.status > 299',
-          subject: '',
           message: '',
         },
         hasSomethingToReport: true,
@@ -73,7 +71,6 @@ describe('validateResponse', () => {
       {
         alert: {
           query: 'response.time > 10',
-          subject: '',
           message: '',
         },
         response: {
@@ -98,7 +95,6 @@ describe('validateResponse', () => {
       {
         alert: {
           query: 'response.status < 200 or response.status > 299',
-          subject: '',
           message: '',
         },
         response: {
@@ -115,7 +111,6 @@ describe('validateResponse', () => {
       {
         alert: {
           query: 'response.time > 10',
-          subject: '',
           message: '',
         },
         response: {
@@ -140,7 +135,6 @@ describe('validateResponse', () => {
       {
         alert: {
           query: 'response.status < 200 or response.status > 299',
-          subject: '',
           message: '',
         },
         response: {
@@ -157,7 +151,6 @@ describe('validateResponse', () => {
       {
         alert: {
           query: 'response.time > 10',
-          subject: '',
           message: '',
         },
         response: {
@@ -182,7 +175,6 @@ describe('validateResponse', () => {
       {
         alert: {
           query: 'response.status < 200 or response.status > 299',
-          subject: '',
           message: '',
         },
         response: {
@@ -199,7 +191,6 @@ describe('validateResponse', () => {
       {
         alert: {
           query: 'response.time > 10',
-          subject: '',
           message: '',
         },
         response: {

--- a/src/plugins/validate-response/checkers/__tests__/index.test.ts
+++ b/src/plugins/validate-response/checkers/__tests__/index.test.ts
@@ -43,7 +43,6 @@ describe('responseChecker', () => {
       const data = responseChecker(
         {
           query: 'response.status < 200 or response.status > 299',
-          subject: '',
           message: '',
         },
         res
@@ -57,7 +56,6 @@ describe('responseChecker', () => {
       const data = responseChecker(
         {
           query: 'response.status < 200 or response.status > 299',
-          subject: '',
           message: '',
         },
         res
@@ -71,7 +69,6 @@ describe('responseChecker', () => {
       const data = responseChecker(
         {
           query: 'response.status < 200 or response.status > 299',
-          subject: '',
           message: '',
         },
         res
@@ -85,7 +82,6 @@ describe('responseChecker', () => {
       const data = responseChecker(
         {
           query: 'response.status < 200 or response.status > 299',
-          subject: '',
           message: '',
         },
         res
@@ -99,7 +95,6 @@ describe('responseChecker', () => {
       const data = responseChecker(
         {
           query: 'response.status < 200 or response.status > 299',
-          subject: '',
           message: '',
         },
         res
@@ -113,7 +108,6 @@ describe('responseChecker', () => {
       const data = responseChecker(
         {
           query: 'response.status < 200 or response.status > 299',
-          subject: '',
           message: '',
         },
         res
@@ -138,7 +132,7 @@ describe('responseChecker', () => {
     it('seconds - should handle when response time is greater than alert defined response time', () => {
       const res = generateMockedResponse(20000)
       const data = responseChecker(
-        { query: 'response.time > 10000', subject: '', message: '' },
+        { query: 'response.time > 10000', message: '' },
         res
       )
 
@@ -148,7 +142,7 @@ describe('responseChecker', () => {
     it('seconds - should handle when response time is less than alert defined response time', () => {
       const res = generateMockedResponse(10000)
       const data = responseChecker(
-        { query: 'response.time > 20000', subject: '', message: '' },
+        { query: 'response.time > 20000', message: '' },
         res
       )
 
@@ -158,7 +152,7 @@ describe('responseChecker', () => {
     it('milliseconds - should handle when response time is greater than alert defined response time', () => {
       const res = generateMockedResponse(20)
       const data = responseChecker(
-        { query: 'response.time > 10', subject: '', message: '' },
+        { query: 'response.time > 10', message: '' },
         res
       )
 
@@ -168,7 +162,7 @@ describe('responseChecker', () => {
     it('milliseconds - should handle when response time is less than alert defined response time', () => {
       const res = generateMockedResponse(10)
       const data = responseChecker(
-        { query: 'response.time > 20', subject: '', message: '' },
+        { query: 'response.time > 20', message: '' },
         res
       )
 

--- a/test/components/notification.test.ts
+++ b/test/components/notification.test.ts
@@ -51,7 +51,7 @@ describe('send alerts', () => {
     chai.spy.on(mailgun, 'sendMailgun', () => Promise.resolve())
     await sendAlerts({
       validation: {
-        alert: { query: 'status-not-2xx', subject: '', message: '' },
+        alert: { query: 'status-not-2xx', message: '' },
         hasSomethingToReport: false,
         response: {
           status: 500,
@@ -84,7 +84,7 @@ describe('send alerts', () => {
     chai.spy.on(mailgun, 'sendMailgun', () => Promise.resolve())
     await sendAlerts({
       validation: {
-        alert: { query: 'status-not-2xx', subject: '', message: '' },
+        alert: { query: 'status-not-2xx', message: '' },
         hasSomethingToReport: true,
         response: {
           status: 500,
@@ -117,7 +117,7 @@ describe('send alerts', () => {
     chai.spy.on(mailgun, 'sendMailgun', () => Promise.resolve())
     await sendAlerts({
       validation: {
-        alert: { query: 'status-not-2xx', subject: '', message: '' },
+        alert: { query: 'status-not-2xx', message: '' },
         hasSomethingToReport: true,
         response: {
           status: 500,
@@ -151,7 +151,7 @@ describe('send alerts', () => {
     chai.spy.on(mailgun, 'sendMailgun', () => Promise.resolve())
     await sendAlerts({
       validation: {
-        alert: { query: 'status-not-2xx', subject: '', message: '' },
+        alert: { query: 'status-not-2xx', message: '' },
         hasSomethingToReport: true,
         response: {
           status: 500,
@@ -186,7 +186,7 @@ describe('send alerts', () => {
 
     await sendAlerts({
       validation: {
-        alert: { query: 'status-not-2xx', subject: '', message: '' },
+        alert: { query: 'status-not-2xx', message: '' },
         hasSomethingToReport: true,
         response: {
           status: 500,
@@ -226,7 +226,7 @@ describe('send alerts', () => {
     chai.spy.on(smtp, 'sendSmtpMail', () => Promise.resolve())
     await sendAlerts({
       validation: {
-        alert: { query: 'status-not-2xx', subject: '', message: '' },
+        alert: { query: 'status-not-2xx', message: '' },
         hasSomethingToReport: true,
         response: {
           status: 500,
@@ -262,7 +262,7 @@ describe('send alerts', () => {
 
     await sendAlerts({
       validation: {
-        alert: { query: 'status-not-2xx', subject: '', message: '' },
+        alert: { query: 'status-not-2xx', message: '' },
         hasSomethingToReport: true,
         response: {
           status: 500,
@@ -316,7 +316,7 @@ describe('send alerts', () => {
 
     await sendAlerts({
       validation: {
-        alert: { query: 'status-not-2xx', subject: '', message: '' },
+        alert: { query: 'status-not-2xx', message: '' },
         hasSomethingToReport: true,
         response: {
           status: 500,
@@ -351,7 +351,7 @@ describe('send alerts', () => {
 
     await sendAlerts({
       validation: {
-        alert: { query: 'status-not-2xx', subject: '', message: '' },
+        alert: { query: 'status-not-2xx', message: '' },
         hasSomethingToReport: true,
         response: {
           status: 500,
@@ -384,7 +384,7 @@ describe('send alerts', () => {
 
     await sendAlerts({
       validation: {
-        alert: { query: 'status-not-2xx', subject: '', message: '' },
+        alert: { query: 'status-not-2xx', message: '' },
         hasSomethingToReport: true,
         response: {
           status: 500,


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
this PR resolves #349 


## Additional note 
1. While updating the alert guide docs to remove the subject, I also remove references to the old alert format in the guide. This is advised by Pak Ariya in team weekly checkpoint.

