### PR TITLE
Fix: Notification was sent when no state transition happen

### DIFF
--- a/src/components/notification/__tests__/process-server-status.test.ts
+++ b/src/components/notification/__tests__/process-server-status.test.ts
@@ -245,6 +245,15 @@ describe('processThresholds', () => {
       validatedResponse: failureResponse,
     })
 
+    // send success response as much threshold
+    for (let i = 0; i < probe.recoveryThreshold; i++) {
+      result = processThresholds({
+        probe,
+        requestIndex: 1,
+        validatedResponse: successResponse,
+      })
+    }
+
     expect(result[0].state).to.equals('UP')
 
     // should not send notification again since state does not change

--- a/src/components/notification/__tests__/process-server-status.test.ts
+++ b/src/components/notification/__tests__/process-server-status.test.ts
@@ -25,6 +25,7 @@
 import { expect } from 'chai'
 import { interpret, Interpreter } from 'xstate'
 import { Probe } from '../../../interfaces/probe'
+import { ServerAlertState } from '../../../interfaces/probe-status'
 import { ValidatedResponse } from '../../../plugins/validate-response'
 import {
   processThresholds,
@@ -43,7 +44,6 @@ describe('serverAlertStateMachine', () => {
         recoveryThreshold: 5,
         consecutiveFailures: 0,
         consecutiveSuccesses: 0,
-        hasBeenDownAtLeastOnce: false,
       })
     ).start()
   })
