### PR TITLE
#802 Fix cannot send alert on threshold 1

### DIFF
--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -105,10 +105,16 @@ async function checkThresholdsAndSendAlert(
     validatedResponseStatuses,
   } = data
 
+  const { flags } = getContext()
+  const isSymonMode = Boolean(flags.symonUrl) && Boolean(flags.symonKey)
+
   statuses
-    ?.filter((probeState) => !probeState.isFirstTime)
     ?.filter((probeState) => probeState.shouldSendNotification)
     ?.forEach((probeState, index) => {
+      if (isSymonMode && probeState.isFirstTime) {
+        return
+      }
+
       probeSendNotification({
         index,
         probe,


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
#802 
Fixing the issue for not sending alert when the threshold is 1. 
This is actually an intended feature to not send firsttime event alert, but is should've been used only in symon mode.

## How did you implement / how did you fix it  
add filter symon mode flag to not send firsttime event alert.

## How to test  
1. run monika using current config :
```yaml
probes:
  - id: '1'
    name: Name of the probe
    description: Probe to check GET time
    interval: 10 # in seconds
    requests:
      - method: POST
        url: http://localhost:3030/v1/users/login
    alerts:
      - query: response.status != 200
        message: Http Response status code is not 200!
    incidentThreshold: 1
    recoveryThreshold: 1
notifications:
  - id: unique-id-desktop
    type: desktop
```
2. it should send notification in first time incident happening
 
![Screen Shot 2022-09-09 at 15 45 07](https://user-images.githubusercontent.com/8952493/189314969-9a9fcfc6-0b52-428c-ac1f-07eff54bb87b.png)

