### PR TITLE
Update Cron Documentation

### DIFF
--- a/docs/src/pages/guides/status-notification.md
+++ b/docs/src/pages/guides/status-notification.md
@@ -86,7 +86,7 @@ Notifies every minutes 1, 2, 5 and 7. In other words every xx:01, xx:02, xx:05, 
 status-notification "1-5 * * * *"
 ```
 
-Notifies every range from minutes 1 to 5.
+Notifies with the range of minute 1 to 5.
 
 ```bash
 status-notification "*/2 * * * *"

--- a/docs/src/pages/guides/status-notification.md
+++ b/docs/src/pages/guides/status-notification.md
@@ -49,7 +49,7 @@ status-notification: false
 
 To schedule the status notification we use standard cron syntax. You can tryout your configuration on [crontab.guru](https://crontab.guru/).
 
-In addition to he standard 5 cront syntax, Monika supports an optional seconds field.
+In addition to the standard 5 cron syntax, Monika supports an optional `seconds` field. So if you wrote 6 cron syntax, please be advised that the status notification could be sent so frequent.
 
 ```bash
  ┌────────────── second (optional)

--- a/docs/src/pages/guides/status-notification.md
+++ b/docs/src/pages/guides/status-notification.md
@@ -3,7 +3,7 @@ id: status-notification
 title: Status Notification
 ---
 
-Monika sends status notification periodically based on a schedule with following information:
+Monika sends status notification periodically based on a set schedule with the following information:
 
 - Host
 - Number of probes
@@ -13,13 +13,13 @@ Monika sends status notification periodically based on a schedule with following
 - Number of sent notifications in the last 24 hours
 - Application version
 
-By default the schedule is set to 6 AM everyday. You can configure the schedule with cron syntax via command line argument like so:
+By default the schedule is set to 6:00 AM everyday. You can configure the schedule with cron syntax via command line argument like so:
 
 ```bash
 monika --status-notification "0 6 * * *"
 ```
 
-or via configuration file like so:
+or via the configuration file with the `status-notification` field like below:
 
 ```yml
 notifications:
@@ -44,3 +44,58 @@ notifications: ...
 probes: ...
 status-notification: false
 ```
+
+## Cron Syntax
+
+To schedule the status notification we use standard cron syntax. You can tryout your configuration on [crontab.guru](https://crontab.guru/).
+
+In addition to he standard 5 cront syntax, Monika supports an optional seconds field.
+
+```bash
+ ┌────────────── second (optional)
+ │ ┌──────────── minute
+ │ │ ┌────────── hour
+ │ │ │ ┌──────── day of month
+ │ │ │ │ ┌────── month
+ │ │ │ │ │ ┌──── day of week
+ │ │ │ │ │ │
+ │ │ │ │ │ │
+ * * * * * *
+```
+
+### Valid Field Values
+
+| Field           | Data                                 |
+| --------------- | ------------------------------------ |
+| second          | 0-59                                 |
+| minute          | 0-59                                 |
+| hour            | 0-23                                 |
+| day             | 1-31                                 |
+| month           | 1-12 (or month names)                |
+| day of the week | 0 - 7, or names (0 and 7 are Sunday) |
+
+Examples:
+
+```bash
+status-notification "1,2,5,7 * * * *"
+```
+
+Notifies every minutes 1, 2, 5 and 7. In other words every xx:01, xx:02, xx:05, xx:07 of every hour.
+
+```bash
+status-notification "1-5 * * * *"
+```
+
+Notifies every range from minutes 1 to 5.
+
+```bash
+status-notification "*/2 * * * *"
+```
+
+Notifies every two minutes.
+
+```bash
+status-notification "* * * Feb,Mar Sun"
+```
+
+Notifies every Sunday in February and March.

--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -45,16 +45,12 @@ let cfg: Config
 let configs: Partial<Config>[]
 
 export const getConfig = (skipConfigCheck = true) => {
-  if (!skipConfigCheck) {
-    if (!cfg) throw new Error('Configuration setup has not been run yet')
-  }
+  if (!skipConfigCheck && !cfg) throw new Error('Configuration setup has not been run yet')
   return cfg
 }
 
 export async function* getConfigIterator(skipConfigCheck = true) {
-  if (!skipConfigCheck) {
-    if (!cfg) throw new Error('Configuration setup has not been run yet')
-  }
+  if (!skipConfigCheck && !cfg) throw new Error('Configuration setup has not been run yet')
 
   yield cfg
 
@@ -64,13 +60,14 @@ export async function* getConfigIterator(skipConfigCheck = true) {
 }
 
 export const updateConfig = (config: Config, validate = true) => {
-  log.debug('Updating config')
+  log.info('Updating config')
   if (validate) {
     const validated = validateConfig(config)
     if (!validated.valid) {
       throw new Error(validated.message)
     }
   }
+
   const lastConfigVersion = cfg?.version
   cfg = config
   cfg.version = cfg.version || md5Hash(cfg)
@@ -129,6 +126,7 @@ const parseDefaultConfig = (flags: any): Promise<Partial<Config>[]> => {
         scheduleRemoteConfigFetcher(source, flags['config-interval'], i)
         return fetchConfig(source)
       }
+
       watchConfigFile(source, 'monika', i, flags.repeat)
       return parseConfig(source, 'monika')
     })

--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -45,12 +45,14 @@ let cfg: Config
 let configs: Partial<Config>[]
 
 export const getConfig = (skipConfigCheck = true) => {
-  if (!skipConfigCheck && !cfg) throw new Error('Configuration setup has not been run yet')
+  if (!skipConfigCheck && !cfg)
+    throw new Error('Configuration setup has not been run yet')
   return cfg
 }
 
 export async function* getConfigIterator(skipConfigCheck = true) {
-  if (!skipConfigCheck && !cfg) throw new Error('Configuration setup has not been run yet')
+  if (!skipConfigCheck && !cfg)
+    throw new Error('Configuration setup has not been run yet')
 
   yield cfg
 

--- a/src/components/notification/alert-message.ts
+++ b/src/components/notification/alert-message.ts
@@ -32,17 +32,12 @@ import { getContext } from '../../context'
 import { NotificationMessage } from '../../interfaces/notification'
 import { ProbeRequestResponse } from '../../interfaces/request'
 import { ProbeAlert } from '../../interfaces/probe'
-import {
-  getPublicIp,
-  publicIpAddress,
-  publicNetworkInfo,
-} from '../../utils/public-ip'
+import { publicIpAddress, publicNetworkInfo } from '../../utils/public-ip'
 
 const getLinuxDistro = promisify(getos)
 
 export const getMonikaInstance = async (ipAddress: string) => {
   const osHostname = hostname()
-  await getPublicIp()
 
   if (publicNetworkInfo) {
     const { city, isp } = publicNetworkInfo
@@ -129,6 +124,7 @@ export async function getMessageForAlert({
       },
     })
   }
+
   const lastIncident = incidents.find(
     (incident) =>
       incident.probeID === probeID && incident.probeRequestURL === url

--- a/src/utils/public-ip.ts
+++ b/src/utils/public-ip.ts
@@ -77,16 +77,20 @@ export async function getPublicNetworkInfo() {
  * @returns {Promise}
  */
 export async function getPublicIp() {
+  const time = new Date().toISOString()
+
   try {
     const address = await pokeStun()
     if (address) {
       publicIpAddress = address
       isConnectedToSTUNServer = true
-      log.info(`Connected to STUN Server. Monika is running from: ${address}`)
+      log.info(
+        `${time} - Connected to STUN Server. Monika is running from: ${address}`
+      )
     }
   } catch {
     isConnectedToSTUNServer = false
-    log.warn(`STUN Server is temporarily unreachable. Check network.`)
+    log.warn(`${time} STUN Server is temporarily unreachable. Check network.`)
     return Promise.resolve() // couldn't access public stun but resolve and retry
   }
 }


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Closing issue #572 
2. Using `--status-notification "* * * * * *"` runs the stun checking rapidly

## How did you implement / how did you fix it  
1. Ooook so it turns out we have an undocumented feature supporting per-second crons intervals
2. The cron package we use supports a six field cron syntax "* * * * * *" for seconds interval
3. Added more documentation under guides/status-notification
4. Refactor the monikaInstance() to not hit stun all the time.

## How to test  
1. call monika with `--status-notification "* * * * * * "`
2. should not have stun called every second (should still be 20s as default)

## Screenshot

![image](https://user-images.githubusercontent.com/964106/151751814-91005aa3-416c-4046-8878-9db1015f09d3.png)
