### PR TITLE
adding option to allow probing invalid ssl endpoint

### DIFF
--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -49,6 +49,7 @@ probes:
         alerts:
           - assertion: response.status != 200
             message: Status not 2xx
+        allowUnauthorized: true
     incidentThreshold: 3
     recoveryThreshold: 3
     alerts:
@@ -72,6 +73,7 @@ Details of the field are given in the table below.
 | saveBody (optional)          | When set to true, the response body of the request is stored in the internal database. The default is off when not defined. This is to keep the log file size small as some responses can be sizable. The setting is for each probe request.                                                                                                              |
 | alerts (optional)            | See [alerts](./alerts) section for detailed information.                                                                                                                                                                                                                                                                                                  |
 | ping (optional)              | (boolean), If set true then send a PING to the specified url instead.                                                                                                                                                                                                                                                                                     |
+| allowUnauthorized (optional) | (boolean), If set to true, will make https agent to not check for ssl certificate validity                                                                                                                                                                                                                                                                |
 
 ### PING Request
 

--- a/monika.example.yml
+++ b/monika.example.yml
@@ -78,6 +78,11 @@ probes:
 #             <name>John</name>
 #             <password>secret</password>
 #           </user>
+#       - url: https://expired.badssl.com
+#         method: GET
+#         timeout: 7000
+#         allowUnauthorized: true
+#         # allowUnauthorized will make the https agent to not check certificate validity
 #     alerts:
 #       - assertion: response.status == 500
 #         message: response status message

--- a/src/components/http-request/http-request.test.ts
+++ b/src/components/http-request/http-request.test.ts
@@ -309,5 +309,47 @@ describe('probingHTTP', () => {
       // assert
       expect(res.status).to.eq(200)
     })
+
+    it('should send request with text-plain content-type even with allowUnauthorized option', async () => {
+      // arrange
+      const server = setupServer(
+        rest.post('https://example.com', (req, res, ctx) => {
+          const { headers, body } = req
+
+          if (
+            headers.get('content-type') !== 'text/plain' ||
+            body !== 'multiline string\nexample'
+          ) {
+            console.error(headers.get('content-type'))
+            console.error(body)
+
+            return res(ctx.status(400))
+          }
+
+          return res(ctx.status(200))
+        })
+      )
+      const request: RequestConfig = {
+        url: 'https://example.com',
+        method: 'POST',
+        headers: { 'content-type': 'text/plain' },
+        body: 'multiline string\nexample' as any,
+        timeout: 10,
+        allowUnauthorized: true,
+      }
+
+      // act
+      server.listen()
+      const flag: { followRedirects: number } = { followRedirects: 0 }
+      setContext({ flags: flag })
+      const res = await httpRequest({
+        requestConfig: request,
+        responses: [],
+      })
+      server.close()
+
+      // assert
+      expect(res.status).to.eq(200)
+    })
   })
 })

--- a/src/interfaces/request.ts
+++ b/src/interfaces/request.ts
@@ -48,4 +48,5 @@ export interface RequestConfig extends Omit<AxiosRequestConfig, 'data'> {
   timeout: number // request timeout
   alerts?: ProbeAlert[]
   ping?: boolean // is this request for a ping?
+  allowUnauthorized?: boolean // ignore ssl cert?
 }

--- a/src/monika-config-schema.json
+++ b/src/monika-config-schema.json
@@ -126,6 +126,11 @@
             "type": "boolean",
             "description": "If defined and to true, the request is an ICMP ping"
           },
+          "allowUnauthorized": {
+            "title": "AllowUnauthorized",
+            "type": "boolean",
+            "description": "If defined and to true, the request will ignore SSL certificate validity"
+          },
           "body": {
             "$ref": "#/definitions/body"
           },


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Adding option to allow probing invalid ssl endpoint

## How did you implement / how did you fix it  
1.  Adding configuration `allowUnauthorized` and used in creating http request, if detected this will make https agent with `rejectUnauthorized` set to false

## How to test  
1. Make probe request to `https://expired.badssl.com/` or other invalid ssl cert from badssl.com


