### PR TITLE
Fix: default monika config directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ const em = getEventEmitter()
 let symonClient: SymonClient
 
 function getDefaultConfig(): Array<string> {
-  const filesArray = fs.readdirSync('../')
+  const filesArray = fs.readdirSync(path.dirname('../'))
   const monikaDotJsonFile = filesArray.find((x) => x === 'monika.json')
   const monikaDotYamlFile = filesArray.find(
     (x) => x === 'monika.yml' || x === 'monika.yaml'


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Fix default monika config directory. It resolves #644.

## How did you implement / how did you fix it  
1.  Add `path.dirname` to get the directory absolute path

## How to test  
1. Run `npm start` with `monika.yaml` in the project root directory
2. Build Monika binary, put the `monika.yaml` in the same directory, run the binary

## Video

https://user-images.githubusercontent.com/15191978/163116262-05fc6091-9574-47cc-82ba-82c5ce8364c9.mp4


