### PR TITLE
Fixed using yaml format with remote configuration

### DIFF
--- a/src/components/config/fetch.ts
+++ b/src/components/config/fetch.ts
@@ -23,13 +23,24 @@
  **********************************************************************************/
 
 import axios from 'axios'
+import yml, { YAMLException } from 'js-yaml'
 import { Config } from '../../interfaces/config'
 
 export const fetchConfig = async (url: string): Promise<Partial<Config>> => {
   try {
     const { data } = await axios.get(url)
-    return data
+
+    const json =
+      typeof data === 'string' ? yml.load(data, { json: true }) : data
+
+    return json
   } catch (error) {
+    if (error instanceof YAMLException) {
+      throw new SyntaxError(
+        'The remote configuration file is in invalid YAML format!'
+      )
+    }
+
     throw new Error(`The configuration file in ${url} is unreachable. Please check the URL again or your internet connection. 
     `)
   }

--- a/src/components/config/parse.ts
+++ b/src/components/config/parse.ts
@@ -29,10 +29,10 @@ import { parseHarFile } from './parse-har'
 import path from 'path'
 import yml from 'js-yaml'
 
-export const parseConfig = async (
+export const parseConfig = (
   configPath: string,
   type: string
-): Promise<Partial<Config>> => {
+): Partial<Config> => {
   // Read file from configPath
   try {
     // Read file from configPath

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,14 +54,9 @@ function getDefaultConfig(): Array<string> {
   const monikaDotYamlFile = filesArray.find(
     (x) => x === 'monika.yml' || x === 'monika.yaml'
   )
+  const defaultConfig = monikaDotYamlFile || monikaDotJsonFile
 
-  return [
-    monikaDotYamlFile
-      ? `./${monikaDotYamlFile}`
-      : monikaDotJsonFile
-      ? `./${monikaDotJsonFile}`
-      : './monika.yml',
-  ]
+  return defaultConfig ? [defaultConfig] : []
 }
 
 class Monika extends Command {


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
fixes #457 

## How did you implement / how did you fix it  
 load remote yaml file into javascript object after fetching

## How to test  
`npm start -- --config https://raw.githubusercontent.com/hyperjumptech/monika/main/monika.example.yml`

## Additional change
I also improve the handling of config file not found. Previously to handle this, the `flags.config` property was deleted first. I think this is not good because there is possibility that the `flags.config` value is gonna be needed later
