### PR TITLE
fix: windows desktop notification doesn't show

### DIFF
--- a/src/components/notification/channel/desktop.ts
+++ b/src/components/notification/channel/desktop.ts
@@ -81,7 +81,7 @@ export const sendDesktop = (data: NotifyData) => {
     case 'Darwin':
       spawnSync('osascript', ['-e', osascript])
       break
-    case 'Windows NT':
+    case 'Windows_NT':
       execSync(powershellScript, { shell: 'powershell.exe' })
       break
     default:


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Fixes issue #453 

## How did you implement / how did you fix it  
1. `type()` returns "Windows_NT" for Windows OS, so changing the case from "Windows NT" to "Windows_NT" fixed this issue

## How to test  
1. Boot Windows 10
2. Run this or any config in Monika
```notifications:
  - id: desktop
    type: desktop
probes:
  - id: sample_1
    name: Sample Request
    requests:
      - method: GET
        url: https://reqres.in/api/users/23
    alerts:
      - query: response.time > 200
        message: Response time is {{ response.time }} ms, expecting less than 200ms
      - query: response.status != 200
        message: Status code is not 200. I think their service is down.
      - query: isEmpty(response.body)
        message: Response body should not be empty!
    incidentThreshold: 2
    recoveryThreshold: 2
```
3. You should see the desktop notification

