### PR TITLE
Add query support

### DIFF
--- a/src/monika-config-schema.json
+++ b/src/monika-config-schema.json
@@ -302,9 +302,18 @@
             "type": "string",
             "description": "Message that will be sent to the notification channel",
             "default": "Http Response status code is not 200!"
+          },
+          "query": {
+            "title": "Assertion",
+            "type": "string",
+            "description": "Note: Query is deprecated. Please use assertion."           
           }
         },
-        "required": ["assertion", "message"]
+        "oneOf": [
+          {"required": ["assertion", "message"]},
+          {"required": ["query", "message"]}
+        ]
+        
       }
     },
     "body": {

--- a/src/monika-config-schema.json
+++ b/src/monika-config-schema.json
@@ -289,31 +289,44 @@
       "description": "The condition which will trigger an alert and the subsequent notification",
       "items": {
         "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "assertion": {
-            "title": "Assertion",
-            "type": "string",
-            "description": "An expression that will trigger an alert when its is logically true. See the assertions here: https://monika.hyperjump.tech/guides/alerts#alert-query",
-            "default": "response.status != 200"
+        "anyOf": [
+          {
+            "required": ["assertion", "message"],
+            "additionalProperties": false,
+            "properties": {
+              "assertion": {
+                "title": "Assertion",
+                "type": "string",
+                "description": "An expression that will trigger an alert when its is logically true. See the assertions here: https://monika.hyperjump.tech/guides/alerts#alert-query",
+                "default": "response.status != 200"
+              },
+              "message": {
+                "title": "Message",
+                "type": "string",
+                "description": "Message that will be sent to the notification channel",
+                "default": "Http Response status code is not 200!"
+              }
+            }
           },
-          "message": {
-            "title": "Message",
-            "type": "string",
-            "description": "Message that will be sent to the notification channel",
-            "default": "Http Response status code is not 200!"
-          },
-          "query": {
-            "title": "Assertion",
-            "type": "string",
-            "description": "Note: Query is deprecated. Please use assertion."           
+          {
+            "required": ["query", "message"],
+            "additionalProperties": false,
+            "properties": {
+              "query": {
+                "title": "Query",
+                "type": "string",
+                "description": "Note: Query is deprecated, please use assertion",
+                "default": "response.status != 200"
+              },
+              "message": {
+                "title": "Message",
+                "type": "string",
+                "description": "Message that will be sent to the notification channel",
+                "default": "Http Response status code is not 200!"
+              }
+            }
           }
-        },
-        "oneOf": [
-          {"required": ["assertion", "message"]},
-          {"required": ["query", "message"]}
         ]
-        
       }
     },
     "body": {


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Closes #954 
2. Fixes error when using using config generator

## How did you implement / how did you fix it  
1.  Readd query as an allowable alert field
2. Allow for `query` but recommend `assertion` as default on the json-schema

## How to test  
1. Use the following config.yaml 
```yaml
notifications:
  - id: unique-id
    type: desktop
  - id: mailtrap-id
    type: smtp
    data:
      hostname: smtp.myserver.com
      port: 25
      username: user
      password: pass
      recipients: ["me@myserver.com"]

probes:
  - id: 'id-1'
    name: Http-Request
    description: http type probe
    interval: 5
    requests:
      - url: http://0.0.0.0:7001/v1/hello

    incidentThreshold: 3
    recoveryThreshold: 3
    alerts:
      - assertion: response.status != 200
        message: 'user message! Response NOK Status!'
      - query: response.time > 2000
        message: 'user message! Response too Slow!'
```
3. `bin/run-dev -c config.yaml -s -1`
4. Should run without error

## Screenshot

### VSCode support
On typo vscode produces a warning but prefers `assertion`
![image](https://user-images.githubusercontent.com/964106/206676602-d63be58b-5cc2-4036-a555-2f354c4d4548.png)

## Before fix
![image](https://user-images.githubusercontent.com/964106/206677553-0f2d59d3-89a8-4c97-a3b8-f20380305e1d.png)

### After fix
![image](https://user-images.githubusercontent.com/964106/206677206-b16a91ad-b0a5-4b1c-bf32-45c328c0089e.png)



