### PR TITLE
Allow merge from --postman and --har with --config

### DIFF
--- a/docs/src/pages/guides/cli-options.md
+++ b/docs/src/pages/guides/cli-options.md
@@ -76,7 +76,7 @@ The example above flushes the database bypassing without waiting for user confir
 
 ## HAR
 
-Monika supports HAR files as input. HAR are JSON formatted HTTP ARchive file. Generate a HAR file from the site you've visited then use Monika to refetch the pages and ensure they still work.
+Monika supports HAR files as input. HAR are JSON formatted HTTP ARchive file. Follow the steps [here](https://medium.com/hyperjump-tech/generate-your-monika-configuration-using-http-archive-har-764944cbb9e6) to generate your own HAR file from the site you've visited then use Monika to refetch the pages and ensure they still work.
 
 You use the `-H` or `--har` to specify a HAR file.
 
@@ -84,9 +84,24 @@ You use the `-H` or `--har` to specify a HAR file.
 monika -H my-file.har
 ```
 
-You can use the combination of --create-config and --har flags to convert the HAR archive into to a monika.yml configuration file.
+### Create config from HAR file
 
-Please note, HAR files may contain sensitive information, use caution when distributing HAR filles.
+You can use the combination of `--create-config` and `--har` flags to convert the HAR archive into to a monika.yml configuration file.
+
+```bash
+# default to monika.json
+monika --create-config -H my-file.har
+```
+
+### Merge HAR file to existing configurations
+
+You can also use `-c/--config` to merge properties with them. Note that using `--har` will override probes passed to `-c/--config`.
+
+```bash
+monika --config monika-notifications.json -H my-file.har
+```
+
+**P.S.**: HAR files may contain sensitive information, use caution when distributing HAR filles.
 
 ## Id
 
@@ -128,7 +143,17 @@ Have an existing request on postman you want to automate? Monika supports readin
 monika -p postman.json
 ```
 
+### Create config from Postman file
+
 You can use the combination of `--create-config` and `--postman` flags to convert the postman files to a monika.yml config file.
+
+### Merge Postman file to existing configurations
+
+You can also use `-c/--config` to merge properties with them. Note that using `--postman` will override probes passed to `-c/--config`.
+
+```bash
+monika --config monika-notifications.json --postman my-file.har
+```
 
 ## Prometheus
 

--- a/docs/src/pages/guides/cli-options.md
+++ b/docs/src/pages/guides/cli-options.md
@@ -76,7 +76,7 @@ The example above flushes the database bypassing without waiting for user confir
 
 ## HAR
 
-Monika supports HAR files as input. HAR are JSON formatted HTTP ARchive file. Follow the steps [here](https://medium.com/hyperjump-tech/generate-your-monika-configuration-using-http-archive-har-764944cbb9e6) to generate your own HAR file from the site you've visited then use Monika to refetch the pages and ensure they still work.
+Monika supports HAR files as input. HAR are JSON formatted HTTP ARchive file. Follow [these steps](https://medium.com/hyperjump-tech/generate-your-monika-configuration-using-http-archive-har-764944cbb9e6) to generate your own HAR file from the site you've visited then use Monika to refetch the pages and ensure they still work.
 
 You use the `-H` or `--har` to specify a HAR file.
 

--- a/src/components/config/__tests__/expected.har.json
+++ b/src/components/config/__tests__/expected.har.json
@@ -1,5 +1,5 @@
 {
-  "notifications": [{ "id": "har-desktop-notif", "type": "desktop" }],
+  "notifications": [{ "id": "default", "type": "desktop" }],
   "probes": [
     {
       "requests": [

--- a/src/components/config/__tests__/expected.postman.json
+++ b/src/components/config/__tests__/expected.postman.json
@@ -1,7 +1,5 @@
 {
-  "notifications": [
-    { "type": "desktop", "id": "unique-id-desktop-monika-notif" }
-  ],
+  "notifications": [{ "type": "desktop", "id": "default" }],
   "probes": [
     {
       "id": "Get Request",

--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -210,7 +210,6 @@ export const createConfig = async (flags: any) => {
     const parse = parseConfig(path, type)
     const result = await addDefaultNotifications(parse)
     const file = flags.output || 'monika.json'
-    log.info(JSON.stringify(result))
 
     if (existsSync(file) && !flags.force) {
       const ans = await cli.prompt(

--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -207,8 +207,10 @@ export const createConfig = async (flags: any) => {
       return
     }
 
-    const parsed = await parseConfig(path, type)
+    const parse = parseConfig(path, type)
+    const result = await addDefaultNotifications(parse)
     const file = flags.output || 'monika.json'
+    log.info(JSON.stringify(result))
 
     if (existsSync(file) && !flags.force) {
       const ans = await cli.prompt(
@@ -223,7 +225,7 @@ export const createConfig = async (flags: any) => {
       }
     }
 
-    writeFileSync(file, JSON.stringify(parsed), 'utf8')
+    writeFileSync(file, JSON.stringify(result), 'utf8')
     log.info(`${file} file has been created.`)
   }
 }

--- a/src/components/config/parse-har.ts
+++ b/src/components/config/parse-har.ts
@@ -68,12 +68,6 @@ export const parseHarFile = (fileContents: string): Config => {
     )
 
     const harConfig: any = {
-      notifications: [
-        {
-          id: 'har-desktop-notif',
-          type: 'desktop',
-        },
-      ],
       probes: [
         {
           requests: harRequest,

--- a/src/components/config/parse-postman.ts
+++ b/src/components/config/parse-postman.ts
@@ -26,13 +26,6 @@ import { Config } from '../../interfaces/config'
 import { Probe } from '../../interfaces/probe'
 import { DEFAULT_THRESHOLD } from '../../looper'
 
-const defaultNotification = [
-  {
-    type: 'desktop',
-    id: 'unique-id-desktop-monika-notif',
-  },
-]
-
 let probes: Probe[] = []
 
 const getConvertedProbeFromPostmanItem = (item: any) => {
@@ -81,7 +74,6 @@ export const parseConfigFromPostman = (configString: string): Config => {
     parsePostmanItem(parsed.item)
 
     const configMonika: any = {
-      notifications: defaultNotification,
       probes,
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,14 @@ class Monika extends Command {
       char: 'p', // (p)ostman
       description: 'Run Monika using a Postman json file.',
       multiple: false,
-      exclusive: ['config', 'har'],
+      exclusive: ['har'],
+    }),
+
+    har: flags.string({
+      char: 'H', // (H)ar file to
+      description: 'Run Monika using a HAR file',
+      multiple: false,
+      exclusive: ['postman'],
     }),
 
     logs: flags.boolean({
@@ -140,13 +147,6 @@ class Monika extends Command {
       char: 'i', // (i)ds to run
       description: 'specific probe ids to run',
       multiple: false,
-    }),
-
-    har: flags.string({
-      char: 'H', // (H)ar file to
-      description: 'Run Monika using a HAR file',
-      multiple: false,
-      exclusive: ['config', 'postman'],
     }),
 
     output: flags.string({

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -103,7 +103,7 @@ describe('monika', () => {
         resolve('./test/testConfigs/harTest.har'),
       ])
     )
-    .it('merge har file with with other config', (ctx) => {
+    .it('merge har file with other config', (ctx) => {
       expect(ctx.stdout).to.contain('Notifications: 2').and.contain('Probes: 1')
     })
 
@@ -133,7 +133,7 @@ describe('monika', () => {
         resolve('./test/testConfigs/simple.postman_collection.json'),
       ])
     )
-    .it('merge postman file with with other config', (ctx) => {
+    .it('merge postman file with other config', (ctx) => {
       expect(ctx.stdout).to.contain('Notifications: 2').and.contain('Probes: 1')
     })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -95,6 +95,71 @@ describe('monika', () => {
   test
     .stdout()
     .do(() =>
+      cmd.run([
+        '-c',
+        resolve('./test/testConfigs/manyNotif.yml'),
+        resolve('./test/testConfigs/manyProbes.yml'),
+        '--har',
+        resolve('./test/testConfigs/harTest.har'),
+      ])
+    )
+    .it('merge har file with with other config', (ctx) => {
+      expect(ctx.stdout).to.contain('Notifications: 2').and.contain('Probes: 1')
+    })
+
+  test
+    .stdout()
+    .do(() =>
+      cmd.run([
+        '--har',
+        resolve('./test/testConfigs/harTest.har'),
+        '-c',
+        resolve('./test/testConfigs/manyNotif.yml'),
+        resolve('./test/testConfigs/manyProbes.yml'),
+      ])
+    )
+    .it('probes from har file will override regardless flag order', (ctx) => {
+      expect(ctx.stdout).to.contain('Notifications: 2').and.contain('Probes: 1')
+    })
+
+  test
+    .stdout()
+    .do(() =>
+      cmd.run([
+        '-c',
+        resolve('./test/testConfigs/manyNotif.yml'),
+        resolve('./test/testConfigs/manyProbes.yml'),
+        '--postman',
+        resolve('./test/testConfigs/simple.postman_collection.json'),
+      ])
+    )
+    .it('merge postman file with with other config', (ctx) => {
+      expect(ctx.stdout).to.contain('Notifications: 2').and.contain('Probes: 1')
+    })
+
+  test
+    .stdout()
+    .do(() =>
+      cmd.run([
+        '--postman',
+        resolve('./test/testConfigs/simple.postman_collection.json'),
+        '-c',
+        resolve('./test/testConfigs/manyNotif.yml'),
+        resolve('./test/testConfigs/manyProbes.yml'),
+      ])
+    )
+    .it(
+      'probes from postman file will override regardless flag order',
+      (ctx) => {
+        expect(ctx.stdout)
+          .to.contain('Notifications: 2')
+          .and.contain('Probes: 1')
+      }
+    )
+
+  test
+    .stdout()
+    .do(() =>
       cmd.run(['--config', resolve('./test/testConfigs/noInterval.yml')])
     )
     .it('runs with config without interval', (ctx) => {

--- a/test/testConfigs/simple.postman_collection.json
+++ b/test/testConfigs/simple.postman_collection.json
@@ -1,0 +1,60 @@
+{
+  "info": {
+    "_postman_id": "73401126-e1d1-4a9e-b43e-7e4822f2b50e",
+    "name": "Tes Monika",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Get Request",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://127.0.0.1:5000/v1",
+          "host": ["127", "0", "0", "1"],
+          "port": "5000",
+          "path": ["v1"]
+        }
+      },
+      "response": [
+        {
+          "name": "Get Request",
+          "originalRequest": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://127.0.0.1:5000/v1",
+              "host": ["127", "0", "0", "1"],
+              "port": "5000",
+              "path": ["v1"]
+            }
+          },
+          "status": "OK",
+          "code": 200,
+          "_postman_previewlanguage": "html",
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "15"
+            },
+            {
+              "key": "Server",
+              "value": "Werkzeug/1.0.1 Python/3.8.2"
+            },
+            {
+              "key": "Date",
+              "value": "Wed, 14 Jul 2021 06:52:56 GMT"
+            }
+          ],
+          "cookie": [],
+          "body": "recommender app"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Monika Pull Request (PR) 
This PR resolves #422 

## What feature/issue does this PR add  
1. Allow `--har` and `--postman` to be combined with `-c/--config`

## How did you implement / how did you fix it  
1.  Probes from `har` and `postman` file will always override configurations passed to `--config`
2. When no additional config provided, `desktop` notification type will be default
3. `--har` and `--postman` are still exclusive against each other

## How to test  
- `npm run -- -c /path/to/notifications/config --har test/testConfigs/harTest.har`
- `npm run -- -c /path/to/notifications/config --postman test/testConfigs/simple.postman_collection.json`

