### PR TITLE
update warning messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -384,7 +384,7 @@ class Monika extends Command {
   }
 
   async deprecationHandler(config: Config): Promise<Config> {
-    let showMessage = false
+    let showDeprecateMsg = false
 
     const checkedConfig = {
       ...config,
@@ -393,9 +393,8 @@ class Monika extends Command {
         requests: probe.requests?.map((request) => ({
           ...request,
           alert: request.alerts?.map((alert) => {
-            showMessage = true
-
             if (alert.query) {
+              showDeprecateMsg = true
               return { ...alert, assertion: alert.query }
             }
 
@@ -403,9 +402,8 @@ class Monika extends Command {
           }),
         })),
         alerts: probe.alerts?.map((alert) => {
-          showMessage = true
-
           if (alert.query) {
+            showDeprecateMsg = true
             return { ...alert, assertion: alert.query }
           }
 
@@ -414,7 +412,7 @@ class Monika extends Command {
       })),
     }
 
-    if (showMessage) {
+    if (showDeprecateMsg) {
       log.warn('"alerts.query" is deprecated. Please use "alerts.assertion"')
     }
 

--- a/src/looper/index.ts
+++ b/src/looper/index.ts
@@ -110,7 +110,7 @@ export function sanitizeProbe(isSymonMode: boolean, probe: Probe): Probe {
       },
     ]
     log.warn(
-      `Warning: Probe ${id} has no Alerts configuration defined. Using the default status-not-2xx and response-time-greater-than-2-s`
+      `Warning: Probe ${id} has no Alerts configuration defined. Using the default response.status != 200 and response.time > 20000`
     )
   }
 


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Clean up warning messages


## How did you implement / how did you fix it  
1. Fix an old default alert message
2. Show alerts.query deprecation warning only if used

## How to test  
1. use the following config
``` yaml
probes:
  - id: '1'
    name: 'status-200-test'
    requests:
      - url: https://httpbin.org/status/201
    alerts:
      - assertion: response.status < 200 or response.status > 299
        message: HTTP Status is not 200
      - assertion: response.time > 2000
        message: Response time is more than 2000ms
    incidentThreshold: 3
    recoveryThreshold: 3

notifications:
  - id: desktop
    type: desktop
```
2. Run `monika -c config.yaml` from above
3. Update the alert entry to 'alerts.query' to trigger the deprecated warning

## before PR
![image](https://user-images.githubusercontent.com/964106/229522122-db4a68f4-0657-4897-83af-bc609a06dba5.png)

## after PR
![image](https://user-images.githubusercontent.com/964106/229521397-c89d6797-7773-4eb5-833c-90a51f072f9e.png)

if alerts.query used
![image](https://user-images.githubusercontent.com/964106/229521754-a79415f2-b616-46ef-9b8a-8a7a500b88e9.png)

