### PR TITLE
Update JSON schema for redis/postgres requests

### DIFF
--- a/monika-config-schema.json
+++ b/monika-config-schema.json
@@ -60,7 +60,7 @@
           "port": {
             "title": "Port number",
             "description": "Port number used for the redis",
-            "type":"integer",
+            "type": "integer",
             "default": "6379"
           }
         }

--- a/monika-config-schema.json
+++ b/monika-config-schema.json
@@ -67,6 +67,18 @@
             "description": "Port number used for the redis",
             "type": "integer",
             "default": "6379"
+          },
+          "password": {
+            "title": "Password",
+            "description": "Password used for the redis AUTH, if set.",
+            "type": "string",
+            "default": "mypassword"
+          },
+          "username": {
+            "title": "Username",
+            "description": "Username used for the redis AUTH, if set.",
+            "type": "string",
+            "default": "myuser"
           }
         }
       }

--- a/monika-config-schema.json
+++ b/monika-config-schema.json
@@ -25,19 +25,24 @@
     },
     "postgres": {
       "title": "Postgres",
-      "type": "object",
+      "type": "array",
       "description": "Monitor postgres readiness",
-      "additionalProperties": false,
-      "required": ["host", "port"],
-      "properties": {
-        "host": {
-          "type": "string",
-          "description": "Postgres host address to connect to"
-        },
-        "port": {
-          "title": "Port",
-          "type": "integer",
-          "description": "Postgres port to connect to"
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["host", "port"],
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Postgres host address to connect to",
+            "default": "172.15.0.1"
+          },
+          "port": {
+            "title": "Port",
+            "type": "integer",
+            "description": "Postgres port to connect to",
+            "default": "5432"
+          }
         }
       }
     },

--- a/monika-config-schema.json
+++ b/monika-config-schema.json
@@ -23,6 +23,49 @@
       "description": "The number of seconds to repeat the probe",
       "default": 10
     },
+    "postgres": {
+      "title": "Postgres",
+      "type": "object",
+      "description": "Monitor postgres readiness",
+      "additionalProperties": false,
+      "required": ["host", "port"],
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Postgres host address to connect to"
+        },
+        "port": {
+          "title": "Port",
+          "type": "integer",
+          "description": "Postgres port to connect to"
+        }
+      }
+    },
+    "redis": {
+      "title": "Redis",
+      "type": "array",
+      "description": "Monitor redis health ",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["host", "port"],
+        "properties": {
+          "host": {
+            "title": "Redis host",
+            "description": "The host address of the redis",
+            "type": "string",
+            "default": "172.15.0.1",
+            "examples": ["localhost", "192.168.0.1"]
+          },
+          "port": {
+            "title": "Port number",
+            "description": "Port number used for the redis",
+            "type":"integer",
+            "default": "6379"
+          }
+        }
+      }
+    },
     "requests": {
       "title": "Requests",
       "type": "array",
@@ -217,6 +260,12 @@
           },
           "interval": {
             "$ref": "#/definitions/interval"
+          },
+          "postgres": {
+            "$ref": "#/definitions/postgres"
+          },
+          "redis": {
+            "$ref": "#/definitions/redis"
           },
           "requests": {
             "$ref": "#/definitions/requests"

--- a/monika-config-schema.json
+++ b/monika-config-schema.json
@@ -57,7 +57,7 @@
         "properties": {
           "host": {
             "title": "Redis host",
-            "description": "The host address of the redis",
+            "description": "The hostname or IP address of the redis server",
             "type": "string",
             "default": "172.15.0.1",
             "examples": ["localhost", "192.168.0.1"]
@@ -72,13 +72,13 @@
             "title": "Password",
             "description": "Password used for the redis AUTH, if set.",
             "type": "string",
-            "default": "mypassword"
+            "default": ""
           },
           "username": {
             "title": "Username",
             "description": "Username used for the redis AUTH, if set.",
             "type": "string",
-            "default": "myuser"
+            "default": ""
           }
         }
       }


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Part of #858 
2. Part of #859 
3. Update json schema for the new probe requests

## How did you implement / how did you fix it  
1.  Add entries for redis and postgres requests

## How to test  
1. Use the monika-config.schema.json in this pr. (For how to setup the yaml see PR: #743
2. Create a config.yml file something like below:
```yaml
probes:
  - id: checking-redis
    name: ping redis
    alerts:
      - query: response.status != 200
        message: redis not available
    incidentThreshold: 2
    recoveryThreshold: 2
    redis:
      - host: 172.17.0.1 // mising port

  - id: checking-postgress
    name: ensure postgress is alive
    alerts:
      - query: response.status != 200
        message: redis not available
    incidentThreshold: 2
    recoveryThreshold: 2
    redis:
      - host: 172.2.1.1
        host: 1.2.3.4 // non unique error
        port: 5432

notifications:
  - id: desktop-01
    type: desktop
```
3.  You should get multiple errors from the schema processor

## Screenshot
Error detection
![image](https://user-images.githubusercontent.com/964106/189289804-113b26fc-ab33-446b-85fd-08226f816f9f.png)

Autocomplete:
https://user-images.githubusercontent.com/964106/189290297-b1a47a2b-a849-41c7-825b-3b2459d5d5cc.mp4



