### PR TITLE
fix: stop STUN check loop on provided repeat flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -214,7 +214,7 @@ class Monika extends Command {
     }
 
     await getPublicNetworkInfo() // cache location & ISP info
-    loopCheckSTUNServer(flags.stun) // check if connected to STUN Server and getting the public IP in the same time
+    loopCheckSTUNServer(flags.stun, Number(flags.repeat)) // check if connected to STUN Server and getting the public IP in the same time
     await openLogfile()
 
     if (flags.logs) {


### PR DESCRIPTION
# Monika Pull Request (PR)  
fix issue #370 

## What feature/issue does this PR add  
1. stop looping to check stun server when repeats flag is added

## How did you implement / how did you fix it  
1.  add conditional to check repeats flag on `loopCheckSTUNServer` fuction

## How to test  
1. run `npm run start -- -r 1`
2. see there will be no checking to stun server after 1 time probing
3. if you want monika to also terminating, add status-notification flag `npm run start -- -r 1 --status-notification=false`
