### PR TITLE
Fix: Monika crashes when send an incident/recovery event

### DIFF
--- a/src/symon/index.ts
+++ b/src/symon/index.ts
@@ -191,6 +191,8 @@ class SymonClient {
             headers: args.validation.response.headers ?? {},
             body: args.validation.response.data,
           },
+        }).catch((error: any) => {
+          log.error(error)
         })
       }
     )


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
Fix Monika crashes when send an incident/recovery event. It resolves #959.

## How did you implement / how did you fix it  
Handle the unhandled error

## How to test  
1. Make the `/api/v1/monika/events` endpoint return HTTP status code < 200 or >= 300 on Symon
2. Run Symon
3. Run Monika

## Screenshot
Monika keeps running after get a fail response from Symon

### 1xx Error
![image](https://user-images.githubusercontent.com/15191978/207279752-d8caec03-b317-4f92-bbfb-606702709e8e.png)


### 3xx Error
![Screenshot from 2022-12-13 16-17-59](https://user-images.githubusercontent.com/15191978/207277687-d95b6a94-9254-4452-bdd2-3b2a7242aad5.png)


### 4xx Error
![handled-error](https://user-images.githubusercontent.com/15191978/207252437-f2e921e3-ab1e-4880-96aa-0cff5561b278.png)

### 5xx Error
![Screenshot from 2022-12-13 16-20-20](https://user-images.githubusercontent.com/15191978/207277759-5e843635-220a-4345-bdc2-ac2d759e81b6.png)

