### PR TITLE
fix(notifications): [815] change min response time

### DIFF
--- a/src/components/notification/channel/dingtalk.ts
+++ b/src/components/notification/channel/dingtalk.ts
@@ -60,7 +60,7 @@ Number of Probes: ${message.meta.numberOfProbes}\n
 Maximum Response Time: ${message.meta.maxResponseTime} ms in the last ${
           message.meta.responseTimelogLifeTimeInHour
         } hours\n
-Minimum Response Time: ${message.meta.maxResponseTime} ms in the last ${
+Minimum Response Time: ${message.meta.minResponseTime} ms in the last ${
           message.meta.responseTimelogLifeTimeInHour
         } hours\n
 Average Response Time: ${message.meta.averageResponseTime} ms in the last ${

--- a/src/components/notification/channel/googlechat.ts
+++ b/src/components/notification/channel/googlechat.ts
@@ -178,7 +178,7 @@ export const sendGoogleChat = async (
                   },
                   {
                     textParagraph: {
-                      text: `<b>Minimum Response Time:</b> ${message.meta.maxResponseTime} ms in the last ${message.meta.responseTimelogLifeTimeInHour} hours`,
+                      text: `<b>Minimum Response Time:</b> ${message.meta.minResponseTime} ms in the last ${message.meta.responseTimelogLifeTimeInHour} hours`,
                     },
                   },
                   {

--- a/src/components/notification/channel/slack.ts
+++ b/src/components/notification/channel/slack.ts
@@ -140,7 +140,7 @@ export const sendSlack = async (
             type: 'section',
             text: {
               type: 'mrkdwn',
-              text: `*Minimum Response Time*: ${message.meta.maxResponseTime} ms in the last ${message.meta.responseTimelogLifeTimeInHour} hours`,
+              text: `*Minimum Response Time*: ${message.meta.minResponseTime} ms in the last ${message.meta.responseTimelogLifeTimeInHour} hours`,
             },
           },
           {

--- a/src/components/notification/channel/teams.ts
+++ b/src/components/notification/channel/teams.ts
@@ -126,7 +126,7 @@ export const sendTeams = async (
                 },
                 {
                   name: 'Minimum Response Time',
-                  value: `${message.meta.maxResponseTime} ms in the last ${message.meta.responseTimelogLifeTimeInHour} hours`,
+                  value: `${message.meta.minResponseTime} ms in the last ${message.meta.responseTimelogLifeTimeInHour} hours`,
                 },
                 {
                   name: 'Average Response Time',


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
#815 Response time in status notification is not correct

## How did you implement / how did you fix it  
change minimum response time value to display minResponseTime instead of maxResponseTime 

## How to test  
1. set monika config with slack/teams notifications and update status notifications :
```
notifications:
  - id: 0001-slack,
    type: slack
    data:
      url: https://hooks.slack.com/services/slackwebhookurl
status-notification: 0 * * * *
```
2. run monika until it send status notifications update
3. it should show status update notif with true max and min response time
![Screen Shot 2022-07-26 at 16 03 18](https://user-images.githubusercontent.com/8952493/180972914-505430d6-2fad-424d-93cf-250c50cbe2a7.png)


