### PR TITLE
fix(docs): [799] fix documentations on alert example

### DIFF
--- a/docs/src/pages/guides/alerts.md
+++ b/docs/src/pages/guides/alerts.md
@@ -7,12 +7,14 @@ Alerts are the types of conditions that will trigger Monika to send notification
 
 ```yaml
 probes:
-  id: '1'
-  name: Name of the probe
-  requests:
-    - alerts:
-        - query: response.size >= 10000
-          message: Response size is {{ response.size }}, expecting less than 10000
+  - id: '1'
+    name: Name of the probe
+    requests:
+      - method: GET
+        url: https://github.com
+        alerts:
+          - query: response.size >= 10000
+            message: Response size is {{ response.size }}, expecting less than 10000
 ```
 
 You can define two types of alerts: **request alerts** and **probe alerts**
@@ -23,19 +25,19 @@ Request alerts are `alerts` configurations that are scoped under the `requests` 
 
 ```yaml
 probes:
-  id: '1'
-  name: Name of the probe
-  requests:
-    - method: GET
-      url: https://github.com
-      alerts:
-        - query: response.status != 200
-          message: Status not 2xx # (This alert is only triggered for the github.com request)
-    - method: GET
-      url: https://gitlab.com
-      alerts:
-        - query: response.status != 200
-          message: Status not 2xx # (This alert is only triggered for the gitlab.com request)
+  - id: '1'
+    name: Name of the probe
+    requests:
+      - method: GET
+        url: https://github.com
+        alerts:
+          - query: response.status != 200
+            message: Status not 2xx # (This alert is only triggered for the github.com request)
+      - method: GET
+        url: https://gitlab.com
+        alerts:
+          - query: response.status != 200
+            message: Status not 2xx # (This alert is only triggered for the gitlab.com request)
 ```
 
 ## Probe Alerts
@@ -44,22 +46,22 @@ Probe alerts are `alerts` configurations that are defined under the `probe` key.
 
 ```yaml
 probes:
-  id: '1'
-  name: Name of the probe
-  requests:
-    - method: GET
-      url: https://github.com
-      alerts:
-        - query: response.status != 200
-          message: Status not 2xx # (This alert is only triggered for the github.com request)
-    - method: GET
-      url: https://gitlab.com
-      alerts:
-        - query: response.status != 200
-          message: Status not 2xx # (This alert is only triggered for the gitlab.com request)
-  alerts:
-    - query: response.time > 10000 # in milliseconds
-      message: Response time is longer than 10 seconds # (This alert is triggered for all request)
+  - id: '1'
+    name: Name of the probe
+    requests:
+      - method: GET
+        url: https://github.com
+        alerts:
+          - query: response.status != 200
+            message: Status not 2xx # (This alert is only triggered for the github.com request)
+      - method: GET
+        url: https://gitlab.com
+        alerts:
+          - query: response.status != 200
+            message: Status not 2xx # (This alert is only triggered for the gitlab.com request)
+    alerts:
+      - query: response.time > 10000 # in milliseconds
+        message: Response time is longer than 10 seconds # (This alert is triggered for all request)
 ```
 
 ## Alert Timing


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
#799 Docs: example in alerts page is not valid 

## How did you implement / how did you fix it  
change the example in alerts documentation page

## How to test  
1. create monika.yml
2. copy examples on alert documentations page to monika.yml
3. make sure there is none validation error

![Screen Shot 2022-07-26 at 17 16 20](https://user-images.githubusercontent.com/8952493/180982887-98c45543-eb23-4d5c-8642-ae1ab50788e6.png)


