### PR TITLE
Fix/715 response body

### DIFF
--- a/docs/src/pages/guides/examples.md
+++ b/docs/src/pages/guides/examples.md
@@ -105,7 +105,7 @@ Here is an example on how you could get previous request(s) response data into y
 
 ```shell
 {{ response.[0].status }} ==> Get status code from first request response
-{{ response.[1].data.token }} ==> Get token from second request response
+{{ response.[1].body.token }} ==> Get token from second request response
 {{ response.[2].headers.SetCookie[0] }} ==> Get first cookie from third request response
 ```
 
@@ -130,7 +130,7 @@ probes:
         url: https://reqres.in/api/users
         timeout: 7000
       - method: GET
-        url: https://reqres.in/api/users/{{ responses.[0].data.data.[0].id }}
+        url: https://reqres.in/api/users/{{ responses.[0].body.data.[0].id }}
         timeout: 7000
     incidentThreshold: 3
     recoveryThreshold: 3
@@ -139,7 +139,7 @@ probes:
       - response-time-greater-than-2000-ms
 ```
 
-In the configuration above, the first request will fetch all users from `https://reqres.in/api/users`. Then in the second request, Monika will fetch the details of the first user from the first request. If there are no triggered alerts, the response returned from the first request is ready to be used by the second request using values from `{{ responses.[0].data }}`.
+In the configuration above, the first request will fetch all users from `https://reqres.in/api/users`. Then in the second request, Monika will fetch the details of the first user from the first request. If there are no triggered alerts, the response returned from the first request is ready to be used by the second request using values from `{{ responses.[0].body }}`.
 
 Let's say the response from fetching all users in JSON format as follows:
 
