### PR TITLE
fix insomnia flag error without -c default in CWD

### DIFF
--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -145,7 +145,12 @@ const addDefaultNotifications = (config: Partial<Config>): Partial<Config> => {
 
 export const setupConfig = async (flags: any) => {
   // check for default config path when -c/--config not provided
-  if (flags.config.length === 0 && !flags.har && !flags.postman) {
+  if (
+    flags.config.length === 0 &&
+    flags.har === undefined &&
+    flags.postman === undefined &&
+    flags.insomnia === undefined
+  ) {
     throw new Error(
       'Configuration file not found. By default, Monika looks for monika.yml configuration file in the current directory.\n\nOtherwise, you can also specify a configuration file using -c flag as follows:\n\nmonika -c <path_to_configuration_file>\n\nYou can create a configuration file via web interface by opening this web app: https://hyperjumptech.github.io/monika-config-generator/'
     )

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -96,6 +96,30 @@ describe('monika', () => {
     .stdout()
     .do(() =>
       cmd.run([
+        '--insomnia',
+        resolve('./src/components/config/__tests__/petstore.insomnia.yaml'),
+      ])
+    )
+    .it('runs with insomnia file config', (ctx) => {
+      expect(ctx.stdout).to.contain('Starting Monika.')
+    })
+
+  test
+    .stdout()
+    .do(() =>
+      cmd.run([
+        '--postman',
+        resolve('./test/testConfigs/simple.postman_collection.json'),
+      ])
+    )
+    .it('runs with postman file', (ctx) => {
+      expect(ctx.stdout).to.contain('Starting Monika.')
+    })
+
+  test
+    .stdout()
+    .do(() =>
+      cmd.run([
         '-c',
         resolve('./test/testConfigs/manyNotif.yml'),
         resolve('./test/testConfigs/manyProbes.yml'),


### PR DESCRIPTION
# Monika Pull Request (PR)
Resolves #601 

## What feature/issue does this PR add
1. Provided `--insomnia` without `monika.json` / `monika.yml` file in CWD will throw error

## How did you implement / how did you fix it
1.  Evaluate insomnia flag existence
2. Add test to run insomnia flag

## How to test  
1. `rm monika.yml && rm monika.json`
2. `npm run start -- -insomnia src/components/config/__tests__/petstore.insomnia.yaml`
3. Monika should run without config error