### PR TITLE
parse json validation error

### DIFF
--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -38,6 +38,7 @@ import { parseConfig } from './parse'
 import { validateConfig } from './validate'
 import { createConfigFile } from './create-config'
 import yml from 'js-yaml'
+import { exit } from 'process'
 
 export const DEFAULT_CONFIG_INTERVAL = 900
 
@@ -72,7 +73,12 @@ export const updateConfig = (config: Config, validate = true): void => {
     const validated = validateConfig(config)
 
     if (!validated.valid) {
-      throw new Error(validated.message)
+      if (process.env.NODE_ENV === 'test') {
+        throw new Error(validated.message) // return error during tests
+      }
+
+      log.error(validated.message)
+      exit(1)
     }
   }
 

--- a/src/components/config/validate-config.ts
+++ b/src/components/config/validate-config.ts
@@ -34,7 +34,7 @@ const ajv = new Ajv()
 export function validateConfigFile(filename: string): Validation {
   const validResult: Validation = {
     valid: false,
-    message: `Errors detected in config file ${filename}: `,
+    message: `Errors detected in config file ${filename}`,
   }
   const validate = ajv.compile(mySchema)
 
@@ -54,7 +54,7 @@ export function validateConfigFile(filename: string): Validation {
 
   if (validate.errors) {
     for (const err of validate.errors) {
-      validResult.message += err.message + ', '
+      validResult.message += ', ' + err.message
     }
 
     validResult.message += '.'

--- a/src/components/config/validate-config.ts
+++ b/src/components/config/validate-config.ts
@@ -34,14 +34,14 @@ const ajv = new Ajv()
 export function validateConfigFile(filename: string): Validation {
   const validResult: Validation = {
     valid: false,
-    message: `Errors detected in config file: ${filename}, please recheck`,
+    message: `Errors detected in config file ${filename}: `,
   }
   const validate = ajv.compile(mySchema)
 
   try {
     const configFile = yaml.load(fs.readFileSync(filename, 'utf8'))
-
     const isValid = validate(configFile)
+
     if (isValid) {
       validResult.valid = true
       validResult.message = `config: ${filename} is ok`
@@ -50,6 +50,14 @@ export function validateConfigFile(filename: string): Validation {
   } catch (error: any) {
     console.error('error:', error)
     validResult.message = error
+  }
+
+  if (validate.errors) {
+    for (const err of validate.errors) {
+      validResult.message += err.message + ', '
+    }
+
+    validResult.message += '.'
   }
 
   return validResult


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Closing #938 
2. Improves error message on config validation

## How did you implement / how did you fix it  
1.  Parse the validation errors back to the user
2.  When not in testing mode, do not throw error on validation fail

## How to test  
1. use a bad config like this:
```yaml
notifications:
  - id: unique-id
    type: desktop
probes:
  - id: 'id-test'
    name: test probe
    description: test db connection monitor
    postgres:
      - host: 172.17.0.1
        portk: 3306
        username: user        
       password: pass
        database: db

    incidentThreshold: 2
    recoveryThreshold: 2
    alerts:
      - assertion: response.status != 200
        message: 'D-E-D! DB is DED'
```
3. then run `bin/run-dev -c config.yaml`
4. you should get a detailed error

## Screenshot

Before fix
![image](https://user-images.githubusercontent.com/964106/199921507-b28d077f-4dcb-4b42-b319-076b45cfb2bb.png)

After fix (when run normally)
![image](https://user-images.githubusercontent.com/964106/200282120-cb9af3d1-68e3-4f99-a76d-ad6002387fdc.png)

After fix (with test env)
![image](https://user-images.githubusercontent.com/964106/200283017-0394494d-e853-4306-81d8-53f73212fb05.png)



