### PR TITLE
CI: honor the lockfile, use `npm ci` instead

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: 16
 
       - name: 📥 Install deps
-        run: npm install
+        run: npm ci
 
       - name: 👷‍♂️ Build
         run: npm run build
@@ -66,7 +66,7 @@ jobs:
           node-version: 16
 
       - name: 📥 Install deps
-        run: npm install
+        run: npm ci
 
       - name: 🔎 Send to Algolia
         run: npm run buildsearch


### PR DESCRIPTION
## What feature/issue does this PR add  

[lockfile](https://nodejs.dev/learn/the-package-lock-json-file) for `docs/` exists, therefore the dependencies must be deterministically installed.

## How did you implement / how did you fix it  

Use `npm ci` instead of `npm install`.

## How to test  

Run `npm ci`.
