### PR TITLE
fix(docs): fix documentations on notification example

### DIFF
--- a/docs/src/pages/guides/notifications.md
+++ b/docs/src/pages/guides/notifications.md
@@ -60,7 +60,6 @@ notifications:
   - id: unique-id-webhook
     type: webhook
     data:
-      method: POST
       url: https://WEBHOOK_URL
 ```
 
@@ -104,11 +103,11 @@ Monika supports Facebook Workplace. To enable notification via Workplace, you mu
 
 ```yml
 notifications:
-  id: unique-workplace-id
-  type: workplace
-  data:
-    thread_id: abcd-123-456
-    access_token: your_custom_integration_access_token
+  - id: unique-workplace-id
+    type: workplace
+    data:
+      thread_id: abcd-123-456
+      access_token: your_custom_integration_access_token
 ```
 
 | Key         | Description                                     | Example                         |
@@ -234,8 +233,8 @@ notifications:
   - id: unique-id-pagerduty-notify
     type: pagerduty
     data:
-      - key: YOUR_PAGERDUTY_INTEGRATION_KEY
-        probeID: ZN32nw_KsvTKtLFNu55JV
+      key: YOUR_PAGERDUTY_INTEGRATION_KEY
+      probeID: ZN32nw_KsvTKtLFNu55JV
 ```
 
 | Key          | Description                  | Example                            |
@@ -400,10 +399,10 @@ Monika supports Dingtalk. To enable notification via Dingtalk, you must create a
 
 ```yml
 notifications:
-  id: unique-id-webhook
-  type: dingtalk
-  data:
-    access_token: YOUR_ACCESS_TOKEN
+  - id: unique-id-webhook
+    type: dingtalk
+    data:
+      access_token: YOUR_ACCESS_TOKEN
 ```
 
 | Key          | Description                        | Example        |


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
fix #800 Docs: example in notifications page is not valid

## How did you implement / how did you fix it  
change the example in notifications documentation page

## How to test  
1. create monika.yml
2. copy examples on notifications documentations page to monika.yml
3. make sure there is none validation error

![1](https://user-images.githubusercontent.com/5974862/181426115-43d21461-410d-4a8e-bd9c-94c421826e20.PNG)

![2](https://user-images.githubusercontent.com/5974862/181426132-c5f4f562-8a85-4cfd-98d0-6ac8826c750f.PNG)

![3](https://user-images.githubusercontent.com/5974862/181426144-10925dc0-d260-4757-a25a-46650747d282.PNG)

![4](https://user-images.githubusercontent.com/5974862/181426152-75f19691-32ca-479c-97b2-fb94c39c67eb.PNG)
