### PR TITLE
fix error when running -v and remove the unnecessary message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "tslib": "^1.14.1",
         "unzip-stream": "^0.3.1",
         "unzipper": "^0.10.11",
-        "xstate": "^4.24.0",
+        "xstate": "^4.35.0",
         "yaml": "1.10.2"
       },
       "bin": {
@@ -14308,9 +14308,9 @@
       }
     },
     "node_modules/xstate": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.24.0.tgz",
-      "integrity": "sha512-0gap+4mo0z4LjA0Wd+8EtB8L82ES0S3tjPGNXryqtsOvIDC53/mQGuyXqEHktvyONGO+dAFqcLIla6oSxexCqA==",
+      "version": "4.35.4",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.35.4.tgz",
+      "integrity": "sha512-mqRBYHhljP1xIItI4xnSQNHEv6CKslSM1cOGmvhmxeoDPAZgNbhSUYAL5N6DZIxRfpYY+M+bSm3mUFHD63iuvg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"
@@ -26142,9 +26142,9 @@
       "dev": true
     },
     "xstate": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.24.0.tgz",
-      "integrity": "sha512-0gap+4mo0z4LjA0Wd+8EtB8L82ES0S3tjPGNXryqtsOvIDC53/mQGuyXqEHktvyONGO+dAFqcLIla6oSxexCqA=="
+      "version": "4.35.4",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.35.4.tgz",
+      "integrity": "sha512-mqRBYHhljP1xIItI4xnSQNHEv6CKslSM1cOGmvhmxeoDPAZgNbhSUYAL5N6DZIxRfpYY+M+bSm3mUFHD63iuvg=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "tslib": "^1.14.1",
     "unzip-stream": "^0.3.1",
     "unzipper": "^0.10.11",