@@ -125,45 +125,52 @@ describe('serverAlertStateMachine', () => {
 })
 
 describe('processThresholds', () => {
+  const probe = {
+    requests: [
+      {
+        method: 'GET',
+        url: 'https://httpbin.org/status/200',
+      },
+      {
+        method: 'POST',
+        url: 'https://httpbin.org/status/201',
+      },
+    ],
+    incidentThreshold: 2,
+    recoveryThreshold: 2,
+  } as Probe
+
+  const successResponse = [
+    {
+      alert: { query: 'response.time > 1000' },
+      isAlertTriggered: false,
+    },
+  ] as ValidatedResponse[]
+
+  const failureResponse = [
+    {
+      alert: { query: 'response.time > 1000' },
+      isAlertTriggered: true,
+    },
+  ] as ValidatedResponse[]
+
   beforeEach(() => {
     resetServerAlertStates()
   })
 
-  it('should attach threshold calculation to each request', () => {
-    const probe = {
-      requests: [
-        {
-          method: 'GET',
-          url: 'https://httpbin.org/status/200',
-        },
-        {
-          method: 'POST',
-          url: 'https://httpbin.org/status/201',
-        },
-      ],
-      incidentThreshold: 2,
-      recoveryThreshold: 2,
-    } as Probe
-
-    const validatedResponse = [
-      {
-        alert: { query: 'response.time > 1000' },
-        isAlertTriggered: true,
-      },
-    ] as ValidatedResponse[]
-
+  it('should attach state calculation to each request', () => {
     // failure happened first for request with index 0
     processThresholds({
       probe,
       requestIndex: 0,
-      validatedResponse,
+      validatedResponse: failureResponse,
     })
 
     // processing request with index 1
     const result1 = processThresholds({
       probe,
       requestIndex: 1,
-      validatedResponse,
+      validatedResponse: failureResponse,
     })
 
     // failure happened only once for request with index 1, it does not reach threshold yet
@@ -172,10 +179,75 @@ describe('processThresholds', () => {
     const result2 = processThresholds({
       probe,
       requestIndex: 1,
-      validatedResponse,
+      validatedResponse: failureResponse,
     })
 
     // second time failure happened for request with index 1, it reaches threshold
     expect(result2[0].state).to.equals('DOWN')
+  })
+
+  it('should compute shouldSendNotification based on threshold and previous state', () => {
+    let result!: ServerAlertState[]
+
+    // trigger down state
+    for (let i = 0; i < probe.incidentThreshold; i++) {
+      result = processThresholds({
+        probe,
+        requestIndex: 1,
+        validatedResponse: failureResponse,
+      })
+    }
+
+    expect(result[0].state).to.equals('DOWN')
+
+    // initial state is UP and now it is changed to DOWN, should send notification
+    expect(result[0].shouldSendNotification).to.equals(true)
+
+    // send success response once
+    result = processThresholds({
+      probe,
+      requestIndex: 1,
+      validatedResponse: successResponse,
+    })
+
+    // send failure response again as much threshold
+    for (let i = 0; i < probe.incidentThreshold; i++) {
+      result = processThresholds({
+        probe,
+        requestIndex: 1,
+        validatedResponse: failureResponse,
+      })
+    }
+
+    expect(result[0].state).to.equals('DOWN')
+
+    // should not send notification again since state does not change
+    expect(result[0].shouldSendNotification).to.equals(false)
+
+    // send success response as much threshold
+    for (let i = 0; i < probe.recoveryThreshold; i++) {
+      result = processThresholds({
+        probe,
+        requestIndex: 1,
+        validatedResponse: successResponse,
+      })
+    }
+
+    expect(result[0].state).to.equals('UP')
+
+    // should send notification since state change from DOWN to UP
+    expect(result[0].shouldSendNotification).to.equals(true)
+
+    // send failure response once
+    result = processThresholds({
+      probe,
+      requestIndex: 1,
+      validatedResponse: failureResponse,
+    })
+
+    expect(result[0].state).to.equals('UP')
+
+    // should not send notification again since state does not change
+    expect(result[0].shouldSendNotification).to.equals(false)
   })
 })

--- a/src/components/notification/process-server-status.ts
+++ b/src/components/notification/process-server-status.ts
@@ -33,7 +33,6 @@ export type ServerAlertStateContext = {
   recoveryThreshold: number
   consecutiveFailures: number
   consecutiveSuccesses: number
-  hasBeenDownAtLeastOnce: boolean
 }
 
 const serverAlertStateInterpreters = new Map<
@@ -68,7 +67,6 @@ export const serverAlertStateMachine = createMachine<ServerAlertStateContext>(
         },
       },
       DOWN: {
-        entry: 'handleDownState',
         on: {
           FAILURE: {
             actions: 'handleFailure',
@@ -96,9 +94,6 @@ export const serverAlertStateMachine = createMachine<ServerAlertStateContext>(
       handleSuccess: assign({
         consecutiveFailures: (_context) => 0,
         consecutiveSuccesses: (context) => context.consecutiveSuccesses + 1,
-      }),
-      handleDownState: assign({
-        hasBeenDownAtLeastOnce: (_context) => true,
       }),
     },
     guards: {
@@ -140,7 +135,6 @@ export const processThresholds = ({
           recoveryThreshold,
           consecutiveFailures: 0,
           consecutiveSuccesses: 0,
-          hasBeenDownAtLeastOnce: false,
         })
 
         interpreters[alert.query] = interpret(stateMachine).start()
@@ -156,6 +150,8 @@ export const processThresholds = ({
 
     const interpreter = serverAlertStateInterpreters.get(request)![alert.query]
 
+    const prevStateValue = interpreter.state.value
+
     interpreter.send(isAlertTriggered ? 'FAILURE' : 'SUCCESS')
 
     const state = interpreter.state
@@ -165,10 +161,11 @@ export const processThresholds = ({
       state: state.value as 'UP' | 'DOWN',
       shouldSendNotification:
         (state.value === 'DOWN' &&
+          prevStateValue === 'UP' &&
           state.context.consecutiveFailures === incidentThreshold) ||
         (state.value === 'UP' &&
-          state.context.consecutiveSuccesses === recoveryThreshold &&
-          state.context.hasBeenDownAtLeastOnce),
+          prevStateValue === 'DOWN' &&
+          state.context.consecutiveSuccesses === recoveryThreshold),
     })
   })
 

--- a/src/components/notification/process-server-status.ts
+++ b/src/components/notification/process-server-status.ts
@@ -160,12 +160,8 @@ export const processThresholds = ({
       alertQuery: alert.query,
       state: state.value as 'UP' | 'DOWN',
       shouldSendNotification:
-        (state.value === 'DOWN' &&
-          prevStateValue === 'UP' &&
-          state.context.consecutiveFailures === incidentThreshold) ||
-        (state.value === 'UP' &&
-          prevStateValue === 'DOWN' &&
-          state.context.consecutiveSuccesses === recoveryThreshold),
+        (state.value === 'DOWN' && prevStateValue === 'UP') ||
+        (state.value === 'UP' && prevStateValue === 'DOWN'),
     })
   })
 


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
This PR fixes #443 
The problem is exactly as @nicnocquee comment here https://github.com/hyperjumptech/monika/issues/443#issuecomment-928258005

## How did you implement / how did you fix it  
1.  set `shouldSendNotification` to true only when state transition happen
2. add test to validate it

## How to test  
1. npm test


