### PR TITLE
fixed: Prometheus histogram in seconds, but response time is in milliseconds

### DIFF
--- a/src/plugins/metrics/prometheus/collector.ts
+++ b/src/plugins/metrics/prometheus/collector.ts
@@ -75,7 +75,9 @@ export class PrometheusCollector {
     const request = requests[requestIndex]
     const { method, url } = request
     const { config, headers } = response
-    const responseTimeInSecond = config.extraData?.responseTime ?? 0
+    const milliSecond = 1000
+    const responseTimeInSecond =
+      config.extraData?.responseTime / milliSecond ?? 0
     const responseSizeBytes = Number(headers['content-length'])
     const labels = {
       id,


### PR DESCRIPTION
# Monika Pull Request (PR)  
fix #394 

## What feature/issue does this PR add  
1. fix Prometheus histogram in seconds, but response time is in milliseconds

## How did you implement / how did you fix it  
1.  change milliseconds to seconds by dividing responseTime with 1000

## How to test  
1. run monika with prometheus config `npm start --prometheus 3001`
2. run prometheus `./prometheus --config.file=prometheus.yml` with config like in [this article](https://medium.com/hyperjump-tech/collecting-monika-with-prometheus-9faa7d484a30)

before, the result is empty:
<img width="1165" alt="Screen Shot 2021-09-15 at 16 46 22" src="https://user-images.githubusercontent.com/5974862/133411219-59e7153d-d7f7-4e92-a374-620c85cc20fb.png">

---

after fix, the bucket other than `le="+Inf"` is filled:
<img width="1188" alt="Screen Shot 2021-09-15 at 15 51 06" src="https://user-images.githubusercontent.com/5974862/133411377-43169b42-a3e0-4904-8c17-ff0debe8b680.png">


