### PR TITLE
Add workflow to build the docs when needed in pull request

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,40 @@
+name: Build the docs
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+        - 'docs/**' # only run if the PR makes changes to the docs content.
+
+env:
+  CI: true
+  NEXT_PUBLIC_ALGOLIA_APPLICATION_ID: ${{secrets.NEXT_PUBLIC_ALGOLIA_APPLICATION_ID}}
+  ALGOLIA_ADMIN_API_KEY: ${{secrets.ALGOLIA_ADMIN_API_KEY}}
+  NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY: ${{secrets.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY}}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./docs
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: ✍🏻 Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: 📥 Install deps
+        run: npm install
+
+      - name: 👷‍♂️ Build
+        run: npm run build


### PR DESCRIPTION
This PR adds a workflow that will run whenever a Pull Request is opened which changes something in docs/ directory. This way we can make sure the docs can be built before merging it into main.