### PR TITLE
Fixed: Prevent Command with logs or flush Flag to Load Unneeded Function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import {
   closeLog,
   flushAllLogs,
   getSummary,
+  openLogfile,
   saveNotificationLog,
 } from './components/logger/history'
 import { sendAlerts, sendNotifications } from './components/notification'
@@ -182,7 +183,7 @@ class Monika extends Command {
         return
       }
 
-      await initLoaders(flags)
+      await openLogfile()
 
       if (flags.logs) {
         await printAllLogs()
@@ -208,6 +209,8 @@ class Monika extends Command {
         await closeLog()
         return
       }
+
+      await initLoaders(flags)
 
       let scheduledTasks: ScheduledTask[] = []
       let abortCurrentLooper: (() => void) | undefined

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -23,7 +23,6 @@
  **********************************************************************************/
 
 import { getConfig, setupConfig } from '../components/config'
-import { openLogfile } from '../components/logger/history'
 import events from '../events'
 import { loopCheckSTUNServer, loopReport } from '../looper'
 import {
@@ -38,13 +37,6 @@ import '../events/subscribers/application'
 export default async function init(flags: any) {
   const eventEmitter = getEventEmitter()
   const isTestEnvironment = process.env.CI || process.env.NODE_ENV === 'test'
-
-  await openLogfile()
-
-  // the logs and flush flag only needs to load openLogfile
-  if (flags.logs || flags.flush) {
-    return
-  }
 
   // cache location & ISP info
   await getPublicNetworkInfo()

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -39,11 +39,17 @@ export default async function init(flags: any) {
   const eventEmitter = getEventEmitter()
   const isTestEnvironment = process.env.CI || process.env.NODE_ENV === 'test'
 
+  await openLogfile()
+
+  // the logs and flush flag only needs to load openLogfile
+  if (flags.logs || flags.flush) {
+    return
+  }
+
   // cache location & ISP info
   await getPublicNetworkInfo()
   // check if connected to STUN Server and getting the public IP in the same time
   loopCheckSTUNServer(flags.stun)
-  await openLogfile()
 
   // start Promotheus server
   if (flags.prometheus) {


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Fixed Monika hangs when run with flush and logs flag. Resolve #419.

## How did you implement / how did you fix it  
1.  Prevent command with logs or flush flag to load unneeded function.

## How to test  
1. Run `npm start -- -l`
2. Run `npm start -- --flush`
3. Run `npm test`