### PR TITLE
Add max-start-delay flag to prevent probes from starting at the same time

### DIFF
--- a/docs/src/pages/guides/cli-options.md
+++ b/docs/src/pages/guides/cli-options.md
@@ -255,6 +255,14 @@ You can combine this flag with the `--id` flag to repeat custom sequences.
 monika -r 3 -i 1,3,1
 ```
 
+## Maximum start delay
+
+When there are many probes, Monika by default will not start the probing all at the same time. It will delay the start of the probing by dividing the value of `--max-start-delay` flag with the number of the probes plus a random value between 0 to 1 seconds. This is to prevent connection timeout due to probing too many probes at the same time. The default value of `--max-start-delay` is 60000 (milliseconds) which corresponds to 1 minutes.
+
+```bash
+monika --max-start-delay 300000 # this will set max-start-delay to 5 minutes.
+```
+
 ## STUN
 
 By default monika will continuously check the [STUN](https://en.wikipedia.org/wiki/STUN) server in 20 second intervals. You can specify the number of intervals using the `-s` or `--stun` flags followed by a number in seconds. For example to set the interval to 10 seconds type the command below:

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,6 +242,12 @@ class Monika extends Command {
       description:
         'Enable auto-update for Monika. Available options: major, minor, patch. This will make Monika terminate itself on successful update but does not restart',
     }),
+
+    'max-start-delay': Flags.integer({
+      default: 1 * 60 * 1000, // 1 minutes in milliseconds
+      description:
+        'The maximum delay (in milliseconds) to start probing when there are many probes. When this is set to value greater than zero, all of the probes will start at slightly different time but within the value set here.',
+    }),
   }
 
   /* eslint-disable complexity */
@@ -416,7 +422,8 @@ class Monika extends Command {
           sanitizedProbe,
           config.notifications ?? [],
           Number(_flags.repeat),
-          verboseLogs
+          verboseLogs,
+          _flags['max-start-delay']
         )
       }
     } catch (error) {

--- a/src/looper/index.ts
+++ b/src/looper/index.ts
@@ -172,7 +172,6 @@ function loopProbe(
   return probeInterval
 }
 
-// const BATCH_SIZE = 100
 const delayForProbe = (
   index: number,
   totalProbes: number,

--- a/src/looper/index.ts
+++ b/src/looper/index.ts
@@ -171,6 +171,19 @@ function loopProbe(
   return probeInterval
 }
 
+// const BATCH_SIZE = 100
+const delayForProbe = (
+  index: number,
+  totalProbes: number,
+  maxStartDelay: number
+) => {
+  const delay =
+    Math.max(Math.ceil(maxStartDelay / totalProbes) * index, 100) +
+    Math.random() * 1000
+
+  return delay
+}
+
 /**
  * idFeeder feeds Prober with actual ids to process
  * @param {object} sanitizedProbes probes that has been sanitized
@@ -184,16 +197,23 @@ export function idFeeder(
   sanitizedProbes: Probe[],
   notifications: Notification[],
   repeats: number,
-  verboseLogs: boolean
+  verboseLogs: boolean,
+  maxStartDelay: number
 ): any {
-  for (const probe of sanitizedProbes) {
-    const interval = loopProbe(
-      probe,
-      notifications ?? [],
-      repeats ?? 0,
-      verboseLogs
-    )
-    intervals.push(interval)
+  for (const [i, probe] of sanitizedProbes.entries()) {
+    const delay =
+      maxStartDelay === 0
+        ? 0
+        : delayForProbe(i, sanitizedProbes.length, maxStartDelay)
+    setTimeout(() => {
+      const interval = loopProbe(
+        probe,
+        notifications ?? [],
+        repeats ?? 0,
+        verboseLogs
+      )
+      intervals.push(interval)
+    }, delay)
   }
 
   const abort = () => {


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Resolve #807 

## How did you implement / how did you fix it  
1.  Add a new flag `max-start-delay`. When set greater than zero, Monika will start probing the probes in slightly different time but still within the specified max-start-delay. Default value for max-start-delay is 60000 (which corresponds to 1 minute).
2. Add documentation about this new flag.

## How to test  
1. Use the following monika config and save it as monika.yml

```yaml
notifications:
  - id: desktop
    type: desktop
probes:
  - id: "probe-0"
    name: "Probe 0"
    incidentThreshold: 3
    recoveryThreshold: 3
    interval: 30
    alerts:
      - query: "response.status != 200"
        message: " Http Response status code is not 200!"
    requests:
      - method: GET
        url: "https://monika.hyperjump.tech/"
        timeout: 10000
  - id: "probe-1"
    name: "Probe 1"
    incidentThreshold: 3
    recoveryThreshold: 3
    interval: 30
    alerts:
      - query: "response.status != 200"
        message: " Http Response status code is not 200!"
    requests:
      - method: GET
        url: "https://github.com/"
        timeout: 10000
  - id: "probe-2"
    name: "Probe 2"
    incidentThreshold: 3
    recoveryThreshold: 3
    interval: 30
    alerts:
      - query: "response.status != 200"
        message: " Http Response status code is not 200!"
    requests:
      - method: GET
        url: "https://twitter.com/"
        timeout: 10000
  - id: "probe-3"
    name: "Probe 3"
    incidentThreshold: 3
    recoveryThreshold: 3
    interval: 30
    alerts:
      - query: "response.status != 200"
        message: " Http Response status code is not 200!"
    requests:
      - method: GET
        url: "https://remix.run/"
        timeout: 10000
  - id: "probe-4"
    name: "Probe 4"
    incidentThreshold: 3
    recoveryThreshold: 3
    interval: 30
    alerts:
      - query: "response.status != 200"
        message: " Http Response status code is not 200!"
    requests:
      - method: GET
        url: "https://developer.apple.com/"
        timeout: 10000

```

2. Run monika: `rm -rf monika-logs.db && npm run start -- -c <path-to-monika.yml>` 
3. See that the probes are not started at the same time. 

Before this PR:

<img width="689" alt="Screenshot 2022-07-26 at 01 48 42" src="https://user-images.githubusercontent.com/311343/180895849-0e7d1c13-0348-4749-a762-b8ea8ceafbfa.png">

With this PR: (note the probe's timestamp)

<img width="932" alt="Screenshot 2022-07-26 at 01 45 57" src="https://user-images.githubusercontent.com/311343/180895912-e523d940-29f8-42b4-a944-9a1468090730.png">
