### PR TITLE
Fix: Error Handling with Oclif

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1.17.0",
+    "@oclif/errors": "^1.3.5",
     "@oclif/plugin-help": "^3.2.2",
     "@sendgrid/mail": "^7.4.2",
     "@types/chai-spies": "^1.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ import { log } from './utils/pino'
 import path from 'path'
 import isUrl from 'is-url'
 import SymonClient from './symon'
+import { ExitError } from '@oclif/errors'
 
 const em = getEventEmitter()
 let symonClient: SymonClient
@@ -469,6 +470,10 @@ Please refer to the Monika documentations on how to how to configure notificatio
       await symonClient.sendStatus({ isOnline: false })
     }
 
+    if (error instanceof ExitError) {
+      const oclifHandler = require('@oclif/errors/handle')
+      return oclifHandler(error)
+    }
     throw error
   }
 }


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
This PR fixes #532 

## How did you implement / how did you fix it  
Use `@oclif/errors`error handler according to the [docs](https://oclif.io/docs/error_handling)
It seems that people are getting the same error when printing help or version ([Exhibit A](https://githubmemory.com/repo/oclif/oclif/issues/427) and [Exhibit B](https://githubmemory.com/repo/oclif/errors/issues/67)). Using the `@oclif/errors` will [respect any EEXIT error (including ExitError) (https://github.com/oclif/errors/releases/tag/v1.3.5) 

## How to test  
1. Run npm run start -- -v
2. It should print version without errors