### PR TITLE
chore: move version to new line

### DIFF
--- a/src/components/notification/alert-message.ts
+++ b/src/components/notification/alert-message.ts
@@ -81,6 +81,7 @@ export async function getMessageForAlert({
     privateIpAddress: ipAddress,
     publicIpAddress,
     monikaInstance,
+    version: userAgent,
   }
   const getSubject = (probeState: string) => {
     const recoveryOrIncident = probeState === 'UP' ? 'Recovery' : 'Incident'
@@ -132,7 +133,8 @@ From: ${monikaInstance}
 OS: ${osName}
 
 Version: ${userAgent}`
-  const summary = `${expectedMessage} - ${userAgent} - ${osName}`
+
+  const summary = `${expectedMessage}`
 
   const message = {
     subject: getSubject(probeState),
@@ -165,6 +167,7 @@ export const getMessageForStart = async (
       hostname,
       privateIpAddress: ip,
       publicIpAddress,
+      version: userAgent,
     },
   }
 }
@@ -190,6 +193,7 @@ export const getMessageForTerminate = async (
       hostname,
       privateIpAddress: ip,
       publicIpAddress,
+      version: userAgent,
     },
   }
 }

--- a/src/components/notification/channel/lark.ts
+++ b/src/components/notification/channel/lark.ts
@@ -92,6 +92,10 @@ export const sendLark = async (
                     tag: 'text',
                     text: `From: ${message.meta.monikaInstance}`,
                   },
+                  {
+                    tag: 'text',
+                    text: `Version: ${message.meta.version}`,
+                  },
                 ],
               ],
             },

--- a/src/components/notification/channel/teams.ts
+++ b/src/components/notification/channel/teams.ts
@@ -89,6 +89,7 @@ export const sendTeams = async (
                   name: 'From',
                   value: message.meta.monikaInstance,
                 },
+                { name: 'Version', value: message.meta.version },
               ],
               markdown: true,
             },

--- a/src/interfaces/notification.ts
+++ b/src/interfaces/notification.ts
@@ -139,6 +139,7 @@ interface BaseNotificationMessageMeta {
   publicIpAddress: string
   [key: string]: unknown
   monikaInstance?: any
+  version: string
 }
 interface NotificationIncidentRecoveryMessageMeta
   extends BaseNotificationMessageMeta {

--- a/src/jobs/summary-notification.ts
+++ b/src/jobs/summary-notification.ts
@@ -61,6 +61,7 @@ Version: ${userAgent}`,
         hostname: hostname(),
         privateIpAddress: getIp(),
         publicIpAddress,
+        version: userAgent,
         ...summary,
       },
     }).catch((error) => log.error(`Summary notification: ${error.message}`))


### PR DESCRIPTION
# Monika Pull Request (PR)  
This PR resolves #449 

## What feature/issue does this PR add  
1. Move version and platform info to new line for Ms Teams and Lark notification channel

## How did you implement / how did you fix it  
1.  Add `version` to `meta` field
2. Add new line to Lark and Ms Teams notification channel

## How to test  
1. To immediately trigger alert, we can use below config
```
"incidentThreshold": 1,
"alerts": ["response-time-greater-than-1-ms"]
```
2. `npm run start`

Screenshot
![image](https://user-images.githubusercontent.com/9563873/135379231-5ed1731f-3ef3-4bc9-8aa5-4bbf66b813a1.png)

