### PR TITLE
added: support for form-urlencoded

### DIFF
--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -108,17 +108,34 @@ In a configuration with multiple probes, `Monika` will perform the requests in s
 
 On completion, `Monika` will sleep until the next interval to start again. At the top of the `monika.yml` file there is an `interval` setting. The execution will be restarted after every `interval`. If interval is shorter than the amount of time to dispatch all the requests, then `Monika` will immediately repeat after the last probe response and any notification alerts sent. When the `--repeat` flag is set with a value, Monika will not run indefinitely, instead, it will stop after executing the probes as many times as specified.
 
+## Content-Type header
+
+Currently, Monika only supports Content-Type value `application/x-www-form-urlencoded` and `application/json` with UTF-8 encoding.
+
+## Request Body
+
+By default, request body will be treated as-is. If request header's `Content-Type` is set to `application/x-www-form-urlencoded`, it will be serialized into URL-safe string in UTF-8 encoding.
+
 ## Postman JSON file support
 
-To run monika using a Postman JSON file, use --postman flag as follows:
+To run monika using a [Postman](https://www.postman.com/) JSON file, use `--postman` flag as follows:
 
 ```bash
 monika --postman <path_to_postman_file>
 ```
 
+## Insomnia file support
+
+Monika supports [Insomnia](https://insomnia.rest/) collection file in **version 4** format. Both `json` and `yaml` files are supported.
+To run Monika using an Insomnia collection file, use `--insomnia` flag as follows:
+
+```bash
+monika --insomnia <path_to_insomnia_file>
+```
+
 ## HAR file support
 
-HAR [HTTP-Archive](<https://en.wikipedia.org/wiki/HAR_(file_format)>) format was created by the Web Performance Working Group and has become the standard in browser archive request data definition. To run monika using a HAR file, use --har flag as follows:
+HAR [HTTP-Archive](<https://en.wikipedia.org/wiki/HAR_(file_format)>) format was created by the Web Performance Working Group and has become the standard in browser archive request data definition. To run monika using a HAR file, use `--har` flag as follows:
 
 ```bash
 monika --har <path_to_HAR_file>

--- a/src/components/probe/probing.test.ts
+++ b/src/components/probe/probing.test.ts
@@ -111,10 +111,7 @@ describe('Probing', () => {
     it('should submit correct form', async () => {
       interceptor.use((req: any) => {
         if (['http://localhost:4000/login'].includes(req.url.href)) {
-          if (
-            req.body ===
-            '{"username":"example@example.com","password":"example"}'
-          )
+          if (req.body === 'username=example%40example.com&password=example')
             return { status: 200 }
 
           return { status: 400 }

--- a/src/components/probe/probing.test.ts
+++ b/src/components/probe/probing.test.ts
@@ -107,5 +107,32 @@ describe('Probing', () => {
         expect(results[k].sentToken).to.be.equals(results[k].expectedToken)
       }
     })
+
+    it('should submit correct form', async () => {
+      interceptor.use((req: any) => {
+        if (['http://localhost:4000/login'].includes(req.url.href)) {
+          if (
+            req.body ===
+            '{"username":"example@example.com","password":"example"}'
+          )
+            return { status: 200 }
+
+          return { status: 400 }
+        }
+      })
+
+      const request: any = {
+        url: 'http://localhost:4000/login',
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: JSON.parse(
+          '{"username": "example@example.com", "password": "example"}'
+        ),
+        timeout: 10,
+      }
+
+      const result = await probing(request, [])
+      expect(result.status).to.be.equals(200)
+    })
   })
 })

--- a/src/components/probe/probing.ts
+++ b/src/components/probe/probing.ts
@@ -59,7 +59,7 @@ export async function probing(
         [header]: renderedHeader,
       }
 
-      // flag for "Content-Type" form
+      // evaluate "Content-Type" header in case-insensitive manner
       if (
         header.toLocaleLowerCase() === headerContentType &&
         rawHeader === contentType['form-urlencoded']

--- a/src/components/probe/probing.ts
+++ b/src/components/probe/probing.ts
@@ -25,6 +25,13 @@
 import axios from 'axios'
 import * as Handlebars from 'handlebars'
 import { ProbeRequestResponse, RequestConfig } from '../../interfaces/request'
+import * as qs from 'querystring'
+
+const headerContentType = 'Content-Type'
+const contentType = {
+  'form-urlencoded': 'application/x-www-form-urlencoded',
+  json: 'application/json',
+}
 
 export async function probing(
   requestConfig: RequestConfig,
@@ -58,10 +65,16 @@ export async function probing(
 
   try {
     // Do the request using compiled URL and compiled headers (if exists)
+    let requestBody: any = newReq.body
+    if (
+      newReq.headers?.[headerContentType] === contentType['form-urlencoded']
+    ) {
+      requestBody = qs.stringify(requestBody)
+    }
     const resp = await axiosInstance.request({
       ...newReq,
       url: renderedURL,
-      data: newReq.body,
+      data: requestBody,
     })
     const responseTime = new Date().getTime() - requestStartedAt
     const { data, headers, status } = resp


### PR DESCRIPTION
# Monika Pull Request (PR)
This PR resolves #562 

## What feature/issue does this PR add
1. Add support for `application/x-www-form-urlencoded` request

## How did you implement / how did you fix it
1. Add check for `Content-Type` request header in case-insensitive manner.
2. If `Content-Type` is `application/x-www-form-urlencoded`, serialize body into URL-safe string.

## How to test
1. Sample config
```
{
  "probes": [
    {
      "requests": [
        {
          "url": "http://0.0.0.0:8080/login",
          "method": "POST",
          "body": { "username": "example@example.com", "password": "example" }
        }
      ],
      "incidentThreshold": 5,
      "recoveryThreshold": 5,
      "alerts": ["response-time-greater-than-200-ms"]
    }
  ]
}
```
2. `npm run start -- -c <path to sample config>`
3. To run unit tests: `npm run test`