### PR TITLE
Add example for request chaining in body payload

### DIFF
--- a/docs/src/pages/guides/examples.md
+++ b/docs/src/pages/guides/examples.md
@@ -219,7 +219,7 @@ Using the above configuration, Monika will perform a login request in the first 
 
 Continuing with the examples from www.reqres.in above, say we would like to use the previous GET request to perform a POST /login. If the data from the initial request is something like below:
 
-```yaml
+```json
 {
   'data':
     {
@@ -227,9 +227,9 @@ Continuing with the examples from www.reqres.in above, say we would like to use 
       'email': 'george.bluth@reqres.in',
       'first_name': 'George',
       'last_name': 'Bluth',
-      'avatar': 'https://reqres.in/img/faces/1-image.jpg',
+      'avatar': 'https://reqres.in/img/faces/1-image.jpg'
     },
-  ....,
+  ....
 }
 ```
 

--- a/docs/src/pages/guides/examples.md
+++ b/docs/src/pages/guides/examples.md
@@ -141,7 +141,7 @@ probes:
 
 In the configuration above, the first request will fetch all users from `https://reqres.in/api/users`. Then in the second request, Monika will fetch the details of the first user from the first request. If there are no triggered alerts, the response returned from the first request is ready to be used by the second request using values from `{{ responses.[0].body }}`.
 
-Let's say the response from fetching all users in JSON format as follows:
+Let's say the response from fetching all users in JSON format is as follows:
 
 ```json
 {
@@ -197,3 +197,56 @@ probes:
 ```
 
 Using the above configuration, Monika will perform a login request in the first request, then use the returned token in the Authorization header of the second request.
+
+### Pass Response Data to Request Body
+
+Continuing with the examples from wwwh.reqres.in above, say we would like to use the previous GET request to perform a POST /login. If the initial data from reqres returned is something like below:
+
+```yaml
+{
+  'data':
+    {
+      'id': 1,
+      'email': 'george.bluth@reqres.in',
+      'first_name': 'George',
+      'last_name': 'Bluth',
+      'avatar': 'https://reqres.in/img/faces/1-image.jpg',
+    },
+  ....,
+}
+```
+
+Then your chain request to get the user email would look something like:
+
+```yaml
+probes:
+  - id: probe-01
+    name: 'body from resonse'
+    interval: 10
+
+    requests:
+      - url: https://reqres.in/api/users/1
+        method: GET
+        timeout: 5000
+        saveBody: false
+        headers:
+          Content-Type: application/json; charset=utf-8
+
+      - url: https://reqres.in/api/login
+        method: POST
+        timeout: 1000
+        headers:
+          Content-Type: application/json; charset=utf-8
+        body:
+          email: '{{ responses.[0].body.data.email }}'
+          password: password
+
+        alerts:
+          - query: response.status != 200
+            message: Http Response status code is not 200!
+notifications:
+  - id: unique-id-desktop
+    type: desktop
+```
+
+Note: Please do not forget the tick marks before and after the opening and closing double braces to explicitely indicate a string value. YAML parsers will generate warnings without it.

--- a/docs/src/pages/guides/examples.md
+++ b/docs/src/pages/guides/examples.md
@@ -233,7 +233,7 @@ Continuing with the examples from www.reqres.in above, say we would like to use 
 }
 ```
 
-Then your chain request to get the user body.email would look something like:
+Then you can use the user's email in the login request body as follows:
 
 ```yaml
 probes:

--- a/docs/src/pages/guides/examples.md
+++ b/docs/src/pages/guides/examples.md
@@ -216,12 +216,12 @@ Continuing with the examples from wwwh.reqres.in above, say we would like to use
 }
 ```
 
-Then your chain request to get the user email would look something like:
+Then your chain request to get the user body.email would look something like:
 
 ```yaml
 probes:
   - id: probe-01
-    name: 'body from resonse'
+    name: 'body from response'
     interval: 10
 
     requests:
@@ -249,4 +249,4 @@ notifications:
     type: desktop
 ```
 
-Note: Please do not forget the tick marks before and after the opening and closing double braces to explicitely indicate a string value. YAML parsers will generate warnings without it.
+Note: Please do not forget the tick marks before and after the opening and closing double braces to explicitly indicate a string value. YAML parsers will generate warnings without it.

--- a/docs/src/pages/guides/examples.md
+++ b/docs/src/pages/guides/examples.md
@@ -217,7 +217,7 @@ Using the above configuration, Monika will perform a login request in the first 
 
 ### Pass Response Data to Request Body
 
-Continuing with the examples from wwwh.reqres.in above, say we would like to use the previous GET request to perform a POST /login. If the initial data from reqres returned is something like below:
+Continuing with the examples from www.reqres.in above, say we would like to use the previous GET request to perform a POST /login. If the data from the initial request is something like below:
 
 ```yaml
 {
@@ -266,4 +266,4 @@ notifications:
     type: desktop
 ```
 
-Note: Please do not forget the tick marks before and after the opening and closing double braces to explicitly indicate a string value. YAML parsers will generate warnings without it.
+Note: Please do not forget the single quotes before and after the opening and closing double braces to explicitly indicate a string value. YAML parsers will generate warnings without it.


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Implements #757 
2. Missing example for request chaining in body

## How did you implement / how did you fix it  
1.  Adding specific example where previous request is used in body
2. Test the example

## How to test  
1. Use the following monika.yaml
```yaml
probes:
  - id: probe-01
    name: 'body from resonse'
    interval: 10

    requests:
      - url: https://reqres.in/api/users/1
        method: GET
        timeout: 5000
        saveBody: false
        headers:
          Content-Type: application/json; charset=utf-8
      - url: https://reqres.in/api/login
        method: POST
        timeout: 1000
        headers:
          Content-Type: application/json; charset=utf-8
        body:
          email: '{{ responses.[0].body.data.email }}'
          password: password
```
2. Then run `monika -c monica.yaml -s 0`

