### PR TITLE
SymonClient: Read Probes Checksum

### DIFF
--- a/src/symon/index.ts
+++ b/src/symon/index.ts
@@ -267,24 +267,24 @@ class SymonClient {
   private async fetchProbes() {
     log.debug('Getting probes from symon')
     return this.httpClient
-      .get<{ data: Probe[] }>(`/${this.monikaId}/probes`, {
-        headers: {
-          ...(this.configHash ? { 'If-None-Match': this.configHash } : {}),
-        },
-        validateStatus(status) {
-          return [200, 304].includes(status)
-        },
-      })
+      .get<{ data: { probes: Probe[]; checksum: string } }>(
+        `/${this.monikaId}/probes`,
+        {
+          validateStatus(status) {
+            return [200, 304].includes(status)
+          },
+        }
+      )
       .then((res) => {
         if (res.data.data) {
-          this.probes = res.data.data
+          this.probes = res.data.data.probes
 
-          log.debug(`Received ${res.data.data.length} probes`)
+          log.debug(`Received ${res.data.data.probes.length} probes`)
         } else {
           log.debug(`No new config from Symon`)
         }
 
-        return { probes: res.data.data, hash: res.headers.etag }
+        return { probes: res.data.data.probes, hash: res.data.data.checksum }
       })
       .catch((error) => {
         if (error.isAxiosError) {


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
This PR fixes #973

## How did you implement / how did you fix it  
Previously, when fetching probes from Symon, it checks for the eTag headers. This is a correct approach, but because of changing `lastEvent` property in the probes' data, it will always return unmatched eTag versions stored in the headers and the Monika instance.

So, we need to read the checksum FROM the response body instead of eTag as it is unreliable.

## How to test  
Run Monika in Symon mode

## Additional Context

Might need to merge the PR in the Symon repository.

