### PR TITLE
Fixed: Improve Monika Config Type for TLS Checker

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,8 +3,7 @@
     "rules": {
         "no-use-before-define": ["warn", "nofunc"],
         "unicorn/prefer-node-protocol": "off",
-        "unicorn/no-array-reduce": "warn",
-        "unicorn/no-array-for-each": "warn"
+        "unicorn/no-array-reduce": "warn"
     },
     "overrides": [
         {
@@ -13,5 +12,6 @@
                 "unicorn/filename-case": "off"
             }
         }
-    ]
+    ],
+    "env": {"node": true}
 }

--- a/src/interfaces/certificate.ts
+++ b/src/interfaces/certificate.ts
@@ -22,8 +22,17 @@
  * SOFTWARE.                                                                      *
  **********************************************************************************/
 
+import type { RequestOptions } from 'https'
+
+type DomainWithOptions = {
+  domain: string
+  options?: RequestOptions
+}
+
+export type Domain = string | DomainWithOptions
+
 export interface Certificate {
-  domains: string[]
+  domains: Domain[]
   // The reminder is the number of days to send notification to user before the domain expires.
   reminder?: number
 }

--- a/src/jobs/tls-check.ts
+++ b/src/jobs/tls-check.ts
@@ -25,76 +25,97 @@
 import { getConfig } from '../components/config'
 import { saveNotificationLog } from '../components/logger/history'
 import { sendAlerts } from '../components/notification'
-import { checkTLS, TLSHostArg } from '../components/tls-checker'
+import { checkTLS, getHostname } from '../components/tls-checker'
+import type { Notification } from '../interfaces/notification'
 import type { ValidatedResponse } from '../plugins/validate-response'
 import { log } from '../utils/pino'
 
+type SendTLSErrorNotificationProps = {
+  hostname: string
+  notifications: Notification[]
+  errorMessage: string
+}
+
 export function tlsChecker(): void {
   const config = getConfig()
-  const isCertificateConfigEmpty =
-    config?.certificate && config?.certificate?.domains.length > 0
+  const hasDomain = (config?.certificate?.domains?.length || 0) > 0
 
-  if (isCertificateConfigEmpty) {
-    const { certificate } = config
-    const defaultExpiryReminder = 30
+  if (!hasDomain) {
+    return
+  }
 
-    certificate?.domains.forEach((domain: string | TLSHostArg) => {
-      const host = (domain as TLSHostArg)?.domain ?? (domain as string)
-      const reminder = certificate?.reminder ?? defaultExpiryReminder
-      const notifications = config?.notifications
+  const { certificate } = config
+  const defaultExpiryReminder = 30
 
-      log.info(`Running TLS check for ${host} every day at 00:00`)
+  for (const domain of certificate?.domains || []) {
+    const hostname = getHostname(domain)
+    const reminder = certificate?.reminder ?? defaultExpiryReminder
 
-      checkTLS(domain, reminder).catch((error) => {
-        log.error(error.message)
+    log.info(`Running TLS check for ${hostname} every day at 00:00`)
 
-        if (notifications && notifications?.length > 0) {
-          // TODO: Remove probe below
-          // probe is used because probe detail is needed to save the notification log
-          const probe = {
-            id: '',
-            name: '',
-            requests: [],
-            interval: 10,
-            incidentThreshold: 0,
-            recoveryThreshold: 0,
-            alerts: [],
-          }
+    checkTLS(domain, reminder).catch((error) => {
+      log.error(error.message)
 
-          for (const notification of notifications) {
-            // TODO: Remove validation below
-            // validation is used because it is needed to send alert
-            const validation: ValidatedResponse = {
-              alert: { assertion: '', message: error.message },
-              isAlertTriggered: true,
-              response: {
-                status: 500,
-                responseTime: 0,
-                data: {},
-                body: {},
-                headers: {},
-              },
-            }
+      const { notifications } = config
+      const hasNotification = (notifications?.length || 0) > 0
 
-            saveNotificationLog(
-              probe,
-              notification,
-              'NOTIFY-TLS',
-              error.message
-            ).catch((error) => log.error(error.message))
+      if (!hasNotification) {
+        return
+      }
 
-            // TODO: invoke sendNotifications function instead
-            // looks like the sendAlerts function does not handle this
-            sendAlerts({
-              probeID: '',
-              url: host,
-              probeState: 'invalid',
-              notifications: notifications ?? [],
-              validation,
-            }).catch((error) => log.error(error.message))
-          }
-        }
+      sendTLSErrorNotification({
+        hostname,
+        notifications: notifications || [],
+        errorMessage: error.message,
       })
     })
+  }
+}
+
+function sendTLSErrorNotification({
+  hostname,
+  notifications,
+  errorMessage,
+}: SendTLSErrorNotificationProps) {
+  // TODO: Remove probe below
+  // probe is used because probe detail is needed to save the notification log
+  const probe = {
+    id: '',
+    name: '',
+    requests: [],
+    interval: 10,
+    incidentThreshold: 0,
+    recoveryThreshold: 0,
+    alerts: [],
+  }
+
+  for (const notification of notifications) {
+    // TODO: Remove validation below
+    // validation is used because it is needed to send alert
+    const validation: ValidatedResponse = {
+      alert: { assertion: '', message: errorMessage },
+      isAlertTriggered: true,
+      response: {
+        status: 500,
+        responseTime: 0,
+        data: {},
+        body: {},
+        headers: {},
+      },
+    }
+
+    saveNotificationLog(probe, notification, 'NOTIFY-TLS', errorMessage).catch(
+      (error) => log.error(error.message)
+    )
+
+    // TODO: invoke sendNotifications function instead
+    // looks like the sendAlerts function does not handle this
+    sendAlerts({
+      probeID: '',
+      url: hostname,
+      probeState: 'invalid',
+      notifications: notifications ?? [],
+      validation,
+    }).catch((error) => log.error(error.message))
   }
 }


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
Improve Monika config type for TLS checker

## How did you implement / how did you fix it  
Replace the type for the Monika's certificate property

### Monika config for TLS checker
```yaml
 certificate:
   domains:
     - example.com
     - expired.badssl.com
     - domain: example.com
       options:
         path: '/foo'
   reminder: 30
```

### Type Before 
```typescript
export interface Certificate {
  domains: string[]
  // The reminder is the number of days to send notification to user before the domain expires.
  reminder?: number
}
```
### Type After

```typescript
import type { RequestOptions } from 'https'

type DomainWithOptions = {
  domain: string
  options?: RequestOptions
}

export type Domain = string | DomainWithOptions

export interface Certificate {
  domains: Domain[]
  // The reminder is the number of days to send notification to user before the domain expires.
  reminder?: number
}
```

## How to test  
Run Monika with the following config

```yaml
certificate:
  domains:
    - example.com
    - expired.badssl.com
    - domain: example.com
      options:
        path: /foo
  reminder: 30
```

