### PR TITLE
Fixed: Validate Symon Configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,9 @@
     "extends": ["oclif", "oclif-typescript", "prettier"],
     "rules": {
         "no-warning-comments": "off",
-        "no-process-exit": "off"
+        "no-process-exit": "off",
+        "no-use-before-define": ["error", "nofunc"],
+        "@typescript-eslint/no-use-before-define": "off",
     },
     "overrides": [
         {

--- a/src/components/config/validate.ts
+++ b/src/components/config/validate.ts
@@ -23,6 +23,7 @@
  **********************************************************************************/
 
 /* eslint-disable complexity */
+import Joi from 'joi'
 import { Notification } from '../../interfaces/notification'
 import { Config } from '../../interfaces/config'
 import { ProbeAlert } from '../../interfaces/probe'
@@ -30,6 +31,7 @@ import { Validation } from '../../interfaces/validation'
 import { isValidURL } from '../../utils/is-valid-url'
 import { parseAlertStringTime } from '../../plugins/validate-response/checkers'
 import { compileExpression } from '../../utils/expression-parser'
+import type { SymonConfig } from '../reporter'
 
 const HTTPMethods = [
   'DELETE',
@@ -241,7 +243,8 @@ const isValidProbeAlert = (alert: ProbeAlert | string): boolean => {
 }
 
 export const validateConfig = (configuration: Config): Validation => {
-  const { notifications, probes } = configuration
+  const { notifications, probes, symon } = configuration
+  const symonConfigError = validateSymonConfig(symon)
 
   // validate notification
   if (notifications && notifications.length > 0) {
@@ -307,5 +310,28 @@ export const validateConfig = (configuration: Config): Validation => {
     })
   }
 
+  // validate symon config
+  if (symonConfigError) {
+    return setInvalidResponse(`Monika configuration: symon ${symonConfigError}`)
+  }
+
   return VALID_CONFIG
+}
+
+function validateSymonConfig(symonConfig?: SymonConfig) {
+  if (!symonConfig) {
+    return ''
+  }
+
+  const schema = Joi.object({
+    id: Joi.string().required(),
+    url: Joi.string().uri().required(),
+    key: Joi.string().required(),
+    projectID: Joi.string().required(),
+    organizationID: Joi.string().required(),
+    interval: Joi.number(),
+  })
+  const validationError = schema.validate(symonConfig)
+
+  return validationError?.error?.message
 }


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Validate Symon configuration. Resolve #409.

## How did you implement / how did you fix it  
1.  Add Symon configuratin validation

## How to test  
1. Run Monika with Symon configuration without projectID and/or organizationID key.
```yaml
symon:
  id: jakarta
  url: http://localhost:3000/api
  key: 680447df-5df7-4dea-82ca-d68d45ccba04
probes:
  - requests:
      - url: http://example.com
```

