### PR TITLE
CI: fix Node.js version matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [14.x, 16.14]
+                node-version: [14.x, 16.x]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:


### PR DESCRIPTION
Before this PR:

![image](https://user-images.githubusercontent.com/7288/218639818-0e1f3c12-b10d-40c0-b757-f491cf0efb47.png)

After this PR:

Note that it correctly grabs and installs Node.js v16.19 (the latest in the 16.x series).

![image](https://user-images.githubusercontent.com/7288/218639860-d6183fe3-fdc2-49fd-a782-0dd0d4af5252.png)
