### PR TITLE
fix workflow to deploy docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,46 +6,67 @@ on:
     types: [created]
   schedule:
     - cron: "0 9 * * 3" # Every 9AM on Wednesday
-  
+
+env:
+  CI: true
+  NEXT_PUBLIC_ALGOLIA_APPLICATION_ID: ${{secrets.NEXT_PUBLIC_ALGOLIA_APPLICATION_ID}}
+  ALGOLIA_ADMIN_API_KEY: ${{secrets.ALGOLIA_ADMIN_API_KEY}}
+  NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY: ${{secrets.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY}}
+
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./docs
-
     steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           persist-credentials: false
 
-      - name: Cache  💾
-        uses: actions/cache@v2
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: ✍🏻 Setup node
+        uses: actions/setup-node@v3
         with:
-          path: ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}
+          node-version: 16
 
-      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
-        uses: actions/setup-node@v2
-      - run: yarn
-      - run: yarn build
-        env:
-          CI: true
+      - name: 📥 Install deps
+        uses: bahmutov/npm-install@v1
 
-      - name: Deploy 🚀
+      - name: 👷‍♂️ Build
+        run: npm run build
+
+      - name: 🚀 Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.0
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: docs/out # The folder the action should deploy.
           clean: true # Automatically remove deleted files from the deploy branch
 
-      - name: Generate and Save Algolia Object
-        uses: actions/setup-node@v2
-      - run: yarn
-      - run: yarn run buildsearch
-        env:
-          CI: true
-          NEXT_PUBLIC_ALGOLIA_APPLICATION_ID: ${{secrets.NEXT_PUBLIC_ALGOLIA_APPLICATION_ID}}
-          ALGOLIA_ADMIN_API_KEY: ${{secrets.ALGOLIA_ADMIN_API_KEY}}
-          NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY: ${{secrets.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY}}
+  algolia:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./docs
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          persist-credentials: false
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: ✍🏻 Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: 📥 Install deps
+        uses: bahmutov/npm-install@v1
+
+      - name: 🔎 Send to Algolia
+        run: npm run buildsearch


### PR DESCRIPTION
The workflow docs failed because the environment variables are needed not only during the algolia steps but also during the build step. This PR fixes it by moving the environment variables out of the steps.