### PR TITLE
Chore: Make MSW Run on Node.js v18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,28 +11,12 @@ on:
         branches: [main]
 
 jobs:
-    build-on-node-14:
-        runs-on: ubuntu-latest
-
-        steps:
-            - uses: actions/checkout@v3
-            - name: Use Node.js 14.x
-              uses: actions/setup-node@v3
-              with:
-                  node-version: 14.x
-            - run: npm ci
-            - run: npm run build --if-present
-            - run: npm test && npx codecov
-            - run: npm pack
-            - run: npm install -g ./hyperjumptech-monika-*.tgz
-            - run: npm run prod_test
-
     build:
         runs-on: ubuntu-latest
 
         strategy:
             matrix:
-                node-version: [16.14, 18.x]
+                node-version: [14.x, 16.14]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:
@@ -41,6 +25,22 @@ jobs:
               uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node-version }}
+            - run: npm ci
+            - run: npm run build --if-present
+            - run: npm test && npx codecov
+            - run: npm pack
+            - run: npm install -g ./hyperjumptech-monika-*.tgz
+            - run: npm run prod_test
+
+    build-on-node-js-18:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v3
+            - name: Use Node.js 18.x
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18.x
             - run: npm ci
             - run: npm run build --if-present
             - run: NODE_OPTIONS='--no-experimental-fetch' npm test && npx codecov

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,12 +11,28 @@ on:
         branches: [main]
 
 jobs:
+    build-on-node-14:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v3
+            - name: Use Node.js 14.x
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 14.x
+            - run: npm ci
+            - run: npm run build --if-present
+            - run: npm test && npx codecov
+            - run: npm pack
+            - run: npm install -g ./hyperjumptech-monika-*.tgz
+            - run: npm run prod_test
+
     build:
         runs-on: ubuntu-latest
 
         strategy:
             matrix:
-                node-version: [14.x, 16.14]
+                node-version: [16.14, 18.x]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:
@@ -27,7 +43,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
             - run: npm ci
             - run: npm run build --if-present
-            - run: npm test && npx codecov
+            - run: NODE_OPTIONS='--no-experimental-fetch' npm test && npx codecov
             - run: npm pack
             - run: npm install -g ./hyperjumptech-monika-*.tgz
             - run: npm run prod_test

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "start": "npm run prepack && ./bin/dev",
     "start:windows": "npm run prepack && /bin/dev",
     "start:prod": "npm run prepack && ./bin/run",
-    "test": "npm run clean && cross-env NODE_ENV=test nyc --reporter=lcov --extension .ts mocha --config .mocharc.json --forbid-only \"{src,test}/**/*.test.ts\" --exclude test/cli.test.ts",
+    "test": "npm run clean && cross-env NODE_ENV=test NODE_OPTIONS='--no-experimental-fetch' nyc --reporter=lcov --extension .ts mocha --config .mocharc.json --forbid-only \"{src,test}/**/*.test.ts\" --exclude test/cli.test.ts",
     "cli-test": "npx bats test/bats/cli.bats",
     "prod_test": "npx bats prod_test/test.bats",
     "version": "oclif readme && git add README.md",
@@ -195,7 +195,6 @@
     "outputPath": "dist"
   },
   "volta": {
-    "node": "16.16.0",
-    "npm": "8.19.0"
+    "node": "18.12.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hyperjumptech/monika",
   "description": "Synthetic monitoring made easy",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "license": "MIT",
   "author": "@hyperjumptech",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hyperjumptech/monika",
   "description": "Synthetic monitoring made easy",
-  "version": "1.14.1",
+  "version": "1.14.0",
   "license": "MIT",
   "author": "@hyperjumptech",
   "main": "lib/index.js",
@@ -37,7 +37,7 @@
     "start": "npm run prepack && ./bin/dev",
     "start:windows": "npm run prepack && /bin/dev",
     "start:prod": "npm run prepack && ./bin/run",
-    "test": "npm run clean && cross-env NODE_ENV=test NODE_OPTIONS='--no-experimental-fetch' nyc --reporter=lcov --extension .ts mocha --config .mocharc.json --forbid-only \"{src,test}/**/*.test.ts\" --exclude test/cli.test.ts",
+    "test": "npm run clean && cross-env NODE_ENV=test nyc --reporter=lcov --extension .ts mocha --config .mocharc.json --forbid-only \"{src,test}/**/*.test.ts\" --exclude test/cli.test.ts",
     "cli-test": "npx bats test/bats/cli.bats",
     "prod_test": "npx bats prod_test/test.bats",
     "version": "oclif readme && git add README.md",
@@ -195,6 +195,7 @@
     "outputPath": "dist"
   },
   "volta": {
-    "node": "18.12.1"
+    "node": "16.16.0",
+    "npm": "8.19.0"
   }
 }


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
Make [MSW](https://github.com/mswjs/msw) run on Node.js v18. Relate to [PR 950](https://github.com/hyperjumptech/monika/pull/950).

## How did you implement / how did you fix it  
Add NODE_OPTIONS environment variable when run unit test to use old fetch from node < 18 when running the test.

## How to test  
1. Run `npm test` using Node.js v16
1. Run `npm test` using Node.js v18.

