### PR TITLE
Make STUN non blocking

### DIFF
--- a/docs/src/pages/guides/cli-options.md
+++ b/docs/src/pages/guides/cli-options.md
@@ -273,9 +273,9 @@ monika --follow-redirects 0 # disable following redirects
 
 ## STUN
 
-By default monika will continuously check the [STUN](https://en.wikipedia.org/wiki/STUN) server every 20 second intervals. Continuously STUN checking ensures that connectivity to the outside world is guaranteed. When the network is down, STUN checking fails, probing will be paused.
+By default monika will continuously check the [STUN](https://en.wikipedia.org/wiki/STUN) server every 20 second intervals. Continuously STUN checking ensures that connectivity to the outside world is guaranteed. When STUN checking fails, Monika assumes the network is down and probing will be paused.
 
-You can specify the number of intervals using the `-s` or `--stun` flags followed by a number in seconds. For example to set the interval to 10 seconds type the parameter below:
+You can specify the number of checking intervals using the `-s` or `--stun` flags followed by a number in seconds. For example to set the interval to every 10 seconds type the parameter below:
 
 ```bash
 monika -s 10
@@ -283,7 +283,7 @@ monika -s 10
 
 If the number is zero or less, monika will check the STUN server just once, not repeatedly, to get public IP.
 
-For internal networks where no outside connection is provided, you can disable the STUN checking. To disable STUN checking, set -s to `-1`.
+For internal networks where no outside connection is needed, you can disable the STUN checking by setting the `-s` flag to `-1` as follows.
 
 ```bash
 monika -s -1

--- a/docs/src/pages/guides/cli-options.md
+++ b/docs/src/pages/guides/cli-options.md
@@ -273,13 +273,21 @@ monika --follow-redirects 0 # disable following redirects
 
 ## STUN
 
-By default monika will continuously check the [STUN](https://en.wikipedia.org/wiki/STUN) server in 20 second intervals. You can specify the number of intervals using the `-s` or `--stun` flags followed by a number in seconds. For example to set the interval to 10 seconds type the command below:
+By default monika will continuously check the [STUN](https://en.wikipedia.org/wiki/STUN) server every 20 second intervals. Continuously STUN checking ensures that connectivity to the outside world is guaranteed. When the network is down, STUN checking fails, probing is paused.
+
+You can specify the number of intervals using the `-s` or `--stun` flags followed by a number in seconds. For example to set the interval to 10 seconds type the parameter below:
 
 ```bash
 monika -s 10
 ```
 
 If the number is zero or less, monika will check the STUN server just once, not repeatedly, to get public IP.
+
+For internal networks where no outside connection is provided, you can disable the STUN checking. To disable STUN checking, set -s to `-1`.
+
+```bash
+monika -s -1
+```
 
 ## Summary
 

--- a/docs/src/pages/guides/cli-options.md
+++ b/docs/src/pages/guides/cli-options.md
@@ -273,7 +273,7 @@ monika --follow-redirects 0 # disable following redirects
 
 ## STUN
 
-By default monika will continuously check the [STUN](https://en.wikipedia.org/wiki/STUN) server every 20 second intervals. Continuously STUN checking ensures that connectivity to the outside world is guaranteed. When the network is down, STUN checking fails, probing is paused.
+By default monika will continuously check the [STUN](https://en.wikipedia.org/wiki/STUN) server every 20 second intervals. Continuously STUN checking ensures that connectivity to the outside world is guaranteed. When the network is down, STUN checking fails, probing will be paused.
 
 You can specify the number of intervals using the `-s` or `--stun` flags followed by a number in seconds. For example to set the interval to 10 seconds type the parameter below:
 

--- a/package.json
+++ b/package.json
@@ -185,5 +185,8 @@
       "node14-win-x64"
     ],
     "outputPath": "dist"
+  },
+  "volta": {
+    "node": "16.14.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -186,6 +186,6 @@
     "outputPath": "dist"
   },
   "volta": {
-    "node": "16.14.2"
+    "node": "16.16.0"
   }
 }

--- a/src/components/config/__tests__/create-config.test.ts
+++ b/src/components/config/__tests__/create-config.test.ts
@@ -48,6 +48,10 @@ beforeEach(() => {
   if (fs.existsSync('monika.insomnia.yml')) {
     fs.unlinkSync('monika.insomnia.yml')
   }
+
+  if (fs.existsSync('monika.sitemap.yml')) {
+    fs.unlinkSync('monika.sitemap.yml')
+  }
 })
 
 describe('Har config', () => {

--- a/src/components/logger/request-log.ts
+++ b/src/components/logger/request-log.ts
@@ -85,7 +85,7 @@ export class RequestLog {
 
   // print() generates the text and prints the logs for the past request iteration
   print(): void {
-    const reversedSentNotifications = this.sentNotifications.slice().reverse()
+    const reversedSentNotifications = [...this.sentNotifications].reverse()
     const printedNotification =
       reversedSentNotifications.find(
         (notif) => notif.type === 'NOTIFY-INCIDENT'
@@ -107,19 +107,19 @@ export class RequestLog {
       this.response?.responseTime || '-'
     }ms`
     // generate logs from ping request or probe request
-    if (this.request?.ping) {
-      probeMsg = `${this.iteration} id:${this.probe.id} PING:${
-        this.response?.alive ? 'alive' : 'dead'
-      } ${this.request?.url} ${
-        this.response?.alive ? this.response?.responseTime : '-'
-      }ms packetLoss:${this.response?.alive ? this.response?.packetLoss : '-'}%`
-    } else {
-      probeMsg = `${this.iteration} id:${this.probe.id} ${
-        this.response?.status || '-'
-      } ${this.request?.method} ${this.request?.url} ${
-        this.response?.responseTime || '-'
-      }ms`
-    }
+    probeMsg = this.request?.ping
+      ? `${this.iteration} id:${this.probe.id} PING:${
+          this.response?.alive ? 'alive' : 'dead'
+        } ${this.request?.url} ${
+          this.response?.alive ? this.response?.responseTime : '-'
+        }ms packetLoss:${
+          this.response?.alive ? this.response?.packetLoss : '-'
+        }%`
+      : `${this.iteration} id:${this.probe.id} ${
+          this.response?.status || '-'
+        } ${this.request?.method} ${this.request?.url} ${
+          this.response?.responseTime || '-'
+        }ms`
 
     if (printedNotification) {
       notifMsg = `, NOTIF: ${

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -128,6 +128,12 @@ async function checkThresholdsAndSendAlert(
     })
 }
 
+type doProbeParams = {
+  checkOrder: number // the order of probe being processed
+  probe: Probe // probe contains all the probes
+  notifications: Notification[] // notifications contains all the notifications
+  flags: any // contain all monika command params, ex: verboseLogs, followRedirects
+}
 /**
  * doProbe sends out the http request
  * @param {object} param object parameter
@@ -138,12 +144,7 @@ export async function doProbe({
   probe,
   notifications,
   flags,
-}: {
-  checkOrder: number // the order of probe being processed
-  probe: Probe // probe contains all the probes
-  notifications: Notification[] // notifications contains all the notifications
-  flags: any // contain all monika command params, ex: verboseLogs, followRedirects
-}): Promise<void> {
+}: doProbeParams): Promise<void> {
   const eventEmitter = getEventEmitter()
   const responses = []
 

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -38,6 +38,7 @@ import { processThresholds } from '../notification/process-server-status'
 import { probing } from './probing'
 import { logResponseTime } from '../logger/response-time-log'
 import { check } from '../tcp-request'
+import { getContext } from '../../context'
 
 // TODO: move this to interface file?
 interface ProbeStatusProcessed {
@@ -52,6 +53,8 @@ interface ProbeSendNotification extends Omit<ProbeStatusProcessed, 'statuses'> {
   index: number
   probeState?: ServerAlertState
 }
+
+const flags = getContext().flags
 
 const probeSendNotification = async (data: ProbeSendNotification) => {
   const eventEmitter = getEventEmitter()
@@ -132,7 +135,6 @@ type doProbeParams = {
   checkOrder: number // the order of probe being processed
   probe: Probe // probe contains all the probes
   notifications: Notification[] // notifications contains all the notifications
-  flags: any // contain all monika command params, ex: verboseLogs, followRedirects
 }
 /**
  * doProbe sends out the http request
@@ -143,7 +145,6 @@ export async function doProbe({
   checkOrder,
   probe,
   notifications,
-  flags,
 }: doProbeParams): Promise<void> {
   const eventEmitter = getEventEmitter()
   const responses = []
@@ -191,7 +192,6 @@ export async function doProbe({
       const probeRes: ProbeRequestResponse = await probing({
         requestConfig: request,
         responses,
-        flags,
       })
 
       logResponseTime(probeRes.responseTime)

--- a/src/components/probe/probing.test.ts
+++ b/src/components/probe/probing.test.ts
@@ -89,12 +89,17 @@ describe('Probing', () => {
       ]
 
       const results: any = []
+      const flags: { followRedirects: number } = { followRedirects: 0 }
       for (let i = 0; i < 2; i++) {
         const responses: any = []
         for (let j = 0; j < requests.length; j++) {
           try {
             // eslint-disable-next-line no-await-in-loop
-            const resp = await probing(requests[j], responses, 0)
+            const resp = await probing({
+              requestConfig: requests[j],
+              responses,
+              flags,
+            })
             responses.push(resp)
             if (j !== 0) {
               results.push({
@@ -131,7 +136,12 @@ describe('Probing', () => {
         timeout: 10,
       }
 
-      const result = await probing(request, [], 0)
+      const flags: { followRedirects: number } = { followRedirects: 0 }
+      const result = await probing({
+        requestConfig: request,
+        responses: [],
+        flags,
+      })
       expect(result.status).to.be.equals(200)
     })
 
@@ -161,9 +171,14 @@ describe('Probing', () => {
         timeout: 10,
       }
 
+      const flags: { followRedirects: number } = { followRedirects: 0 }
       // act
       server.listen()
-      const res = await probing(request, [], 0)
+      const res = await probing({
+        requestConfig: request,
+        responses: [],
+        flags,
+      })
       server.close()
 
       // assert
@@ -199,7 +214,12 @@ describe('Probing', () => {
 
       // act
       server.listen()
-      const res = await probing(request, [], 0)
+      const flags: { followRedirects: number } = { followRedirects: 0 }
+      const res = await probing({
+        requestConfig: request,
+        responses: [],
+        flags,
+      })
       server.close()
 
       // assert
@@ -235,7 +255,12 @@ describe('Probing', () => {
 
       // act
       server.listen()
-      const res = await probing(request, [], 0)
+      const flags: { followRedirects: number } = { followRedirects: 0 }
+      const res = await probing({
+        requestConfig: request,
+        responses: [],
+        flags,
+      })
       server.close()
 
       // assert
@@ -272,7 +297,12 @@ describe('Probing', () => {
 
       // act
       server.listen()
-      const res = await probing(request, [], 0)
+      const flags: { followRedirects: number } = { followRedirects: 0 }
+      const res = await probing({
+        requestConfig: request,
+        responses: [],
+        flags,
+      })
       server.close()
 
       // assert

--- a/src/components/probe/probing.test.ts
+++ b/src/components/probe/probing.test.ts
@@ -28,6 +28,7 @@ import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { RequestInterceptor } from 'node-request-interceptor'
 import withDefaultInterceptors from 'node-request-interceptor/lib/presets/default'
+import { setContext } from '../../context'
 import { RequestConfig } from '../../interfaces/request'
 import { probing } from './probing'
 
@@ -89,7 +90,8 @@ describe('Probing', () => {
       ]
 
       const results: any = []
-      const flags: { followRedirects: number } = { followRedirects: 0 }
+      const flag: { followRedirects: number } = { followRedirects: 0 }
+      setContext({ flags: flag })
       for (let i = 0; i < 2; i++) {
         const responses: any = []
         for (let j = 0; j < requests.length; j++) {
@@ -98,7 +100,6 @@ describe('Probing', () => {
             const resp = await probing({
               requestConfig: requests[j],
               responses,
-              flags,
             })
             responses.push(resp)
             if (j !== 0) {
@@ -136,11 +137,11 @@ describe('Probing', () => {
         timeout: 10,
       }
 
-      const flags: { followRedirects: number } = { followRedirects: 0 }
+      const flag: { followRedirects: number } = { followRedirects: 0 }
+      setContext({ flags: flag })
       const result = await probing({
         requestConfig: request,
         responses: [],
-        flags,
       })
       expect(result.status).to.be.equals(200)
     })
@@ -171,13 +172,13 @@ describe('Probing', () => {
         timeout: 10,
       }
 
-      const flags: { followRedirects: number } = { followRedirects: 0 }
+      const flag: { followRedirects: number } = { followRedirects: 0 }
+      setContext({ flags: flag })
       // act
       server.listen()
       const res = await probing({
         requestConfig: request,
         responses: [],
-        flags,
       })
       server.close()
 
@@ -214,11 +215,11 @@ describe('Probing', () => {
 
       // act
       server.listen()
-      const flags: { followRedirects: number } = { followRedirects: 0 }
+      const flag: { followRedirects: number } = { followRedirects: 0 }
+      setContext({ flags: flag })
       const res = await probing({
         requestConfig: request,
         responses: [],
-        flags,
       })
       server.close()
 
@@ -255,11 +256,11 @@ describe('Probing', () => {
 
       // act
       server.listen()
-      const flags: { followRedirects: number } = { followRedirects: 0 }
+      const flag: { followRedirects: number } = { followRedirects: 0 }
+      setContext({ flags: flag })
       const res = await probing({
         requestConfig: request,
         responses: [],
-        flags,
       })
       server.close()
 
@@ -297,11 +298,11 @@ describe('Probing', () => {
 
       // act
       server.listen()
-      const flags: { followRedirects: number } = { followRedirects: 0 }
+      const flag: { followRedirects: number } = { followRedirects: 0 }
+      setContext({ flags: flag })
       const res = await probing({
         requestConfig: request,
         responses: [],
-        flags,
       })
       server.close()
 

--- a/src/components/probe/probing.ts
+++ b/src/components/probe/probing.ts
@@ -31,6 +31,7 @@ import * as qs from 'querystring'
 import { sendPing, PING_TIMEDOUT } from '../../utils/ping'
 import http from 'http'
 import https from 'https'
+import { getContext } from '../../context'
 
 // Keep the agenst alive to reduce the overhead of DNS queries and creating TCP connection.
 // More information here: https://rakshanshetty.in/nodejs-http-keep-alive/
@@ -43,7 +44,6 @@ const axiosInstance = axios.create()
 type probingParams = {
   requestConfig: Omit<RequestConfig, 'saveBody' | 'alert'> // is a config object
   responses: Array<ProbeRequestResponse> // an array of previous responses
-  flags: any // monika context flags, from parameters etc.
 }
 
 /**
@@ -54,13 +54,14 @@ type probingParams = {
 export async function probing({
   requestConfig,
   responses,
-  flags,
 }: probingParams): Promise<ProbeRequestResponse> {
   // Compile URL using handlebars to render URLs that uses previous responses data
   const { method, url, headers, timeout, body, ping } = requestConfig
   const newReq = { method, headers, timeout, body, ping }
   const renderURL = Handlebars.compile(url)
   const renderedURL = renderURL({ responses })
+
+  const flags = getContext().flags
 
   // Compile headers using handlebars to render URLs that uses previous responses data.
   // In some case such as value is not string, it will be returned as is without being compiled.

--- a/src/components/probe/probing.ts
+++ b/src/components/probe/probing.ts
@@ -42,16 +42,18 @@ const axiosInstance = axios.create()
 
 /**
  * probing() is the heart of monika requests generation
- * @param {obj} requestConfig is a config object
- * @param {array} responses an array of previous responses
- * @param {number} followRedirects number of times monika should follow redirects
+ * @param {obj} parameter as input object
  * @returns ProbeRequestResponse, response to the probe request
  */
-export async function probing(
-  requestConfig: Omit<RequestConfig, 'saveBody' | 'alert'>,
-  responses: Array<ProbeRequestResponse>,
-  followRedirects: number
-): Promise<ProbeRequestResponse> {
+export async function probing({
+  requestConfig,
+  responses,
+  flags,
+}: {
+  requestConfig: Omit<RequestConfig, 'saveBody' | 'alert'> // is a config object
+  responses: Array<ProbeRequestResponse> // an array of previous responses
+  flags: any // monika context flags, from parameters etc.
+}): Promise<ProbeRequestResponse> {
   // Compile URL using handlebars to render URLs that uses previous responses data
   const { method, url, headers, timeout, body, ping } = requestConfig
   const newReq = { method, headers, timeout, body, ping }
@@ -172,7 +174,7 @@ export async function probing(
       ...newReq,
       url: renderedURL,
       data: newReq.body,
-      maxRedirects: followRedirects,
+      maxRedirects: flags.followRedirects,
       httpAgent,
       httpsAgent,
     })

--- a/src/components/probe/probing.ts
+++ b/src/components/probe/probing.ts
@@ -40,6 +40,12 @@ const httpsAgent = new https.Agent({ keepAlive: true })
 // Create an instance of axios here so it will be reused instead of creating a new one all the time.
 const axiosInstance = axios.create()
 
+type probingParams = {
+  requestConfig: Omit<RequestConfig, 'saveBody' | 'alert'> // is a config object
+  responses: Array<ProbeRequestResponse> // an array of previous responses
+  flags: any // monika context flags, from parameters etc.
+}
+
 /**
  * probing() is the heart of monika requests generation
  * @param {obj} parameter as input object
@@ -49,11 +55,7 @@ export async function probing({
   requestConfig,
   responses,
   flags,
-}: {
-  requestConfig: Omit<RequestConfig, 'saveBody' | 'alert'> // is a config object
-  responses: Array<ProbeRequestResponse> // an array of previous responses
-  flags: any // monika context flags, from parameters etc.
-}): Promise<ProbeRequestResponse> {
+}: probingParams): Promise<ProbeRequestResponse> {
   // Compile URL using handlebars to render URLs that uses previous responses data
   const { method, url, headers, timeout, body, ping } = requestConfig
   const newReq = { method, headers, timeout, body, ping }

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -26,11 +26,13 @@ type Context = {
   // userAgent example: @hyperjumptech/monika/1.2.3 linux-x64 node-14.17.0
   userAgent: string
   incidents: Incident[]
+  flags: any // monika parameter flags
 }
 
 type NewContext = {
   userAgent?: string
   incidents?: Incident[]
+  flags?: any
 }
 
 type Incident = {
@@ -42,6 +44,7 @@ type Incident = {
 const initialContext: Context = {
   userAgent: '',
   incidents: [],
+  flags: {},
 }
 
 let context: Context = initialContext
@@ -50,10 +53,10 @@ export function getContext(): Context {
   return context
 }
 
-export function setContext(newContext: NewContext) {
+export function setContext(newContext: NewContext): void {
   context = { ...context, ...newContext }
 }
 
-export function resetContext() {
+export function resetContext(): void {
   context = initialContext
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,7 @@ class Monika extends Command {
       char: 's', // (s)stun
       description: 'Interval in seconds to check STUN server',
       multiple: false,
-      default: -1, // default is STUN lookup unblocking
+      default: 20, // default is 20s interval lookup
     }),
 
     id: Flags.string({

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,7 @@ class Monika extends Command {
       char: 's', // (s)stun
       description: 'Interval in seconds to check STUN server',
       multiple: false,
-      default: 20,
+      default: -1, // default is STUN lookup unblocking
     }),
 
     id: Flags.string({
@@ -422,16 +422,11 @@ class Monika extends Command {
           scheduledTasks.push(scheduledStatusUpdateTask)
         }
 
-        const verboseLogs = isSymonMode || _flags['keep-verbose-logs']
-
-        abortCurrentLooper = idFeeder(
-          sanitizedProbe,
-          config.notifications ?? [],
-          Number(_flags.repeat),
-          verboseLogs,
-          Number(_flags['max-start-delay']),
-          Number(_flags['follow-redirects'])
-        )
+        abortCurrentLooper = idFeeder({
+          sanitizedProbes: sanitizedProbe,
+          notifications: config.notifications ?? [],
+          flags: _flags,
+        })
       }
     } catch (error) {
       await closeLog()

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ import path from 'path'
 import isUrl from 'is-url'
 import SymonClient from './symon'
 import { DEFAULT_CONFIG_FILENAME } from './components/config/create-config'
+import { setContext } from './context'
 
 const em = getEventEmitter()
 let symonClient: SymonClient
@@ -260,6 +261,7 @@ class Monika extends Command {
   async run(): Promise<void> {
     const monika = await this.parse(Monika)
     const _flags = monika.flags
+    setContext({ flags: _flags })
 
     try {
       if (_flags.help) {
@@ -426,7 +428,6 @@ class Monika extends Command {
         abortCurrentLooper = idFeeder({
           sanitizedProbes: sanitizedProbe,
           notifications: config.notifications ?? [],
-          flags: _flags,
         })
       }
     } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -422,6 +422,7 @@ class Monika extends Command {
           scheduledTasks.push(scheduledStatusUpdateTask)
         }
 
+        // feed the configs and probes to be processed
         abortCurrentLooper = idFeeder({
           sanitizedProbes: sanitizedProbe,
           notifications: config.notifications ?? [],

--- a/src/looper/index.ts
+++ b/src/looper/index.ts
@@ -164,7 +164,7 @@ function loopProbe({
       clearInterval(probeInterval)
       clearInterval(checkSTUNinterval)
       process.kill(process.pid, 'SIGINT')
-    } else if ((isConnectedToSTUNServer && !isPaused) || flags.stun !== -1) {
+    } else if ((isConnectedToSTUNServer && !isPaused) || flags.stun === -1) {
       doProbe({
         checkOrder: ++counter,
         probe,


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Closes #848 
2. Improve how flags are passed into functions

## How did you implement / how did you fix it  
1. Refactor function parameters using objects
2. Add monika flags as paramenter inputs for easier checking/access
3. Checks for -s == -1 to disable STUN blocking

## How to test  
1. First we want to block stun server. Find out the stun server available from your provider/location. Ping the stun to get its IP like below (your ping and ip result will likely be different than the example).
```bash
ping stun.l.google.com

PING stun.l.google.com (172.253.118.127) 56(84) bytes of data.
64 bytes from sl-in-f127.1e100.net (172.253.118.127): icmp_seq=1 ttl=106 time=22.5 ms
64 bytes from sl-in-f127.1e100.net (172.253.118.127): icmp_seq=2 ttl=106 time=22.8 ms
64 bytes from sl-in-f127.1e100.net (172.253.118.127): icmp_seq=3 ttl=106 time=23.6 ms
64 bytes from sl-in-f127.1e100.net (172.253.118.127): icmp_seq=4 ttl=106 time=26.9 ms
```
2.  Next block this ip. In my case I'm using Linux UFW firewall, to block a specific ip address, type below:
```bash
sudo ufw deny out from any to 172.253.118.127
```
4. Now run Monika again with the `-s -1` parameter.
5. Expect that STUN is still inaccessible, but the probing will continue to work. See 3rd screenshot below.

## Screenshot

Monika with `-s 5`, checking stun every 5 seconds.
![image](https://user-images.githubusercontent.com/964106/184331534-54b2173d-5479-4805-9a0d-703308b0a2ad.png)

Monika with `-s 5` but with STUN blocked. Notice the probe not running.
![image](https://user-images.githubusercontent.com/964106/184333268-990e4822-6d77-4178-8380-4491ce99f3fc.png)

Monika with `-s -1` to unblock STUN checking. Notice the `stun inaccessible` message, but probe continues.
![image](https://user-images.githubusercontent.com/964106/184334882-27a09e4a-1407-4d14-b67b-dfe52f238a47.png)
