### PR TITLE
fixed summary bug

### DIFF
--- a/src/components/logger/history.ts
+++ b/src/components/logger/history.ts
@@ -477,7 +477,7 @@ export async function getSummary(): Promise<any> {
   const config = getConfig()
 
   return {
-    numberOfProbes: config.probes.length,
+    numberOfProbes: config?.probes?.length ? config.probes.length : null,
     numberOfIncidents,
     numberOfRecoveries,
     numberOfSentNotifications,


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
It fixes a bug which occurs when running `monika --summary`:
```
> monika --summary
ERROR: Summary notification: Cannot read property 'probes' of undefined
```

## How did you implement / how did you fix it  
I only added a check if `config` is defined in `getSummary()` function. It seems to be undefined when running the function in CLI. The value on number of probes in CLI is taken for PID file, so it's still OK if config is undefined.

## How to test  
Just run `monika --summary`

