### PR TITLE
SymonClient: Add --symonLocationId flag for Symon handshake process  

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -320,10 +320,10 @@ class Monika extends Command {
           }
 
           // doing custom sequences if list of ids is declared
-          const idSplit = new Set(flags.id.split(',').map((item: string) => item.trim()))
-          probesToRun = config.probes.filter((probe) =>
-            idSplit.has(probe.id)
+          const idSplit = new Set(
+            flags.id.split(',').map((item: string) => item.trim())
           )
+          probesToRun = config.probes.filter((probe) => idSplit.has(probe.id))
         }
 
         const sanitizedProbe = probesToRun.map((probe: Probe) => {


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
This PR fixes #581 

## How did you implement / how did you fix it  
This PR adds an optional `--symonLocationId` flag to assign a location to a Monika instance when the handshake process is being run. So, a user who uses Monika in Symon mode doesn't have to run-assign-restart the Monika instance anymore.

## How to test  
1. Run this command `npm run start -- --symonUrl=<SYMON_URL> --symonKey=<SYMON_KEY> --symonLocationId=<SYMON_LOCATION_ID>`
2. You should see logs similar to this (ignore the console.log as it is only for development)
![Screenshot_20220128_111519](https://user-images.githubusercontent.com/16670475/151487546-c1dad54c-6a52-4e22-90e5-4e754dcf5957.png)
3. Remove existing connected Monika instance
4. Run this command again without the location ID `npm run start -- --symonUrl=<SYMON_URL> --symonKey=<SYMON_KEY>`
5. You should see logs similar to this (ignore the console.log as it is only for development)
![Screenshot_20220128_111541](https://user-images.githubusercontent.com/16670475/151487652-419f5df1-8bc9-4aa2-bcaf-7b4e84948e8c.png)

## Additional Context

You may have to wait until the PR in Symon to handle the Location ID to be merged.