### PR TITLE
Fix broken link on documentation

### DIFF
--- a/docs/src/pages/overview.md
+++ b/docs/src/pages/overview.md
@@ -37,4 +37,4 @@ Monika is open sourced. How many of you click the "Pricing" menu every time afte
 
 ## You talked me into it, what now?
 
-[Let's install Monika](https://hyperjumptech.github.io/monika/installation)
+[Let's install Monika](https://monika.hyperjump.tech/quick-start)


### PR DESCRIPTION
fix broken link

# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Fix broken link in https://monika.hyperjump.tech/overview

## How did you implement / how did you fix it  
1.  Change installation link to https://monika.hyperjump.tech/quick-start

## How to test  
1. Click on "lets install monika" make sure it goes to quick start page

