### PR TITLE
Fix: responsive table of content placement (#702)

### DIFF
--- a/docs/src/components/NavIndex.js
+++ b/docs/src/components/NavIndex.js
@@ -65,7 +65,7 @@ export default function NavIndex(props) {
       </div>
 
       <style jsx>{`
-        @media (max-width: 1535px) {
+        @media (max-width: 1023px) {
           .csticky {
             display: none;
           }
@@ -76,7 +76,7 @@ export default function NavIndex(props) {
             margin-bottom: 15px;
           }
         }
-        @media (min-width: 1536px) {
+        @media (min-width: 1024px) {
           .cmedium {
             display: none;
           }

--- a/docs/src/pages/guides/examples.md
+++ b/docs/src/pages/guides/examples.md
@@ -13,7 +13,7 @@ probes:
       - url: https://github.com
 ```
 
-If you didn't define the http method, it will use the GET method by default. Please note that with this configuration, you will not get any notifications when <github.com> is down since the notification configuration is not defined.
+If you didn't define the http method, it will use the GET method by default. Please note that with this configuration, you will not get any notifications when `github.com` is down since the notification configuration is not defined.
 
 ## Enabling Notification
 


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. fix  #702 

## How did you implement / how did you fix it  
1.  change min width > 1024 so the ToC placed on the right side of the docs
2.  change max width < 1023 for mobile

**this display above 1024 pixel**
<img width="702" alt="Screen Shot 2022-06-23 at 09 49 57" src="https://user-images.githubusercontent.com/31987195/175441706-f8e6cb95-935f-4884-a33e-acfd5e86d98c.png">



----
**this display below 1024 pixel**
<img width="707" alt="Screen Shot 2022-06-23 at 09 49 41" src="https://user-images.githubusercontent.com/31987195/175441716-2faf387b-01a2-4568-83a6-e418aa86ca62.png">


------
I found the sidebar doesn't appear exactly 1024 pixels, maybe this can be made into new issue
<img width="514" alt="Screen Shot 2022-06-23 at 09 49 49" src="https://user-images.githubusercontent.com/31987195/175444083-164294b9-fdf2-4c13-b86a-13e2c215188b.png">