-    "xstate": "^4.24.0",
+    "xstate": "^4.35.0",
     "yaml": "1.10.2"
   },
   "devDependencies": {

--- a/src/components/notification/process-server-status.ts
+++ b/src/components/notification/process-server-status.ts
@@ -45,6 +45,7 @@ export const serverAlertStateInterpreters = new Map<
 export const serverAlertStateMachine = createMachine<ServerAlertStateContext>(
   {
     id: 'server-alerts-state',
+    predictableActionArguments: true,
     initial: 'UP',
     states: {
       UP: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -574,6 +574,13 @@ Please refer to the Monika documentations on how to how to configure notificatio
       return Errors.handle(error)
     }
 
+    if (error.message.includes('EEXIT: 0')) {
+      // this is normal exit, for example after running with --version,
+      // not an error so just quit immediately
+      // eslint-disable-next-line no-process-exit, unicorn/no-process-exit
+      process.exit(0)
+    }
+
     throw error
   }
 

--- a/src/utils/probe-state.ts
+++ b/src/utils/probe-state.ts
@@ -13,6 +13,7 @@ type ProbeStateContext = {
 const probeStateMachine = createMachine<ProbeStateValue, ProbeStateContext>(
   {
     id: 'probe-state',
+    predictableActionArguments: true,
     initial: 'idle',
     states: {
       idle: {


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Issue #982 and also fixes the error when running `monika -v` which causes the prod_test to fail.

## How did you implement / how did you fix it  
1.  Update the `catch` function in `src/index.ts` to exit immediately if the caught error contains `EEXIT: 0`. This string is in the error when oclif tries to exit normally for example after printing out the version.
2. Update the xstate then add `predictableActionArguments: true` as advised in the warning message.

## How to test  
1. `npm pack`
3. `npm install -g ./hyperjumptech-monika-*.tgz`
4. `monika -v` and `npm run prod_test`

```shell-session
npm pack

> @hyperjumptech/monika@1.15.0 prepack
> npm run clean && tsc -b && oclif manifest


> @hyperjumptech/monika@1.15.0 clean
> rm -rf coverage lib tsconfig.tsbuildinfo oclif.manifest.json

 ›   Warning: oclif update available from 3.0.1 to 3.4.2.
wrote manifest to /Users/nico/Projects/work/hyperjump/monika/oclif.manifest.json
npm notice
npm notice 📦  @hyperjumptech/monika@1.15.0
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE.txt
npm notice 3.5kB  README.md
npm notice 431B   bin/dev
npm notice 30B    bin/dev.cmd
npm notice 82B    bin/run
npm notice 31B    bin/run.cmd
npm notice 496B   db/migrations/20210504091802.sql
npm notice 1.6kB  db/migrations/20210510173100.sql
npm notice 102B   db/migrations/20210518173100.sql
npm notice 249B   db/migrations/20220411224500.sql
npm notice 497B   db/migrations/20221007151300_add_atlassian_status_page_incidents_table.sql
npm notice 1.9kB  lib/components/config/__tests__/create-config.test.d.ts
npm notice 10.2kB lib/components/config/__tests__/create-config.test.js
npm notice 3.6kB  lib/components/config/__tests__/mock_files/basic-postman_collection-v2.0.json
npm notice 4.6kB  lib/components/config/__tests__/mock_files/basic-postman_collection-v2.1.json
npm notice 8.8kB  lib/components/config/__tests__/mock_files/grouped-postman_collection-v2.0.json
npm notice 11.2kB lib/components/config/__tests__/mock_files/grouped-postman_collection-v2.1.json
npm notice 1.2kB  lib/components/config/__tests__/mock_files/postman_collection-unsupported.json
npm notice 1.9kB  lib/components/config/__tests__/parse-postman.test.d.ts
npm notice 12.8kB lib/components/config/__tests__/parse-postman.test.js
npm notice 2.1kB  lib/components/config/create-config.d.ts
npm notice 3.1kB  lib/components/config/create-config.js
npm notice 2.0kB  lib/components/config/fetch.d.ts
npm notice 2.4kB  lib/components/config/fetch.js
npm notice 2.5kB  lib/components/config/index.d.ts
npm notice 11.9kB lib/components/config/index.js
npm notice 2.1kB  lib/components/config/parse-har.d.ts
npm notice 3.4kB  lib/components/config/parse-har.js
npm notice 2.1kB  lib/components/config/parse-insomnia.d.ts
npm notice 6.2kB  lib/components/config/parse-insomnia.js
npm notice 2.1kB  lib/components/config/parse-postman.d.ts
npm notice 6.7kB  lib/components/config/parse-postman.js
npm notice 2.2kB  lib/components/config/parse-sitemap.d.ts
npm notice 5.5kB  lib/components/config/parse-sitemap.js
npm notice 4.0kB  lib/components/config/parse-text.d.ts
npm notice 3.8kB  lib/components/config/parse-text.js
npm notice 2.2kB  lib/components/config/parse.d.ts
npm notice 4.9kB  lib/components/config/parse.js
npm notice 2.1kB  lib/components/config/validate-config.d.ts
npm notice 3.4kB  lib/components/config/validate-config.js
npm notice 2.1kB  lib/components/config/validate.d.ts
npm notice 19.4kB lib/components/config/validate.js
npm notice 1.9kB  lib/components/http-request/http-request.test.d.ts
npm notice 17.9kB lib/components/http-request/http-request.test.js
npm notice 2.6kB  lib/components/http-request/index.d.ts
npm notice 10.5kB lib/components/http-request/index.js
npm notice 2.4kB  lib/components/icmp-request/index.d.ts
npm notice 3.7kB  lib/components/icmp-request/index.js
npm notice 5.9kB  lib/components/logger/history.d.ts
npm notice 16.6kB lib/components/logger/history.js
npm notice 2.1kB  lib/components/logger/index.d.ts
npm notice 3.4kB  lib/components/logger/index.js
npm notice 2.8kB  lib/components/logger/request-log.d.ts
npm notice 6.4kB  lib/components/logger/request-log.js
npm notice 2.3kB  lib/components/logger/response-time-log.d.ts
npm notice 4.0kB  lib/components/logger/response-time-log.js
npm notice 316B   lib/components/mariadb-request/index.d.ts
npm notice 1.7kB  lib/components/mariadb-request/index.js
npm notice 2.4kB  lib/components/mongodb-request/index.d.ts
npm notice 4.9kB  lib/components/mongodb-request/index.js
npm notice 1.9kB  lib/components/notification/__tests__/alert-message.test.d.ts
npm notice 7.4kB  lib/components/notification/__tests__/alert-message.test.js
npm notice 1.9kB  lib/components/notification/__tests__/process-server-status.test.d.ts
npm notice 9.4kB  lib/components/notification/__tests__/process-server-status.test.js
npm notice 2.8kB  lib/components/notification/alert-message.d.ts
npm notice 8.6kB  lib/components/notification/alert-message.js
npm notice 2.4kB  lib/components/notification/channel/desktop.d.ts
npm notice 4.2kB  lib/components/notification/channel/desktop.js
npm notice 2.2kB  lib/components/notification/channel/dingtalk.d.ts
npm notice 4.6kB  lib/components/notification/channel/dingtalk.js
npm notice 2.2kB  lib/components/notification/channel/discord.d.ts
npm notice 3.2kB  lib/components/notification/channel/discord.js
npm notice 2.2kB  lib/components/notification/channel/googlechat.d.ts
npm notice 11.0kB lib/components/notification/channel/googlechat.js
npm notice 2.2kB  lib/components/notification/channel/gotify.d.ts
npm notice 3.1kB  lib/components/notification/channel/gotify.js
npm notice 2.2kB  lib/components/notification/channel/lark.d.ts
npm notice 8.0kB  lib/components/notification/channel/lark.js
npm notice 2.2kB  lib/components/notification/channel/mailgun.d.ts
npm notice 2.8kB  lib/components/notification/channel/mailgun.js
npm notice 2.1kB  lib/components/notification/channel/monika-notif.d.ts
npm notice 2.6kB  lib/components/notification/channel/monika-notif.js
npm notice 2.2kB  lib/components/notification/channel/opsgenie.d.ts
npm notice 3.3kB  lib/components/notification/channel/opsgenie.js
npm notice 2.5kB  lib/components/notification/channel/pagerduty.d.ts
npm notice 4.9kB  lib/components/notification/channel/pagerduty.js
npm notice 1.9kB  lib/components/notification/channel/pagerduty.test.d.ts
npm notice 8.2kB  lib/components/notification/channel/pagerduty.test.js
npm notice 2.2kB  lib/components/notification/channel/pushbullet.d.ts
npm notice 3.6kB  lib/components/notification/channel/pushbullet.js
npm notice 2.2kB  lib/components/notification/channel/pushover.d.ts
npm notice 2.9kB  lib/components/notification/channel/pushover.js
npm notice 2.2kB  lib/components/notification/channel/sendgrid.d.ts
npm notice 2.6kB  lib/components/notification/channel/sendgrid.js
npm notice 2.2kB  lib/components/notification/channel/slack.d.ts
npm notice 8.0kB  lib/components/notification/channel/slack.js
npm notice 2.2kB  lib/components/notification/channel/smtp.d.ts
npm notice 3.4kB  lib/components/notification/channel/smtp.js
npm notice 2.2kB  lib/components/notification/channel/teams.d.ts
npm notice 7.3kB  lib/components/notification/channel/teams.js
npm notice 2.2kB  lib/components/notification/channel/telegram.d.ts
npm notice 2.8kB  lib/components/notification/channel/telegram.js
npm notice 2.1kB  lib/components/notification/channel/webhook.d.ts
npm notice 2.3kB  lib/components/notification/channel/webhook.js
npm notice 2.5kB  lib/components/notification/channel/whatsapp.d.ts
npm notice 4.4kB  lib/components/notification/channel/whatsapp.js
npm notice 2.1kB  lib/components/notification/channel/workplace.d.ts
npm notice 2.7kB  lib/components/notification/channel/workplace.js
npm notice 2.2kB  lib/components/notification/checker.d.ts
npm notice 4.6kB  lib/components/notification/checker.js
npm notice 2.7kB  lib/components/notification/index.d.ts
npm notice 13.3kB lib/components/notification/index.js
npm notice 3.2kB  lib/components/notification/process-server-status.d.ts
npm notice 6.9kB  lib/components/notification/process-server-status.js
npm notice 3.4kB  lib/components/notification/validator.d.ts
npm notice 7.6kB  lib/components/notification/validator.js
npm notice 2.3kB  lib/components/postgres-request/index.d.ts
npm notice 3.8kB  lib/components/postgres-request/index.js
npm notice 2.6kB  lib/components/probe/index.d.ts
npm notice 22.8kB lib/components/probe/index.js
npm notice 1.9kB  lib/components/probe/index.test.d.ts
npm notice 4.0kB  lib/components/probe/index.test.js
npm notice 2.4kB  lib/components/redis-request/index.d.ts
npm notice 4.1kB  lib/components/redis-request/index.js
npm notice 2.2kB  lib/components/reporter/index.d.ts
npm notice 2.0kB  lib/components/reporter/index.js
npm notice 2.2kB  lib/components/tcp-request/index.d.ts
npm notice 4.6kB  lib/components/tcp-request/index.js
npm notice 2.1kB  lib/components/tls-checker/index.d.ts
npm notice 3.1kB  lib/components/tls-checker/index.js
npm notice 1.9kB  lib/components/tls-checker/index.test.d.ts
npm notice 4.5kB  lib/components/tls-checker/index.test.js
npm notice 2.4kB  lib/context/index.d.ts
npm notice 3.3kB  lib/context/index.js
npm notice 1.0kB  lib/context/monika-flags.d.ts
npm notice 983B   lib/context/monika-flags.js
npm notice 2.3kB  lib/events/index.d.ts
npm notice 2.7kB  lib/events/index.js
npm notice 1.9kB  lib/events/subscribers/application.d.ts
npm notice 3.1kB  lib/events/subscribers/application.js
npm notice 1.9kB  lib/events/subscribers/probe.d.ts
npm notice 3.9kB  lib/events/subscribers/probe.js
npm notice 4.3kB  lib/index.d.ts
npm notice 23.7kB lib/index.js
npm notice 2.2kB  lib/interfaces/certificate.d.ts
npm notice 2.0kB  lib/interfaces/certificate.js
npm notice 2.4kB  lib/interfaces/config.d.ts
npm notice 2.0kB  lib/interfaces/config.js
npm notice 4.3kB  lib/interfaces/data.d.ts
npm notice 2.0kB  lib/interfaces/data.js
npm notice 2.1kB  lib/interfaces/mailgun.d.ts
npm notice 2.0kB  lib/interfaces/mailgun.js
npm notice 5.9kB  lib/interfaces/notification.d.ts
npm notice 2.0kB  lib/interfaces/notification.js
npm notice 2.1kB  lib/interfaces/probe-status.d.ts
npm notice 2.0kB  lib/interfaces/probe-status.js
npm notice 3.4kB  lib/interfaces/probe.d.ts
npm notice 2.0kB  lib/interfaces/probe.js
npm notice 2.6kB  lib/interfaces/request.d.ts
npm notice 2.0kB  lib/interfaces/request.js
npm notice 1.9kB  lib/interfaces/response.d.ts
npm notice 1.9kB  lib/interfaces/response.js
npm notice 2.0kB  lib/interfaces/validation.d.ts
npm notice 2.0kB  lib/interfaces/validation.js
npm notice 2.4kB  lib/interfaces/whatsapp.d.ts
npm notice 2.0kB  lib/interfaces/whatsapp.js
npm notice 2.0kB  lib/jobs/check-database.d.ts
npm notice 3.2kB  lib/jobs/check-database.js
npm notice 650B   lib/jobs/summary-notification.d.ts
npm notice 10.1kB lib/jobs/summary-notification.js
npm notice 2.0kB  lib/jobs/tls-check.d.ts
npm notice 5.2kB  lib/jobs/tls-check.js
npm notice 2.2kB  lib/loaders/index.d.ts
npm notice 4.3kB  lib/loaders/index.js
npm notice 43B    lib/loaders/jobs.d.ts
npm notice 2.7kB  lib/loaders/jobs.js
npm notice 2.8kB  lib/looper/index.d.ts
npm notice 7.5kB  lib/looper/index.js
npm notice 56.9kB lib/monika-config-schema.json
npm notice 2.5kB  lib/plugins/metrics/prometheus/collector.d.ts
npm notice 6.1kB  lib/plugins/metrics/prometheus/collector.js
npm notice 2.1kB  lib/plugins/metrics/prometheus/index.d.ts
npm notice 2.5kB  lib/plugins/metrics/prometheus/index.js
npm notice 2.0kB  lib/plugins/metrics/prometheus/publisher.d.ts
npm notice 3.1kB  lib/plugins/metrics/prometheus/publisher.js
npm notice 2.1kB  lib/plugins/updater/index.d.ts
npm notice 13.2kB lib/plugins/updater/index.js
npm notice 1.9kB  lib/plugins/validate-response/__tests__/index.test.d.ts
npm notice 7.0kB  lib/plugins/validate-response/__tests__/index.test.js
npm notice 1.9kB  lib/plugins/validate-response/checkers/__tests__/index.test.d.ts
npm notice 6.0kB  lib/plugins/validate-response/checkers/__tests__/index.test.js
npm notice 1.9kB  lib/plugins/validate-response/checkers/__tests__/query-expression.test.d.ts
npm notice 4.2kB  lib/plugins/validate-response/checkers/__tests__/query-expression.test.js
npm notice 2.2kB  lib/plugins/validate-response/checkers/index.d.ts
npm notice 3.2kB  lib/plugins/validate-response/checkers/index.js
npm notice 2.4kB  lib/plugins/validate-response/checkers/query-expression.d.ts
npm notice 2.8kB  lib/plugins/validate-response/checkers/query-expression.js
npm notice 2.7kB  lib/plugins/validate-response/index.d.ts
npm notice 2.8kB  lib/plugins/validate-response/index.js
npm notice 2.7kB  lib/plugins/visualization/atlassian-status-page/database.d.ts
npm notice 3.4kB  lib/plugins/visualization/atlassian-status-page/database.js
npm notice 2.7kB  lib/plugins/visualization/atlassian-status-page/index.d.ts
npm notice 6.7kB  lib/plugins/visualization/atlassian-status-page/index.js
npm notice 1.9kB  lib/symon/bree/report.d.ts
npm notice 4.7kB  lib/symon/bree/report.js
npm notice 3.5kB  lib/symon/index.d.ts
npm notice 16.0kB lib/symon/index.js
npm notice 1.9kB  lib/symon/index.test.d.ts
npm notice 11.7kB lib/symon/index.test.js
npm notice 2.2kB  lib/utils/authorization.d.ts
npm notice 3.0kB  lib/utils/authorization.js
npm notice 128B   lib/utils/check-probe-id.d.ts
npm notice 480B   lib/utils/check-probe-id.js
npm notice 2.0kB  lib/utils/events.d.ts
npm notice 2.2kB  lib/utils/events.js
npm notice 2.1kB  lib/utils/expression-parser.d.ts
npm notice 3.5kB  lib/utils/expression-parser.js
npm notice 2.2kB  lib/utils/fakes.d.ts
npm notice 5.1kB  lib/utils/fakes.js
npm notice 2.0kB  lib/utils/hash.d.ts
npm notice 2.3kB  lib/utils/hash.js
npm notice 2.1kB  lib/utils/http.d.ts
npm notice 3.2kB  lib/utils/http.js
npm notice 2.0kB  lib/utils/ip.d.ts
npm notice 2.5kB  lib/utils/ip.js
npm notice 2.0kB  lib/utils/is-valid-url.d.ts
npm notice 2.3kB  lib/utils/is-valid-url.js
npm notice 2.0kB  lib/utils/open-website.d.ts
npm notice 2.6kB  lib/utils/open-website.js
npm notice 2.2kB  lib/utils/ping.d.ts
npm notice 2.6kB  lib/utils/ping.js
npm notice 2.0kB  lib/utils/pino.d.ts
npm notice 2.8kB  lib/utils/pino.js
npm notice 591B   lib/utils/probe-state.d.ts
npm notice 2.7kB  lib/utils/probe-state.js
npm notice 2.3kB  lib/utils/public-ip.d.ts
npm notice 5.0kB  lib/utils/public-ip.js
npm notice 66B    lib/utils/text.d.ts
npm notice 290B   lib/utils/text.js
npm notice 34B    oclif.manifest.json
npm notice 5.5kB  package.json
npm notice 2.2kB  scripts/add-license.js
npm notice 4.7kB  scripts/monika-install.sh
npm notice === Tarball Details ===
npm notice name:          @hyperjumptech/monika
npm notice version:       1.15.0
npm notice filename:      @hyperjumptech/monika-1.15.0.tgz
npm notice package size:  109.8 kB
npm notice unpacked size: 948.6 kB
npm notice shasum:        3d7c4e5a272d01ae8302572e81807cfe618f3352
npm notice integrity:     sha512-HlHx8NHyI2e4N[...]aRgdR139dBmng==
npm notice total files:   243
npm notice
hyperjumptech-monika-1.15.0.tgz


npm install -g ./hyperjumptech-monika-*.tgz
npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.
npm WARN deprecated @npmcli/move-file@1.1.2: This functionality has been moved to @npmcli/fs
npm WARN deprecated querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.

changed 857 packages, and audited 858 packages in 33s

78 packages are looking for funding
  run `npm fund` for details

6 vulnerabilities (1 moderate, 4 high, 1 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.



monika -v
@hyperjumptech/monika/1.15.0 darwin-arm64 node-v16.16.0



npm run prod_test

> @hyperjumptech/monika@1.15.0 prod_test
> npx bats prod_test/test.bats

 ✓ shows version
 ✓ shows initializing file when no config
 ✓ shows starting message with valid json config
 ✓ shows starting message with valid yaml config

4 tests, 0 failures

node -v
v16.16.0

```
