### PR TITLE
fix: deprecationHandler and sanitizeProbe alert bugs

### DIFF
--- a/src/looper/index.ts
+++ b/src/looper/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/consistent-destructuring */
 /**********************************************************************************
  * MIT License                                                                    *
  *                                                                                *
@@ -51,12 +52,29 @@ const DISABLE_STUN = -1 // -1 is disable stun checking
 export function sanitizeProbe(probe: Probe, id: string): Probe {
   const { name, requests, incidentThreshold, recoveryThreshold, alerts } = probe
   probe.id = `${id}`
+  probe.alerts = probe.alerts?.map((alert) => {
+    if (alert.query) {
+      return { ...alert, assertion: alert.query }
+    }
+
+    return alert
+  })
+
   probe.requests = requests?.map((request) => {
     if (!request.method) {
       return { ...request, method: 'GET' }
     }
 
-    return { ...request }
+    return {
+      ...request,
+      alerts: request.alerts?.map((alert) => {
+        if (alert.query) {
+          return { ...alert, assertion: alert.query }
+        }
+
+        return alert
+      }),
+    }
   })
 
   if (!name) {


### PR DESCRIPTION
This PR fixes two bugs:

1. Fixes `Alert ID` error when sending event to symon.
2. Fixes error when saving to local db.