### PR TITLE
Update auto pr workflow

### DIFF
--- a/.github/workflows/auto-pr-schemastore.yml
+++ b/.github/workflows/auto-pr-schemastore.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          repository: hyperjumptech/schemastore
+          repository: SchemaStore/schemastore
           token: ${{ secrets.AUTO_PR_TOKEN }}
           ref: master
 
@@ -34,6 +34,10 @@ jobs:
           cd src/schemas/json
           rm monika-config-schema.json
           wget https://raw.githubusercontent.com/hyperjumptech/monika/main/src/monika-config-schema.json
+      
+      - name: Run some tests on it
+        run : |
+          make
 
       - name: Create Pull Request
         id: cpr
@@ -50,7 +54,7 @@ jobs:
           body: |
             In this PR:
             - Update config json schema to improve suggestions
-            - Update keys, default values and fix typos
+            - Update keys, default values and properties.
 
           draft: false
           delete-branch: true

--- a/.github/workflows/auto-pr-schemastore.yml
+++ b/.github/workflows/auto-pr-schemastore.yml
@@ -23,19 +23,13 @@ jobs:
           token: ${{ secrets.AUTO_PR_TOKEN }}
           ref: master
 
-      - name: Sync local fork
-        run: |
-          git remote add upstream https://github.com/SchemaStore/schemastore.git
-          git pull upstream master --ff-only
-          git push origin master
-
       - name: Update schema file
         run: |
           cd src/schemas/json
           rm monika-config-schema.json
           wget https://raw.githubusercontent.com/hyperjumptech/monika/main/src/monika-config-schema.json
       
-      - name: Run some tests on it
+      - name: Run Test on Schema
         run : |
           make
 

--- a/src/monika-config-schema.json
+++ b/src/monika-config-schema.json
@@ -130,15 +130,15 @@
             "title": "MongoDB URI",
             "description": "The hostname or IP address of the MongoDB server",
             "type": "string",
-            "examples": ["mongodb://127.0.0.1:27017"],
-            "default": ""
+            "examples": ["mongodb://user:password@127.0.0.1:27017/database"],
+            "default": "mongodb://127.0.0.1:27017"
           },
           "host": {
             "title": "MongoDB host",
             "description": "The hostname or IP address of the MongoDB server",
             "type": "string",
             "examples": ["localhost", "127.0.0.1"],
-            "default": ""
+            "default": "0.0.0.0.0"
           },
           "port": {
             "title": "Port number",

--- a/src/monika-config-schema.json
+++ b/src/monika-config-schema.json
@@ -30,7 +30,7 @@
       "items": {
         "type": "object",
         "anyOf": [
-          { 
+          {
             "required": ["uri"],
             "additionalProperties": false,
             "properties": {

--- a/src/monika-config-schema.json
+++ b/src/monika-config-schema.json
@@ -29,52 +29,55 @@
       "description": "Monitor postgres readiness",
       "items": {
         "type": "object",
-        "additionalProperties": false,
-        "oneOf": [
-          {
-            "required": ["host", "port", "database"]
+        "anyOf": [
+          { 
+            "required": ["uri"],
+            "additionalProperties": false,
+            "properties": {
+              "uri": {
+                "title": "URI connection",
+                "type": "string",
+                "description": "Postgres uri connection configuration",
+                "examples": ["postgres://user:password@172.1.0.1:5432/mydb"]
+              }
+            }
           },
           {
-            "required": ["uri"]
+            "required": ["host", "port", "database"],
+            "additionalProperties": true,
+            "properties": {
+              "host": {
+                "type": "string",
+                "description": "Postgres host address to connect to",
+                "default": "172.15.0.1"
+              },
+              "port": {
+                "title": "Port",
+                "type": "integer",
+                "description": "Postgres port to connect to",
+                "default": "5432"
+              },
+              "database": {
+                "title": "Database",
+                "type": "string",
+                "description": "Name of the database",
+                "default": ""
+              },
+              "username": {
+                "title": "Username",
+                "type": "string",
+                "description": "Username with access to the database",
+                "default": ""
+              },
+              "password": {
+                "title": "Password",
+                "type": "string",
+                "description": "User's database password",
+                "default": ""
+              }
+            }
           }
-        ],
-        "properties": {
-          "host": {
-            "type": "string",
-            "description": "Postgres host address to connect to",
-            "default": "172.15.0.1"
-          },
-          "port": {
-            "title": "Port",
-            "type": "integer",
-            "description": "Postgres port to connect to",
-            "default": "5432"
-          },
-          "database": {
-            "title": "Database",
-            "type": "string",
-            "description": "Name of the database",
-            "default": ""
-          },
-          "username": {
-            "title": "Username",
-            "type": "string",
-            "description": "Username with access to the database",
-            "default": ""
-          },
-          "password": {
-            "title": "Password",
-            "type": "string",
-            "description": "User's database password",
-            "default": ""
-          },
-          "uri": {
-            "title": "URI connection",
-            "type": "string",
-            "description": "Postgres uri connection configuration",
-            "examples": ["postgres://user:password@172.1.0.1:5432/mydb"]
-          }
-        }
+        ]
       }
     },
     "redis": {


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Create a PR when monika-config-schema.json
2. AutoPR was broken

## How did you implement / how did you fix it  
1. Base repo changed to SchemasStore/schemastore
2. Fork is the local fork (hyperjumptech/schemastore)
3. Add a schemastore testing phase `make`
4. Made sure monika-config-schema.json passes schemastore ci testing (no 3 above)

## Testing
1. The following sample should work:
(with "missing host error id-postgres"
```yaml
notifications:
  - id: unique-id
    type: desktop
probes:
  - id: 'id-1'
    name: Example
    description: Probe
    interval: 5
    requests:
      - url: 'https://httpbin.org/status/200'

    incidentThreshold: 2
    recoveryThreshold: 2
    alerts:
      - assertion: response.status != 200
        message: 'AAALEEEERT!!!'

  - id: 'id-postgres'
    name: Postgres test
    description: Test schema
    postgres:
      - uri: 'postgres://user:password@172.1.0.1/database'        
      - username: 'name'        
        port: 1234
        database: hello 

  - id: 'id-Mongodb'
    name: Mongo test
    description: Mongo probe
    mongo:
      - uri: mongodb://localhost:27017
      


```

## Screenshot

### Before fix

![image](https://user-images.githubusercontent.com/964106/196876224-2f4b6b6f-ee25-4602-a945-e743999a4687.png)

### After fix (autoPR to monika repo)

![image](https://user-images.githubusercontent.com/964106/196883798-50994900-b6b0-4a87-8583-913570dc6aac.png)


### Schemastore testing result (local): Before fix
![image](https://user-images.githubusercontent.com/964106/196883439-73283dee-3382-4d5b-81e2-a2869d73c705.png)

### Schemastore testing result (local) : After fix
![image](https://user-images.githubusercontent.com/964106/196877700-130e6d8e-7f48-4627-af1c-f9c4fcb52824.png)



