### PR TITLE
Update workflow to allow manual trigger

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -2,6 +2,7 @@
 name: DockerPush
 
 on:
+  workflow_dispatch:
   release:
     types: [created]
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,6 +4,7 @@
 name: Node.js CI
 
 on:
+    workflow_dispatch:
     push:
         branches: [main]
     pull_request:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,6 +4,7 @@
 name: Node.js Package
 
 on:
+  workflow_dispatch:
   release:
     types: [created]
 

--- a/.github/workflows/publish-snap.yml
+++ b/.github/workflows/publish-snap.yml
@@ -3,6 +3,7 @@
 name: Publish to Snapcraft
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/upload-binary.yml
+++ b/.github/workflows/upload-binary.yml
@@ -4,6 +4,7 @@
 name: Upload Binary
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 


### PR DESCRIPTION
This PR updates the GitHub workflows so that we can run them manually in addition to the existing triggers.