### PR TITLE
Add status notification validation

### DIFF
--- a/monika-config-schema.json
+++ b/monika-config-schema.json
@@ -788,7 +788,8 @@
     },
     "status-notification": {
       "type": "string",
-      "description": "Set to periodically send status notifications. To disable set to false.",
+      "title": "Status notification",
+      "description": "Sends status notification periodically according to a cron schedule. To disable set to false.",
       "default": "0 6 * * *"
     }
   },

--- a/monika-config-schema.json
+++ b/monika-config-schema.json
@@ -785,6 +785,11 @@
         }
       },
       "required": ["max_db_size", "deleted_data", "cron_schedule"]
+    },
+    "status-notification": {
+      "type": "string",
+      "description": "Set to periodically send status notifications. To disable set to false.",
+      "default": "0 6 * * *"
     }
   },
   "type": "object"

--- a/monika-config-schema.json
+++ b/monika-config-schema.json
@@ -789,7 +789,7 @@
     "status-notification": {
       "type": "string",
       "title": "Status notification",
-      "description": "Sends status notification periodically according to a cron schedule. To disable set to false.",
+      "description": "Sends status notification periodically according to a cron schedule. Set to false to disable.",
       "default": "0 6 * * *"
     }
   },

--- a/monika.example.yml
+++ b/monika.example.yml
@@ -188,3 +188,5 @@ db_limit:
   max_db_size: 1000000000
   deleted_data: 1
   cron_schedule: '*/1 * * * *'
+
+# status-notification: 0 6 * * *

--- a/monika.example.yml
+++ b/monika.example.yml
@@ -188,5 +188,4 @@ db_limit:
   max_db_size: 1000000000
   deleted_data: 1
   cron_schedule: '*/1 * * * *'
-
 # status-notification: 0 6 * * *


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Implements #797 
2. Forgot status-notification validation

## How did you implement / how did you fix it  
1. Add "status-notification" 
2. Add status-notification in example.yaml

## How to test  
1. Use this latest json schema for testing, On VSCode goto File --> Preferences, type "schema" above and you should see:

![image](https://user-images.githubusercontent.com/964106/180722363-cfdba1f6-aee8-400c-8894-830e74b83e3d.png)

2. Under the settings.json we can define a specific schema (this update file) to a test file say `test.yaml`:
(your original yaml setting will not be affected/modified)

![image](https://user-images.githubusercontent.com/964106/180722675-27adae29-9cae-4633-a302-66fb7fb54a48.png)

3. You might need to quit vscode and start it again for the settings to be updated.
4. Then create your teset config file, `test.yaml`:
```yaml
probes:
  - id: probe-01
    name: 'test'
    interval: 10
    requests:
      - url: http://errorhttpbin.org/status/400
        method: GET
        timeout: 5000
        saveBody: false
        headers:
          Content-Type: application/json; charset=utf-8

notifications:
  - id: unique-id-desktop
    type: desktop
```
5. Finally type in `status-notification` you should see suggestion, description and default value.

## Screenshot
1. Auto-completion / suggestion
![image](https://user-images.githubusercontent.com/964106/180722922-6297bc7c-1eee-4748-9ede-546e8953d239.png)

