### PR TITLE
Fixed: Change Error Message for Non-HTTP Error

### DIFF
--- a/src/components/notification/alert-message.ts
+++ b/src/components/notification/alert-message.ts
@@ -72,12 +72,29 @@ export async function getMessageForAlert({
     alert: ProbeAlert,
     response: AxiosResponseWithExtraData
   ) => {
+    const { statusText, status } = response
+    const isHTTPStatusCode = status >= 100 && status <= 599
+
     if (!alert.message) return ''
+
+    if (!isHTTPStatusCode) {
+      switch (status) {
+        case 0:
+          return 'URI not found'
+        case 1:
+          return 'Connection reset'
+        case 2:
+          return 'Connection refused'
+
+        default:
+          return statusText
+      }
+    }
 
     return Handlebars.compile(alert.message)({
       response: {
         size: Number(response.headers['content-length']),
-        status: response.status,
+        status,
         time: response.config.extraData?.responseTime,
         body: response.data,
         headers: response.headers,


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Change Error Message for Non-HTTP Error Message

## How did you implement / how did you fix it  
1.  Catch non-HTTP error, and change the error message

## How to test  
1. Run `npm test`
2. Run monika with 1000+ probes, until you got ENOTFOUND, ECONNRESET, or ECONNREFUSED error. Or, you can just change `errResponseCode` variable [here](https://github.com/hyperjumptech/monika/blob/main/src/components/probe/probing.ts#L115)
 with 0 for ENOTFOUND, 1 for ECONNRESET, and 2 for ECONNREFUSED.