### PR TITLE
fix: config file update not detected

### DIFF
--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -76,10 +76,10 @@ const handshakeAndValidate = async (config: Config) => {
 
 const updateConfig = async (config: Config) => {
   await handshakeAndValidate(config)
-  const lastConfig = cfg?.version
+  const lastConfigVersion = cfg?.version
   cfg = config
-  cfg.version = lastConfig || md5Hash(config)
-  if (lastConfig !== cfg.version) {
+  cfg.version = cfg.version || md5Hash(cfg)
+  if (lastConfigVersion !== undefined && lastConfigVersion !== cfg.version) {
     emitter.emit(events.config.updated, cfg)
     log.warn('config file update detected')
   }


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
fixes #441 
Monika does not reload because of a mistake in the version assignment to the updated config.

## How to test  
1. run monika with any config
2. update the config while monika is running
3. check the terminal, it should display something similar to
```sh
WARN: config file update detected
Restarting Monika. ...
```


