### PR TITLE
removes 'bats-support' from deps and update the Bats tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,6 @@
         "@types/unzipper": "^0.10.5",
         "bats": "^1.5.0",
         "bats-assert": "^2.0.0",
-        "bats-support": "^0.3.0",
         "chai": "^4.3.4",
         "chai-spies": "^1.0.0",
         "cross-env": "^7.0.3",
@@ -3056,13 +3055,10 @@
       }
     },
     "node_modules/bats-support": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/bats-support/-/bats-support-0.3.0.tgz",
-      "integrity": "sha512-z+2WzXbI4OZgLnynydqH8GpI3+DcOtepO66PlK47SfEzTkiuV9hxn9eIQX+uLVFbt2Oqoc7Ky3TJ/N83lqD+cg==",
+      "version": "0.2.0",
+      "resolved": "git+ssh://git@github.com/ztombol/bats-support.git#d0a131831c487a1f1141e76d3ab386c89642cdff",
       "dev": true,
-      "peerDependencies": {
-        "bats": "0.4 || ^1"
-      }
+      "peer": true
     },
     "node_modules/before-after-hook": {
       "version": "2.2.2",
@@ -16905,11 +16901,10 @@
       "requires": {}
     },
     "bats-support": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/bats-support/-/bats-support-0.3.0.tgz",
-      "integrity": "sha512-z+2WzXbI4OZgLnynydqH8GpI3+DcOtepO66PlK47SfEzTkiuV9hxn9eIQX+uLVFbt2Oqoc7Ky3TJ/N83lqD+cg==",
+      "version": "git+ssh://git@github.com/ztombol/bats-support.git#d0a131831c487a1f1141e76d3ab386c89642cdff",
       "dev": true,
-      "requires": {}
+      "from": "bats-support@git+https://github.com/ztombol/bats-support.git#v0.2.0",
+      "peer": true
     },
     "before-after-hook": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "@types/unzipper": "^0.10.5",
     "bats": "^1.5.0",
     "bats-assert": "^2.0.0",
-    "bats-support": "^0.3.0",
     "chai": "^4.3.4",
     "chai-spies": "^1.0.0",
     "cross-env": "^7.0.3",

--- a/test/bats/cli.bats
+++ b/test/bats/cli.bats
@@ -5,39 +5,40 @@ function setup() {
 
 @test "Should be able to check version" {
     run npm start -- -v
-    
-    assert_success 
+
+    assert_success
     assert_output --partial '@hyperjumptech/monika'
 }
 
 @test "Should be able to print help" {
     run npm start -- -h
-    
-    assert_success 
+
+    assert_success
     assert_output --partial 'Monika command line monitoring tool'
     assert_output --partial 'USAGE'
-    assert_output --partial 'OPTIONS'
+    assert_output --partial 'FLAGS'
+    assert_output --partial 'DESCRIPTION'
     assert_output --partial 'EXAMPLES'
 }
 
 @test "Should failed with missing configuration" {
-    run npm start
-    
-    assert_failure 
-    assert_output --partial 'Error: Configuration file not found.'
+    run npm start -- -c ./not-found.yml
+
+    assert_failure
+    assert_output --partial 'CLIError: Configuration file not found: ./not-found.yml.'
 }
 
 @test "Should success starting monika" {
     run npm start -- -r 1 -s 0 -c test/bats/configs/basic.yml
-    
+
     assert_success
     assert_output --partial 'Starting Monika.'
 }
 
 @test "Should success starting monika with warnings" {
     run npm start -- -r 1 -s 0 -c test/bats/configs/basic_warnings.yml
-    
-    assert_success    
+
+    assert_success
     assert_output --partial 'Warning: Probe 1 has no name defined'
     assert_output --partial 'Warning: Probe 1 has no incidentThreshold configuration defined'
     assert_output --partial 'Warning: Probe 1 has no recoveryThreshold configuration defined'
@@ -46,8 +47,8 @@ function setup() {
 
 @test "Should be able to run probe" {
     run npm start -- -r 1 -s 0 -c test/bats/configs/basic.yml
-    
-    assert_success    
+
+    assert_success
     assert_output --partial 'GET https://symon.hyperjump.tech'
 }
 
@@ -63,20 +64,20 @@ function setup() {
     run npm start -- --create-config --postman test/testConfigs/simple.postman_collection.json --output test/bats/configs/postman_collection.yml
     run cat test/bats/configs/postman_collection.yml
     run rm test/bats/configs/postman_collection.yml
-    
+
     assert_success
 }
 
 @test "Should be able to run monika using har file" {
     run npm start -- -r 1 -s 0 --har test/testConfigs/harTest.har
-    
-    assert_success    
+
+    assert_success
     assert_output --partial 'GET https://yt3.ggpht.com/a/default-user=s68'
 }
 
 @test "Should be able to run monika using postman collections" {
     run npm start -- -r 1 -s 0 --postman test/testConfigs/simple.postman_collection.json
-    
-    assert_success    
+
+    assert_success
     assert_output --partial 'GET http://127.0.0.1:5000/v1'
 }


### PR DESCRIPTION
This PR contains:

<img width="782" alt="Screen Shot 2022-08-12 at 11 40 32" src="https://user-images.githubusercontent.com/20070808/184301710-8c7a555f-e2de-4549-929e-234c33ea7bdc.png">

- `bats-support` causes package installation failed, since it has already been installed when we install `bats-assert` so we no need to install it individually.

<img width="677" alt="Screen Shot 2022-08-12 at 13 56 09" src="https://user-images.githubusercontent.com/20070808/184301938-5a8fd542-bc22-4412-a21d-7827bcad2acb.png">

- Updated the Bats tests.
