### PR TITLE
change link color in docs to purple

### DIFF
--- a/docs/src/components/markdown.module.css
+++ b/docs/src/components/markdown.module.css
@@ -67,7 +67,7 @@
 .markdown > ol > li > a,
 .markdown > blockquote > p > a,
 .markdown > table > tbody > tr > td > a {
-  @apply bg-gradient-to-r from-purple-monika to-aqua-monika bg-clip-text text-transparent font-semibold transition-colors duration-150 ease-out;
+  @apply text-purple-monika font-semibold transition-colors duration-150 ease-out;
 }
 
 .markdown > p > a:hover,


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1.  fix #826 

## How did you implement / how did you fix it  
1.  change background gradient text link to purple with `text-purple-monika` class

here the screenshoot

<img width="1415" alt="Screen Shot 2022-08-01 at 14 11 44" src="https://user-images.githubusercontent.com/31987195/182095081-7356d94b-0b13-418c-85a4-9a1c78ade0f6.png">

Is this enough?
