### PR TITLE
Add ping feature

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@
         "no-process-exit": "off",
         "no-use-before-define": ["warn", "nofunc"],
         "@typescript-eslint/no-use-before-define": "off",
-        "unicorn/prefer-node-protocol": "warn",
+        "unicorn/prefer-node-protocol": "off",
         "unicorn/no-lonely-if": "warn",
         "padding-line-between-statements": "warn",
         "unicorn/no-array-reduce": "warn",

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@
         "no-process-exit": "off",
         "no-use-before-define": ["warn", "nofunc"],
         "@typescript-eslint/no-use-before-define": "off",
-        "unicorn/prefer-node-protocol": "off",
+        "unicorn/prefer-node-protocol": "warn",
         "unicorn/no-lonely-if": "warn",
         "padding-line-between-statements": "warn",
         "unicorn/no-array-reduce": "warn",

--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -58,17 +58,34 @@ Details of the field are give in the table below.
 
 | Topic                        | Description                                                                                                                                                                                                                                                                                                                                               |
 | :--------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| method                       | Http method such as GET, POST, PUT, DELETE                                                                                                                                                                                                                                                                                                                |
-| url                          | This is the url endpoint to dispatch the request to                                                                                                                                                                                                                                                                                                       |
-| timeout                      | Request timeout, after which time, `Monika`will assume timeout                                                                                                                                                                                                                                                                                            |
-| headers                      | Your http header                                                                                                                                                                                                                                                                                                                                          |
-| body                         | Any http body if your method requires it                                                                                                                                                                                                                                                                                                                  |
+| method                       | Http method such as GET, POST, PUT, DELETE.                                                                                                                                                                                                                                                                                                               |
+| url                          | This is the url endpoint to dispatch the request to.                                                                                                                                                                                                                                                                                                      |
+| timeout                      | Request timeout, after which time, `Monika` will assume timeout.                                                                                                                                                                                                                                                                                          |
+| headers                      | Http headers you might need for your request.                                                                                                                                                                                                                                                                                                             |
+| body                         | Any http body if your method requires it.                                                                                                                                                                                                                                                                                                                 |
 | interval (optional)          | Number of probe's interval (in seconds). Default value is 10 seconds.                                                                                                                                                                                                                                                                                     |
 | incidentThreshold (optional) | Number of times an alert should return true before Monika sends notifications. For example, when incidentThreshold is 3, Monika will only send notifications when the probed URL returns non-2xx status 3 times in a row. After sending the notifications, Monika will not send notifications anymore until the alert status changes. Default value is 5. |
 | recoveryThreshold (optional) | Number of times an alert should return false before Monika sends notifications. For example, when recoveryThreshold is 3, Monika will only send notifications when the probed URL returns status 2xx 3 times in a row. After sending the notifications, Monika will not send notifications anymore until the alert status changes. Default value is 5.    |
 | alerts                       | The condition which will trigger an alert, and the subsequent notification method to send out the alert. See below for further details on alerts and notifications.                                                                                                                                                                                       |
 | saveBody (optional)          | When set to true, the response body of the request is stored in the internal database. The default is off when not defined. This is to keep the log files size small as some responses can be sizeable. The setting is for each probe request.                                                                                                            |
-| alerts (optional)            | See [alerts](./alerts) section for detailed information                                                                                                                                                                                                                                                                                                   |
+| alerts (optional)            | See [alerts](./alerts) section for detailed information.                                                                                                                                                                                                                                                                                                  |
+| ping (optional)              | (boolean), If set true then send a PING to the specified url instead.                                                                                                                                                                                                                                                                                     |
+
+### PING
+
+You can send an ICMP echo request, to a specific url by enabling the `ping: true` field.
+In this mode the http method is ignored and a PING echo request is sent to the specified url.
+
+```yaml
+probes:
+  - id: 'ping_test'
+    name: ping_test
+    description: requesting icmp ping
+    interval: 10
+    requests:
+      - url: http://google.com
+        ping: true
+```
 
 ## Probe Response Anatomy
 

