### PR TITLE
fix wrong options in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,11 +22,11 @@ jobs:
     steps:
       - name: 🛑 Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          persist-credentials: false
 
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: ✍🏻 Setup node
         uses: actions/setup-node@v3
@@ -54,11 +54,11 @@ jobs:
     steps:
       - name: 🛑 Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          persist-credentials: false
 
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: ✍🏻 Setup node
         uses: actions/setup-node@v3


### PR DESCRIPTION
I put the persist-credentials option in the wrong step in the docs workflow. This PR fixes it.