### PR TITLE
fix: resolve default config as array

### DIFF
--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -146,7 +146,9 @@ const addDefaultNotifications = (
 }
 
 export const setupConfig = async (flags: any) => {
+  // check for default config path when -c/--config not provided
   if (
+    flags.config.length === 1 &&
     ['./monika.json', './monika.yml', './monika.yaml'].includes(
       flags.config[0]
     ) &&

--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -146,8 +146,16 @@ const addDefaultNotifications = (
 }
 
 export const setupConfig = async (flags: any) => {
+  if (
+    ['./monika.json', './monika.yml', './monika.yaml'].includes(
+      flags.config[0]
+    ) &&
+    !existsSync(flags.config[0])
+  ) {
+    delete flags.config
+  }
   const configParse = new Array<Promise<Partial<Config>>>(0)
-  if (Array.isArray(flags.config) && flags.config.length > 0) {
+  if (flags.config && Array.isArray(flags.config) && flags.config.length > 0) {
     const json = parseDefaultConfig(flags)
     configParse.push(...json)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,19 +48,22 @@ import { log } from './utils/pino'
 
 const em = getEventEmitter()
 
-function getDefaultConfig() {
+function getDefaultConfig(): Array<string> {
   const filesArray = fs.readdirSync('./')
   const monikaDotJsonFile = filesArray.find((x) => x === 'monika.json')
   const monikaDotYamlFile = filesArray.find(
     (x) => x === 'monika.yml' || x === 'monika.yaml'
   )
 
-  return monikaDotYamlFile
-    ? `./${monikaDotYamlFile}`
-    : monikaDotJsonFile
-    ? `./${monikaDotJsonFile}`
-    : './monika.yml'
+  return [
+    monikaDotYamlFile
+      ? `./${monikaDotYamlFile}`
+      : monikaDotJsonFile
+      ? `./${monikaDotJsonFile}`
+      : './monika.yml',
+  ]
 }
+
 class Monika extends Command {
   static description = 'Monika command line monitoring tool'
 


### PR DESCRIPTION
# Monika Pull Request (PR)  
This PR resolves #437 

## What feature/issue does this PR add/fix  
1. Fix `-c/--config` flag to have `['./monika.json/yml/yaml']` as default

## How did you implement / how did you fix it  
1. Change return value of `getDefaultConfig()`
2. Workaround the impact of removing `-c/--config`'s exclusivity against `--postman` and `--har`

## How to test  
1. If you don't have `monika.json/yaml/yml` file, `cp monika.example.yml monika.yml`
2. `npm run start` should properly use `./monika.yml`
