### PR TITLE
fixed: missing host in monika status notification

### DIFF
--- a/src/components/notification/alert-message.ts
+++ b/src/components/notification/alert-message.ts
@@ -40,7 +40,7 @@ import {
 
 const getLinuxDistro = promisify(getos)
 
-const getMonikaInstance = async (ipAddress: string) => {
+export const getMonikaInstance = async (ipAddress: string) => {
   const osHostname = hostname()
   await getPublicIp()
 


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. fixes #491 

## How did you implement / how did you fix it  
1.  Added `monikaInstance` information to message meta which will be used by teams and other channels

## How to test  
1. configure your monika to send notification to microsoft teams
2. run monika with flag `--status-notification "* * * * *"`
3. wait until you get notification in teams