--- a/monika.example.json
+++ b/monika.example.json
@@ -1,11 +1,36 @@
 {
   "probes": [
     {
+      "id": "1",
+      "name": "Probing Github",
+      "description": "Multiple",
+      "interval": 10,
       "requests": [
         {
-          "url": "https://github.com"
+          "url": "https://github.com/",
+          "method": "GET",
+          "timeout": 7000,
+          "saveBody": false
+        },
+        {
+          "url": "https://github.com/hyperjumptech",
+          "method": "GET",
+          "timeout": 7000,
+          "saveBody": true
         }
-      ]
+      ],
+      "alerts": [
+        {
+          "query": "response.status == 500",
+          "message": "response status message"
+        },
+        {
+          "query": "response.time > 150",
+          "message": "response time message"
+        }
+      ],
+      "incidentThreshold": 3,
+      "recoveryThreshold": 3
     }
   ]
 }

--- a/monika.example.yml
+++ b/monika.example.yml
@@ -23,6 +23,20 @@ probes:
 #           username: someusername
 #           password: somepassword
 
+# Example for sending a ping instead of a REST request.
+# - id: 'ping_test'
+#   name: ping_test
+#   description: requesting icmp ping
+#   interval: 10
+#   requests:
+#     - url: http://google.com
+#       ping: true
+#   alerts:
+#     - query: response.status == 500
+#       message: response status message
+#   incidentThreshold: 3
+#   recoveryThreshold: 3
+
 # Configuration example for sending Multiple requests
 # Requests could be define in array to run for multiple requests
 # and with this configuration monika will check on github.com first and then https://github.com/hyperjumptech.

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
   "lint-staged": {
     "*.{ts,js}": [
       "node scripts/add-license.js",
-      "eslint --cache --fix"
+      "eslint --cache"
     ],
     "*.{ts,js,css,md}": "prettier --write"
   },

--- a/src/components/config/validate.ts
+++ b/src/components/config/validate.ts
@@ -34,7 +34,7 @@ import { compileExpression } from '../../utils/expression-parser'
 import type { SymonConfig } from '../reporter'
 import { newPagerDuty } from '../notification/channel/pagerduty'
 
