### PR TITLE
Add follow-redirects flag

### DIFF
--- a/docs/src/pages/guides/cli-options.md
+++ b/docs/src/pages/guides/cli-options.md
@@ -255,6 +255,14 @@ You can combine this flag with the `--id` flag to repeat custom sequences.
 monika -r 3 -i 1,3,1
 ```
 
+## Follow Redirects
+
+By default Monika will follow redirects once. You can set the value of `--follow-redirects` flag to tell Monika to follow redirects as many as you want. If you don't want to follow redirects, set the value to zero.
+
+```bash
+monika --follow-redirects 0 # disable following redirects
+```
+
 ## STUN
 
 By default monika will continuously check the [STUN](https://en.wikipedia.org/wiki/STUN) server in 20 second intervals. You can specify the number of intervals using the `-s` or `--stun` flags followed by a number in seconds. For example to set the interval to 10 seconds type the command below:

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -134,13 +134,15 @@ async function checkThresholdsAndSendAlert(
  * @param {object} probe contains all the probes
  * @param {array} notifications contains all the notifications
  * @param {boolean} verboseLogs flag for log verbosity
+ * @param {number} followRedirects number of times monika should follow redirects
  * @returns {Promise<void>} void
  */
 export async function doProbe(
   checkOrder: number,
   probe: Probe,
   notifications: Notification[],
-  verboseLogs: boolean
+  verboseLogs: boolean,
+  followRedirects: number
 ): Promise<void> {
   const eventEmitter = getEventEmitter()
   const responses = []
@@ -185,7 +187,11 @@ export async function doProbe(
     try {
       // intentionally wait for a request to finish before processing next request in loop
       // eslint-disable-next-line no-await-in-loop
-      const probeRes: ProbeRequestResponse = await probing(request, responses)
+      const probeRes: ProbeRequestResponse = await probing(
+        request,
+        responses,
+        followRedirects
+      )
 
       logResponseTime(probeRes.responseTime)
 

--- a/src/components/probe/probing.test.ts
+++ b/src/components/probe/probing.test.ts
@@ -94,7 +94,7 @@ describe('Probing', () => {
         for (let j = 0; j < requests.length; j++) {
           try {
             // eslint-disable-next-line no-await-in-loop
-            const resp = await probing(requests[j], responses)
+            const resp = await probing(requests[j], responses, 0)
             responses.push(resp)
             if (j !== 0) {
               results.push({
@@ -131,7 +131,7 @@ describe('Probing', () => {
         timeout: 10,
       }
 
-      const result = await probing(request, [])
+      const result = await probing(request, [], 0)
       expect(result.status).to.be.equals(200)
     })
 
@@ -163,7 +163,7 @@ describe('Probing', () => {
 
       // act
       server.listen()
-      const res = await probing(request, [])
+      const res = await probing(request, [], 0)
       server.close()
 
       // assert
@@ -199,7 +199,7 @@ describe('Probing', () => {
 
       // act
       server.listen()
-      const res = await probing(request, [])
+      const res = await probing(request, [], 0)
       server.close()
 
       // assert
@@ -235,7 +235,7 @@ describe('Probing', () => {
 
       // act
       server.listen()
-      const res = await probing(request, [])
+      const res = await probing(request, [], 0)
       server.close()
 
       // assert
@@ -272,7 +272,7 @@ describe('Probing', () => {
 
       // act
       server.listen()
-      const res = await probing(request, [])
+      const res = await probing(request, [], 0)
       server.close()
 
       // assert

--- a/src/components/probe/probing.ts
+++ b/src/components/probe/probing.ts
@@ -36,17 +36,21 @@ import https from 'https'
 // More information here: https://rakshanshetty.in/nodejs-http-keep-alive/
 const httpAgent = new http.Agent({ keepAlive: true })
 const httpsAgent = new https.Agent({ keepAlive: true })
+
+// Create an instance of axios here so it will be reused instead of creating a new one all the time.
 const axiosInstance = axios.create()
 
 /**
  * probing() is the heart of monika requests generation
  * @param {obj} requestConfig is a config object
  * @param {array} responses an array of previous responses
+ * @param {number} followRedirects number of times monika should follow redirects
  * @returns ProbeRequestResponse, response to the probe request
  */
 export async function probing(
   requestConfig: Omit<RequestConfig, 'saveBody' | 'alert'>,
-  responses: Array<ProbeRequestResponse>
+  responses: Array<ProbeRequestResponse>,
+  followRedirects: number
 ): Promise<ProbeRequestResponse> {
   // Compile URL using handlebars to render URLs that uses previous responses data
   const { method, url, headers, timeout, body, ping } = requestConfig
@@ -168,7 +172,7 @@ export async function probing(
       ...newReq,
       url: renderedURL,
       data: newReq.body,
-      maxRedirects: 0,
+      maxRedirects: followRedirects,
       httpAgent,
       httpsAgent,
     })

--- a/src/components/probe/probing.ts
+++ b/src/components/probe/probing.ts
@@ -29,6 +29,14 @@ import YAML from 'yaml'
 import { ProbeRequestResponse, RequestConfig } from '../../interfaces/request'
 import * as qs from 'querystring'
 import { sendPing, PING_TIMEDOUT } from '../../utils/ping'
+import http from 'http'
+import https from 'https'
+
+// Keep the agenst alive to reduce the overhead of DNS queries and creating TCP connection.
+// More information here: https://rakshanshetty.in/nodejs-http-keep-alive/
+const httpAgent = new http.Agent({ keepAlive: true })
+const httpsAgent = new https.Agent({ keepAlive: true })
+const axiosInstance = axios.create()
 
 /**
  * probing() is the heart of monika requests generation
@@ -124,7 +132,6 @@ export async function probing(
     }
   }
 
-  const axiosInstance = axios.create()
   const requestStartedAt = Date.now()
 
   try {
@@ -161,6 +168,9 @@ export async function probing(
       ...newReq,
       url: renderedURL,
       data: newReq.body,
+      maxRedirects: 0,
+      httpAgent,
+      httpsAgent,
     })
 
     const responseTime = Date.now() - requestStartedAt

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,17 +230,23 @@ class Monika extends Command {
     }),
 
     'status-notification': Flags.string({
-      description: 'cron syntax for status notification schedule',
+      description: 'Cron syntax for status notification schedule',
     }),
 
     'keep-verbose-logs': Flags.boolean({
-      description: 'store all requests logs to database',
+      description: 'Store all requests logs to database',
       default: false,
     }),
 
     'auto-update': Flags.string({
       description:
         'Enable auto-update for Monika. Available options: major, minor, patch. This will make Monika terminate itself on successful update but does not restart',
+    }),
+
+    'follow-redirects': Flags.integer({
+      default: 1,
+      description:
+        'Monika will follow redirects as many times as the specified value here. By default, Monika will follow redirects once. To disable redirects following, set the value to zero.',
     }),
   }
 
@@ -416,7 +422,8 @@ class Monika extends Command {
           sanitizedProbe,
           config.notifications ?? [],
           Number(_flags.repeat),
-          verboseLogs
+          verboseLogs,
+          Number(_flags['follow-redirects'])
         )
       }
     } catch (error) {

--- a/src/looper/index.ts
+++ b/src/looper/index.ts
@@ -149,7 +149,8 @@ function loopProbe(
   probe: Probe,
   notifications: Notification[],
   repeats: number,
-  verboseLogs: boolean
+  verboseLogs: boolean,
+  followRedirects: number
 ) {
   let counter = 0
 
@@ -160,7 +161,7 @@ function loopProbe(
       clearInterval(checkSTUNinterval)
       process.kill(process.pid, 'SIGINT')
     } else if (isConnectedToSTUNServer && !isPaused) {
-      doProbe(++counter, probe, notifications, verboseLogs)
+      doProbe(++counter, probe, notifications, verboseLogs, followRedirects)
     }
   }, (probe.interval ?? 10) * MILLISECONDS)
 
@@ -184,14 +185,16 @@ export function idFeeder(
   sanitizedProbes: Probe[],
   notifications: Notification[],
   repeats: number,
-  verboseLogs: boolean
+  verboseLogs: boolean,
+  followRedirects: number
 ): any {
   for (const probe of sanitizedProbes) {
     const interval = loopProbe(
       probe,
       notifications ?? [],
       repeats ?? 0,
-      verboseLogs
+      verboseLogs,
+      followRedirects
     )
     intervals.push(interval)
   }


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Resolve #818 

## How did you implement / how did you fix it  
1.  Add a new flag `--follow-redirects`. Set to zero to disable following redirects or to a certain number to tell Monika to follow redirects as many times as specified here. Seems like the cause of connection timeout when there are many probes is because of the redirect following. Setting this flag to zero resolves the problem.
2. Update doc.


## How to test  
1. Create monika.yml with the content from [here](https://gist.github.com/nicnocquee/0aae7746041c700fd3b952c826703ada).
2. Run monika from this PR: `rm -rf monika-logs.db && npm run start -- -c ~/Downloads/monika-experiments/monika.yml --follow-redirects 0`

## Screenshots

When `--follow-redirects` is zero,

First cycle, the probe monika.hyperjump.tech is ok

<img width="840" alt="Screenshot 2022-07-26 at 02 27 38" src="https://user-images.githubusercontent.com/311343/180899384-ffd06148-d387-4f30-8b33-77e0f2255043.png">

Second cycle, the probe monika.hyperjump.tech is still ok

<img width="744" alt="Screenshot 2022-07-26 at 02 27 53" src="https://user-images.githubusercontent.com/311343/180899458-212ded80-ac0b-4580-8e23-59db4457a854.png">

When running with  `--follow-redirects 1` and the config contains probes that redirects,

<img width="743" alt="Screenshot 2022-07-26 at 02 45 44" src="https://user-images.githubusercontent.com/311343/180899639-170f13a9-a9cb-4520-8ff0-b424a3b38943.png">

While setting  `--follow-redirects 1` will result in alert, 

<img width="697" alt="Screenshot 2022-07-26 at 02 44 37" src="https://user-images.githubusercontent.com/311343/180899636-25386830-90ac-410f-8d86-54f35a32aba7.png">