@@ -162,7 +162,7 @@ Let's say the response from fetching all users in JSON format as follows:
 }
 ```
 
-To use the user ID of the first user in the second request, we define the url of the second request as `{{ responses.[0].data.data.[0].id }}`.
+To use the user ID of the first user in the second request, we define the url of the second request as `{{ responses.[0].body.data.[0].id }}`.
 
 ### Pass Response Data as Headers value
 
@@ -188,7 +188,7 @@ probes:
           name: morpheus
           job: leader
         headers:
-          Authorization: Bearer {{ responses.[0].data.token }}
+          Authorization: Bearer {{ responses.[0].body.token }}
     incidentThreshold: 3
     recoveryThreshold: 3
     alerts:

--- a/src/components/notification/__tests__/alert-message.test.ts
+++ b/src/components/notification/__tests__/alert-message.test.ts
@@ -48,6 +48,7 @@ describe('Alert message', () => {
         isRecovery: false,
         response: {
           data: '',
+          body: '',
           status: 404,
           headers: '',
           responseTime: 1000,
@@ -75,6 +76,7 @@ describe('Alert message', () => {
         isRecovery: false,
         response: {
           data: '',
+          body: '',
           status: 404,
           headers: '',
           responseTime: 1000,
@@ -109,6 +111,7 @@ describe('Alert message', () => {
         isRecovery: true,
         response: {
           data: '',
+          body: '',
           status: 404,
           headers: '',
           responseTime: 1000,
@@ -158,6 +161,7 @@ describe('Alert message', () => {
         isRecovery: true,
         response: {
           data: '',
+          body: '',
           status: 404,
           headers: '',
           responseTime: 1000,

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -285,6 +285,7 @@ async function processTCPRequestResult({
   const probeRes: ProbeRequestResponse = {
     requestType: 'tcp',
     data: '',
+    body: '',
     status: isAlertTriggered ? 0 : 200, // set to 0 if down, and 200 if ok
     headers: {},
     responseTime,

--- a/src/components/probe/probing.ts
+++ b/src/components/probe/probing.ts
@@ -108,6 +108,7 @@ export async function probing(
       return {
         requestType,
         data,
+        body: data,
         status,
         headers,
         responseTime,
@@ -131,6 +132,7 @@ export async function probing(
     return {
       requestType,
       data,
+      body: data,
       status,
       headers,
       responseTime,
@@ -143,6 +145,7 @@ export async function probing(
     if (error?.response) {
       return {
         data: error?.response?.data,
+        body: error?.response?.data,
         status: error?.response?.status,
         headers: error?.response?.headers,
         responseTime,
@@ -156,6 +159,7 @@ export async function probing(
 
       return {
         data: '',
+        body: '',
         status,
         headers: '',
         responseTime,
@@ -165,6 +169,7 @@ export async function probing(
     // other errors
     return {
       data: '',
+      body: '',
       status: error.code || 'Unknown error',
       headers: '',
       responseTime,

--- a/src/interfaces/request.ts
+++ b/src/interfaces/request.ts
@@ -32,6 +32,7 @@ export type RequestTypes = 'http' | 'HTTP' | 'icmp' | 'ICMP' | 'tcp'
 export interface ProbeRequestResponse<T = any> {
   requestType?: RequestTypes // is this for http (default) or icmp  or others
   data: T
+  body: T
   status: number // todo: Improve status management. Status as number is pretty limiting here if we want to support other protocols other than http
   headers: any
   responseTime: number

--- a/src/jobs/tls-check.ts
+++ b/src/jobs/tls-check.ts
@@ -71,6 +71,7 @@ export function tlsChecker() {
                 status: 500,
                 responseTime: 0,
                 data: {},
+                body: {},
                 headers: {},
               },
             }

--- a/src/plugins/validate-response/__tests__/index.test.ts
+++ b/src/plugins/validate-response/__tests__/index.test.ts
@@ -61,6 +61,7 @@ describe('validateResponse', () => {
         isAlertTriggered: true,
         response: {
           data: '',
+          body: '',
           responseTime: 20,
           headers: {},
           status: 300,
@@ -73,6 +74,7 @@ describe('validateResponse', () => {
         },
         response: {
           data: '',
+          body: '',
           responseTime: 20,
           headers: {},
           status: 300,
@@ -94,6 +96,7 @@ describe('validateResponse', () => {
         },
         response: {
           data: '',
+          body: '',
           responseTime: 20,
           headers: {},
           status: 200,
@@ -107,6 +110,7 @@ describe('validateResponse', () => {
         },
         response: {
           data: '',
+          body: '',
           responseTime: 20,
           headers: {},
           status: 200,
@@ -128,6 +132,7 @@ describe('validateResponse', () => {
         },
         response: {
           data: '',
+          body: '',
           responseTime: 10,
           headers: {},
           status: 300,
@@ -141,6 +146,7 @@ describe('validateResponse', () => {
         },
         response: {
           data: '',
+          body: '',
           responseTime: 10,
           headers: {},
           status: 300,
@@ -162,6 +168,7 @@ describe('validateResponse', () => {
         },
         response: {
           data: '',
+          body: '',
           responseTime: 10,
           headers: {},
           status: 200,
@@ -175,6 +182,7 @@ describe('validateResponse', () => {
         },
         response: {
           data: '',
+          body: '',
           responseTime: 10,
           headers: {},
           status: 200,

--- a/src/plugins/validate-response/__tests__/index.test.ts
+++ b/src/plugins/validate-response/__tests__/index.test.ts
@@ -41,6 +41,7 @@ describe('validateResponse', () => {
   ): ProbeRequestResponse => {
     return {
       data: '',
+      body: '',
       status,
       responseTime,
       headers: {},

--- a/src/plugins/validate-response/checkers/__tests__/index.test.ts
+++ b/src/plugins/validate-response/checkers/__tests__/index.test.ts
@@ -118,6 +118,7 @@ describe('responseChecker', () => {
     const generateMockedResponse = (responseTime: number) => {
       return {
         data: '',
+        body: '',
         status: 200,
         responseTime, // milliseconds
         headers: {},

--- a/src/plugins/validate-response/checkers/__tests__/query-expression.test.ts
+++ b/src/plugins/validate-response/checkers/__tests__/query-expression.test.ts
@@ -29,6 +29,7 @@ describe('queryExpression', () => {
   it('should handle response time query', () => {
     const res = {
       data: '',
+      body: '',
       status: 200,
       headers: {},
       responseTime: 150,
@@ -42,6 +43,7 @@ describe('queryExpression', () => {
   it('should handle response status query', () => {
     const res = {
       data: '',
+      body: '',
       status: 200,
       headers: {},
       responseTime: 200,
@@ -55,6 +57,7 @@ describe('queryExpression', () => {
   it('should handle response size query', () => {
     const res = {
       data: '',
+      body: '',
       status: 200,
       headers: { 'content-length': 2000 },
       responseTime: 200,
@@ -68,6 +71,7 @@ describe('queryExpression', () => {
   it('should handle response headers query', () => {
     const res = {
       data: '',
+      body: '',
       status: 200,
       headers: { 'Content-Type': 'application/json' },
       responseTime: 200,
@@ -87,6 +91,9 @@ describe('queryExpression', () => {
       headers: {},
       responseTime: 200,
       data: {
+        message: 'Hello',
+      },
+      body: {
         message: 'Hello',
       },
     }

--- a/test/components/notification.test.ts
+++ b/test/components/notification.test.ts
@@ -61,6 +61,7 @@ describe('send alerts', () => {
         isAlertTriggered: false,
         response: {
           data: '',
+          body: '',
           status: 500,
           responseTime: 0,
           headers: {},
@@ -92,6 +93,7 @@ describe('send alerts', () => {
         isAlertTriggered: true,
         response: {
           data: '',
+          body: '',
           status: 500,
           responseTime: 0,
           headers: {},
@@ -123,6 +125,7 @@ describe('send alerts', () => {
         isAlertTriggered: true,
         response: {
           data: '',
+          body: '',
           status: 500,
           responseTime: 0,
           headers: {},
@@ -155,6 +158,7 @@ describe('send alerts', () => {
         isAlertTriggered: true,
         response: {
           data: '',
+          body: '',
           status: 500,
           responseTime: 0,
           headers: {},
@@ -188,6 +192,7 @@ describe('send alerts', () => {
         isAlertTriggered: true,
         response: {
           data: '',
+          body: '',
           status: 500,
           responseTime: 0,
           headers: {},
@@ -226,6 +231,7 @@ describe('send alerts', () => {
         isAlertTriggered: true,
         response: {
           data: '',
+          body: '',
           status: 500,
           responseTime: 0,
           headers: {},
@@ -260,6 +266,7 @@ describe('send alerts', () => {
         isAlertTriggered: true,
         response: {
           data: '',
+          body: '',
           status: 500,
           responseTime: 0,
           headers: {},
@@ -312,6 +319,7 @@ describe('send alerts', () => {
         isAlertTriggered: true,
         response: {
           data: '',
+          body: '',
           status: 500,
           responseTime: 0,
           headers: {},
@@ -347,6 +355,7 @@ describe('send alerts', () => {
         isAlertTriggered: true,
         response: {
           data: '',
+          body: '',
           status: 500,
           responseTime: 0,
           headers: {},
@@ -378,6 +387,7 @@ describe('send alerts', () => {
         isAlertTriggered: true,
         response: {
           data: '',
+          body: '',
           status: 500,
           responseTime: 0,
           headers: {},
@@ -409,6 +419,7 @@ describe('send alerts', () => {
         isAlertTriggered: true,
         response: {
           data: '',
+          body: '',
           status: 500,
           responseTime: 0,
           headers: {},
@@ -440,6 +451,7 @@ describe('send alerts', () => {
         isAlertTriggered: true,
         response: {
           data: '',
+          body: '',
           status: 500,
           responseTime: 0,
           headers: {},


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. #715 Fix Alert Example Inconsistensies

## How did you implement / how did you fix it  
1.  By adding body to probe responses, so it will be equals to the alert body usage

## How to test  
1. create a chain request using the body data from probe response in monika.yml e.g 
```yaml
probes:
  - id: '1'
    name: Probing Github
    description: simulate html form submission
    interval: 10
    requests:
      - method: GET
        url: https://reqres.in/api/users
        timeout: 7000
      - method: GET
        url: https://reqres.in/api/users/{{ responses.[0].body.data.[0].id }}
        timeout: 7000
    incidentThreshold: 3
    recoveryThreshold: 3
    alerts:
      - status-not-2xx
      - response-time-greater-than-2000-ms 
```
2. run monika : `npm run start`
3. it should be successfully run the probe requests

