### PR TITLE
SymonClient: adds send status when initiated, terminated and exited

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ import isUrl from 'is-url'
 import SymonClient from './symon'
 
 const em = getEventEmitter()
-let symonClient
+let symonClient: SymonClient
 
 function getDefaultConfig(): Array<string> {
   const filesArray = fs.readdirSync('./')
@@ -461,6 +461,14 @@ Please refer to the Monika documentations on how to how to configure notificatio
 
     return startupMessage
   }
+
+  async catch(error: Error) {
+    super.catch(error)
+
+    if (symonClient) {
+      await symonClient.sendStatus({ isOnline: false })
+    }
+  }
 }
 
 /**
@@ -473,6 +481,10 @@ process.on('SIGINT', async () => {
     log.info(
       'Can you give us some feedback by clicking this link https://github.com/hyperjumptech/monika/discussions?\n'
     )
+  }
+
+  if (symonClient) {
+    await symonClient.sendStatus({ isOnline: false })
   }
 
   em.emit(events.application.terminated)

--- a/src/index.ts
+++ b/src/index.ts
@@ -468,6 +468,8 @@ Please refer to the Monika documentations on how to how to configure notificatio
     if (symonClient) {
       await symonClient.sendStatus({ isOnline: false })
     }
+
+    throw error
   }
 }
 

--- a/src/symon/index.ts
+++ b/src/symon/index.ts
@@ -154,6 +154,7 @@ class SymonClient {
 
   async initiate() {
     this.monikaId = await this.handshake()
+    await this.sendStatus({ isOnline: true })
 
     log.debug('Handshake succesful')
 
@@ -315,6 +316,23 @@ class SymonClient {
       log.warn(
         "Warning: Can't report history to Symon. " + (error as any).message
       )
+    }
+  }
+
+  async sendStatus({ isOnline }: { isOnline: boolean }) {
+    try {
+      await this.httpClient({
+        url: '/status',
+        method: 'POST',
+        data: {
+          monikaId: this.monikaId,
+          status: isOnline,
+        },
+      })
+
+      log.debug('Status successfully sent to Symon.')
+    } catch (error) {
+      log.warn("Warning: Can't send status to Symon. " + error?.message)
     }
   }
 }


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
This PR adds the ability to SymonClient to send Monika's status when initiated, terminated and exited.

## How to test  
1. npm start -- --symonUrl `<your-symon-url>` --symonKey `<your-symon-api-key>`

