### PR TITLE
Minor eye candy: add display which config used

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -246,6 +246,7 @@ class Monika extends Command {
           flags.verbose,
           !abortCurrentLooper
         )
+        this.log('Using config file: ', flags.config)
         this.log(startupMessage)
 
         // config probes to be run by the looper


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. I would like to see the current config file being used.

## How did you implement / how did you fix it  
1.  Display the config flile being used as a startup emssage
2. reading straght from flags.config

![image](https://user-images.githubusercontent.com/964106/135982304-cb53ddc4-60b2-4e0a-aadf-063a15d8d0d5.png)
