### PR TITLE
Fix symon not running

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,7 @@
 node_modules
+.nyc_output
+.github
+docs
+dist
+lib
+monika-logs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-# Need to use 16.15 because npm ci fails with 16.15
+# Need to use node 16 because symon mode doesn't work in lower version.
+# Also need to use 16.15 because npm ci fails with 16.15.
 FROM node:16.14-alpine AS builder
 
 WORKDIR /monika

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:16.14-alpine AS builder
 
 WORKDIR /monika
 
@@ -8,9 +8,13 @@ COPY . .
 
 RUN npm run prepack
 RUN npm pack
+
+FROM node:16.14-alpine AS runner
+
+COPY --from=builder /monika/hyperjumptech-monika-*.tgz ./
 RUN npm install -g --unsafe-perm ./hyperjumptech-monika-*.tgz
 
 WORKDIR /
 RUN mkdir /config
 
-CMD [ "monika"]
+CMD ["monika"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Need to use 16.15 because npm ci fails with 16.15
 FROM node:16.14-alpine AS builder
 
 WORKDIR /monika


### PR DESCRIPTION
This PR 
- fixes monika not running in symon mode. For some reason it needs to use node 16. But cannot use node 16.15 since for some reason npm ci fails with it.
- reduce the size of the docker image. Before it was 645MB. With this PR it becomes 261MB.