### PR TITLE
Docs: Change link in Notification page(#767)

### DIFF
--- a/docs/src/pages/guides/notifications.md
+++ b/docs/src/pages/guides/notifications.md
@@ -5,7 +5,7 @@ title: Notifications
 
 ## Notification Types
 
-Monika will send notifications to you whenever [alerts](https://hyperjumptech.github.io/monika/guides/alerts) are triggered, e.g., when the response status of a probed URL is not [2xx success code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#2xx_success) ([status-not-2xx](https://hyperjumptech.github.io/monika/guides/alerts#1-http-code)).
+Monika will send notifications to you whenever [alerts](https://hyperjumptech.github.io/monika/guides/alerts) are triggered, e.g., when the response status of a probed URL is not [2xx success code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#2xx_success) ([status-not-2xx](https://hyperjumptech.github.io/monika/guides/alerts#request-alerts)).
 
 At this moment, Monika support these channel of notifications (You can use just one or more):
 


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. 767/Docs: Wrong link in Notification page

## How to test  
1. Go to https://monika.hyperjump.tech/guides/notifications
2. click status-not-2xx
<img width="852" alt="Screen Shot 2022-07-14 at 14 26 19" src="https://user-images.githubusercontent.com/47026826/178926067-bcef9a26-8b18-4bf6-b891-396ef3a06c67.png">
3. 
https://user-images.githubusercontent.com/47026826/178926181-1ebfadcd-d34a-4745-8ac8-4eb4846c2683.mov
