### PR TITLE
Change the trigger for doc build workflow

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -2,7 +2,8 @@ name: Build the docs
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
+    types: [opened, reopened]
     branches: [main]
     paths:
         - 'docs/**' # only run if the PR makes changes to the docs content.


### PR DESCRIPTION
The docs-build workflow will always fail if the Pull Request comes from outside this repository. Changing the trigger to pull_request_target should fix it.