-const HTTPMethods = new Set([
+const HTTPMethods = [
   'DELETE',
   'GET',
   'HEAD',
@@ -46,7 +46,7 @@ const HTTPMethods = new Set([
   'LINK',
   'UNLINK',
   'PING', // fake method for ping
-])
+]
 
 const setInvalidResponse = (message: string): Validation => ({
   valid: false,
@@ -299,13 +299,11 @@ export const validateConfig = (configuration: Config): Validation => {
         }
       }
 
-      if (request.ping === true) {
-        request.method = 'PING' // ok PING is not an HTTP method, but for the purposes of logging, filtering and display
-      } else if (!request.method) {
+      if (!request.method) {
         request.method = 'GET'
       }
 
-      if (!HTTPMethods.has(request.method.toUpperCase()))
+      if (HTTPMethods.indexOf(request.method.toUpperCase()) < 0)
         return PROBE_REQUEST_INVALID_METHOD
     }
 

--- a/src/components/config/validate.ts
+++ b/src/components/config/validate.ts
@@ -290,14 +290,12 @@ export const validateConfig = (configuration: Config): Validation => {
 
       if (!url) return PROBE_REQUEST_NO_URL
 
-      if (url) {
-        if (request.ping === true) {
-          // if ping request, url not need to be so strict
-        } else if (!isValidURL(url)) {
-          return PROBE_REQUEST_INVALID_URL
-        }
+      // if not a ping request and url not valid, return INVLID_URL error
+      if (request.ping !== true && !isValidURL(url)) {
+        return PROBE_REQUEST_INVALID_URL
       }
 
+      // if method is not set, set a default method
       if (!request.method) {
         request.method = 'GET'
       }

--- a/src/components/config/validate.ts
+++ b/src/components/config/validate.ts
@@ -45,7 +45,6 @@ const HTTPMethods = [
   'PURGE',
   'LINK',
   'UNLINK',
-  'PING', // fake method for ping
 ]
 
 const setInvalidResponse = (message: string): Validation => ({

--- a/src/components/logger/request-log.ts
+++ b/src/components/logger/request-log.ts
@@ -83,6 +83,7 @@ export class RequestLog {
     this.errors.push(error)
   }
 
+  // print() generates the text and prints the logs for the past request iteration
   print() {
     const reversedSentNotifications = this.sentNotifications.slice().reverse()
     const printedNotification =
@@ -97,11 +98,22 @@ export class RequestLog {
     let errorMsg = ''
     let notifMsg = ''
 
-    const probeMsg = `${this.iteration} id:${this.probe.id} ${
-      this.response?.status || '-'
-    } ${this.request.method} ${this.request.url} ${
-      this.response?.responseTime || '-'
-    }ms`
+    // generate probe result messages
+    let probeMsg = ''
+
+    if (this.request.ping) {
+      probeMsg = `${this.iteration} id:${this.probe.id} PING:${
+        this.response?.alive ? 'alive' : 'dead'
+      } ${this.request.url} ${
+        this.response?.responseTime || '-'
+      }ms packetLoss:${this.response?.packetLoss}%`
+    } else {
+      probeMsg = `${this.iteration} id:${this.probe.id} ${
+        this.response?.status || '-'
+      } ${this.request.method} ${this.request.url} ${
+        this.response?.responseTime || '-'
+      }ms`
+    }
 
     if (printedNotification) {
       notifMsg = `, NOTIF: ${

--- a/src/components/logger/request-log.ts
+++ b/src/components/logger/request-log.ts
@@ -105,8 +105,8 @@ export class RequestLog {
       probeMsg = `${this.iteration} id:${this.probe.id} PING:${
         this.response?.alive ? 'alive' : 'dead'
       } ${this.request.url} ${
-        this.response?.responseTime || '-'
-      }ms packetLoss:${this.response?.packetLoss}%`
+        this.response?.alive ? this.response?.responseTime : '-'
+      }ms packetLoss:${this.response?.alive ? this.response?.packetLoss : '-'}%`
     } else {
       probeMsg = `${this.iteration} id:${this.probe.id} ${
         this.response?.status || '-'

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -168,13 +168,14 @@ export async function doProbe(
       requestLog.setResponse(probeRes)
 
       // store request error log
-      if ([0, 1, 2, 599].includes(probeRes.status)) {
+      if ([0, 1, 2, 3, 4, 599].includes(probeRes.status)) {
         const errorMessageMap: Record<number, string> = {
-          0: 'URI not found',
-          1: 'Connection reset',
-          2: 'Connection refused',
-          3: 'Unknown error',
-          599: 'Request Timed out',
+          0: 'URI not found', // axios error
+          1: 'Connection reset', // axios error
+          2: 'Connection refused', // axios error
+          3: 'Unknown error', // axios error
+          4: 'ping timed out', // ping error
+          599: 'Request Timed out', // axios error
         }
 
         requestLog.addError(errorMessageMap[probeRes.status])

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -174,7 +174,7 @@ export async function doProbe(
           1: 'Connection reset', // axios error
           2: 'Connection refused', // axios error
           3: 'Unknown error', // axios error
-          4: 'ping timed out', // ping error
+          4: 'Ping timed out', // ping error
           599: 'Request Timed out', // axios error
         }
 

--- a/src/components/probe/probing.ts
+++ b/src/components/probe/probing.ts
@@ -25,7 +25,8 @@
 import axios from 'axios'
 import * as Handlebars from 'handlebars'
 import { ProbeRequestResponse, RequestConfig } from '../../interfaces/request'
-import * as qs from 'querystring'
+import * as qs from 'node:querystring'
+import { sendPing } from '../../utils/ping'
 
 const headerContentType = 'content-type'
 const contentType = {
@@ -33,6 +34,12 @@ const contentType = {
   json: 'application/json',
 }
 
+/**
+ * probing() is the heart of monika requests generation
+ * @param requestConfig
+ * @param responses an array of previous responses
+ * @returns ProbeRequestResponse, response to the probe request
+ */
 export async function probing(
   requestConfig: RequestConfig,
   responses: Array<ProbeRequestResponse>
@@ -70,7 +77,9 @@ export async function probing(
   }
 
   const axiosInstance = axios.create()
-  const requestStartedAt = new Date().getTime()
+  const requestStartedAt = Date.now()
+
+  let resp: any = {}
 
   try {
     // Do the request using compiled URL and compiled headers (if exists)
@@ -78,22 +87,43 @@ export async function probing(
     if (shouldEncodeFormUrl) {
       requestBody = qs.stringify(requestBody)
     }
-    const resp = await axiosInstance.request({
-      ...newReq,
-      url: renderedURL,
-      data: requestBody,
-    })
-    const responseTime = new Date().getTime() - requestStartedAt
-    const { data, headers, status } = resp
 
-    return {
-      data,
-      status,
-      headers,
-      responseTime,
+    // is this a reqeust for ping?
+    if (newReq.ping === true) {
+      const pingResp = await sendPing(renderedURL)
+
+      const responseTime = pingResp.avg // response time is the average ping time
+      const status = pingResp.alive ? 200 : 503 //  let's translate for now alive == 200, not alive = 503
+      const headers = {}
+      const data = pingResp
+
+      return {
+        data,
+        status,
+        headers,
+        responseTime,
+      }
     }
+ 
+      // if this is not a ping, then do regular REST request through axios
+      resp = await axiosInstance.request({
+        ...newReq,
+        url: renderedURL,
+        data: requestBody,
+      })
+
+      const responseTime = Date.now() - requestStartedAt
+      const { data, headers, status } = resp
+
+      return {
+        data,
+        status,
+        headers,
+        responseTime,
+      }
+    
   } catch (error: any) {
-    const responseTime = new Date().getTime() - requestStartedAt
+    const responseTime = Date.now() - requestStartedAt
 
     // The request was made and the server responded with a status code
     // 400, 500 get here

--- a/src/components/probe/probing.ts
+++ b/src/components/probe/probing.ts
@@ -25,7 +25,7 @@
 import axios from 'axios'
 import * as Handlebars from 'handlebars'
 import { ProbeRequestResponse, RequestConfig } from '../../interfaces/request'
-import * as qs from 'node:querystring'
+import * as qs from 'querystring'
 import { sendPing } from '../../utils/ping'
 
 const headerContentType = 'content-type'
@@ -88,7 +88,7 @@ export async function probing(
       requestBody = qs.stringify(requestBody)
     }
 
-    // is this a reqeust for ping?
+    // is this a request for ping?
     if (newReq.ping === true) {
       const pingResp = await sendPing(renderedURL)
 

--- a/src/components/probe/probing.ts
+++ b/src/components/probe/probing.ts
@@ -104,24 +104,23 @@ export async function probing(
         responseTime,
       }
     }
- 
-      // if this is not a ping, then do regular REST request through axios
-      resp = await axiosInstance.request({
-        ...newReq,
-        url: renderedURL,
-        data: requestBody,
-      })
 
-      const responseTime = Date.now() - requestStartedAt
-      const { data, headers, status } = resp
+    // if this is not a ping, then do regular REST request through axios
+    resp = await axiosInstance.request({
+      ...newReq,
+      url: renderedURL,
+      data: requestBody,
+    })
 
-      return {
-        data,
-        status,
-        headers,
-        responseTime,
-      }
-    
+    const responseTime = Date.now() - requestStartedAt
+    const { data, headers, status } = resp
+
+    return {
+      data,
+      status,
+      headers,
+      responseTime,
+    }
   } catch (error: any) {
     const responseTime = Date.now() - requestStartedAt
 

--- a/src/interfaces/request.ts
+++ b/src/interfaces/request.ts
@@ -25,13 +25,23 @@
 import { AxiosRequestConfig } from 'axios'
 import { ProbeAlert } from './probe'
 
+// RequestTypes are used to define the type of request that is being made.
+export type RequestTypes = 'http' | 'HTTP' | 'icmp' | 'ICMP'
+
+// ProbeRequestResponse is used to define the response from a probe requests.
 export interface ProbeRequestResponse<T = any> {
+  requestType?: RequestTypes // is this for http (default) or icmp  or others
   data: T
-  status: number
+  status: number // todo: Improve status management. Status as number is pretty limiting here if we want to support other protocols other than http
   headers: any
   responseTime: number
+
+  numericHost?: string
+  alive?: boolean
+  packetLoss?: number
 }
 
+// ProbeRequest is used to define the requests that is being made.
 export interface RequestConfig extends Omit<AxiosRequestConfig, 'data'> {
   saveBody?: boolean // save response body to db?
   url: string

--- a/src/interfaces/request.ts
+++ b/src/interfaces/request.ts
@@ -33,9 +33,10 @@ export interface ProbeRequestResponse<T = any> {
 }
 
 export interface RequestConfig extends Omit<AxiosRequestConfig, 'data'> {
-  saveBody?: boolean
+  saveBody?: boolean // save response body to db?
   url: string
   body: JSON
-  timeout: number
+  timeout: number // request timeout
   alerts?: ProbeAlert[]
+  ping?: boolean // is this request for a ping?
 }

--- a/src/plugins/validate-response/checkers/index.ts
+++ b/src/plugins/validate-response/checkers/index.ts
@@ -47,8 +47,12 @@ const responseChecker = (
   alert: ProbeAlert,
   res: ProbeRequestResponse
 ): boolean => {
-  // if status is 599 : timeout or uri is not found (0), worth reporting so return true
+  // if status is 599 : timeout or uri is not found (0), worth reporting so return true for alert
   if (res.status === 599 || res.status === 0 || res.status === 1) {
+    return true
+  }
+  // if a ping request is not connected, return an alert
+  if (res.alive === false) {
     return true
   }
 

--- a/src/utils/ping.ts
+++ b/src/utils/ping.ts
@@ -34,3 +34,6 @@ export async function sendPing(host: string) {
   const cleanUrl: any = host.replace(/^https?:\/\//, '') // sanitize url
   return ping.promise.probe(cleanUrl, { timeout: PING_TIMEOUT_S })
 }
+
+// some signal constants
+export const PING_TIMEDOUT = 4

--- a/src/utils/ping.ts
+++ b/src/utils/ping.ts
@@ -22,14 +22,15 @@
  * SOFTWARE.                                                                      *
  **********************************************************************************/
 
-const ping = require('ping')
+import ping from 'ping'
 
-const PING_TIMEOUT_S = 10 // 10 seconds
+const PING_TIMEOUT_S = 10 // 10 seconds timeout
 /**
  * sendPing() sends a ping to an address/host
  * @param host is a string
- * @returns
+ * @returns result of ping.promise.probe()
  */
 export async function sendPing(host: string) {
-  return ping.promise.probe(host, { timeout: PING_TIMEOUT_S })
+  const cleanUrl: any = host.replace(/^https?:\/\//, '') // sanitize url
+  return ping.promise.probe(cleanUrl, { timeout: PING_TIMEOUT_S })
 }


### PR DESCRIPTION
## Monika Pull Request (PR)  

1. Implements ping as a request
2. Closing #551

## Implementation 

1. Add documentation for ping
2. Add ping as a type of probe request
```yaml
probes:
  - id: 'ping_test'
    name: ping_test
    description: requesting icmp ping
    interval: 10
    requests:
      - url: http://google.com  
      ping: true
```
3. Update validation to account for ping host not need http/https, and filtering for it.
4. Add alert if ping is not alive.
5. Update logger to map ping result properly via our standard logger/output.

![image](https://user-images.githubusercontent.com/964106/151124461-c9b32cf9-7b3d-4753-b499-4e67a1912f40.png)



