### PR TITLE
CI: Test out the built binaries from PKG in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -51,7 +51,3 @@ jobs:
             - run: npm pack
             - run: npm install -g ./hyperjumptech-monika-*.tgz
             - run: npm run prod_test
-            - run: npm run pkg -- -t node16-linux-x64
-              name: Pack the binary using vercel/pkg
-            - run: ./dist/monika -v
-              name: Test if printing the version is not error

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,6 +31,10 @@ jobs:
             - run: npm pack
             - run: npm install -g ./hyperjumptech-monika-*.tgz
             - run: npm run prod_test
+            - run: npm run pkg -- -t node16-linux-x64
+              name: Pack the binary using vercel/pkg
+            - run: ./dist/monika -v
+              name: Test if printing the version is not error
 
     build-on-node-js-18:
         runs-on: ubuntu-latest
@@ -47,3 +51,7 @@ jobs:
             - run: npm pack
             - run: npm install -g ./hyperjumptech-monika-*.tgz
             - run: npm run prod_test
+            - run: npm run pkg -- -t node16-linux-x64
+              name: Pack the binary using vercel/pkg
+            - run: ./dist/monika -v
+              name: Test if printing the version is not error

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,57 +4,58 @@
 name: Node.js CI
 
 on:
-    workflow_dispatch:
-    push:
-        branches: [main]
-    pull_request:
-        branches: [main]
-
+  workflow_dispatch: null
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      
 jobs:
-    build:
-        runs-on: ubuntu-latest
-
-        strategy:
-            matrix:
-                node-version: [14.x, 16.x]
-                targets: [node14, node16]
-                # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
-        steps:
-            - uses: actions/checkout@v3
-            - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
-              with:
-                  node-version: ${{ matrix.node-version }}
-            - run: npm ci
-            - run: npm run build --if-present
-            - run: npm test && npx codecov
-            - run: npm pack
-            - run: npm install -g ./hyperjumptech-monika-*.tgz
-            - run: npm run prod_test
-            - run: npm run pkg -- -t ${{ matrix.targets }}-linux-x64
-              name: Pack the binary using vercel/pkg
-            - run: ./dist/monika -v
-              name: Test if printing the version is not error
-
-    build-on-node-js-18:
-        runs-on: ubuntu-latest
-
-        steps:
-            - uses: actions/checkout@v3
-            - name: Use Node.js 18.x
-              uses: actions/setup-node@v3
-              with:
-                  node-version: 18.x
-            - run: npm ci
-            - run: npm run build --if-present
-            - run: NODE_OPTIONS='--no-experimental-fetch' npm test && npx codecov
-            - run: npm pack
-            - run: npm install -g ./hyperjumptech-monika-*.tgz
-            - run: npm run prod_test
-            - run: |
-                echo "No node18 target supported yet, using node16..."
-                npm run pkg -- -t node16-linux-x64
-              name: Pack the binary using vercel/pkg
-            - run: ./dist/monika -v
-              name: Test if printing the version is not error
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - node-version: 14.x
+            targets: node14
+          - node-version: 16.x
+            targets: node16
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Use Node.js ${{ matrix.node-version }}'
+        uses: actions/setup-node@v3
+        with:
+          node-version: '${{ matrix.node-version }}'
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test && npx codecov
+      - run: npm pack
+      - run: npm install -g ./hyperjumptech-monika-*.tgz
+      - run: npm run prod_test
+      - run: 'npm run pkg -- -t ${{ matrix.targets }}-linux-x64'
+        name: Pack the binary using vercel/pkg
+      - run: ./dist/monika -v
+        name: Test if printing the version is not error
+        
+  build-on-node-js-18:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: NODE_OPTIONS='--no-experimental-fetch' npm test && npx codecov
+      - run: npm pack
+      - run: npm install -g ./hyperjumptech-monika-*.tgz
+      - run: npm run prod_test
+      - run: |
+          echo "No node18 target supported yet, using node16..."
+          npm run pkg -- -t node16-linux-x64
+        name: Pack the binary using vercel/pkg
+      - run: ./dist/monika -v
+        name: Test if printing the version is not error

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,6 +17,7 @@ jobs:
         strategy:
             matrix:
                 node-version: [14.x, 16.x]
+                targets: [node14, node16]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:
@@ -31,7 +32,7 @@ jobs:
             - run: npm pack
             - run: npm install -g ./hyperjumptech-monika-*.tgz
             - run: npm run prod_test
-            - run: npm run pkg -- -t node16-linux-x64
+            - run: npm run pkg -- -t ${{ matrix.targets }}-linux-x64
               name: Pack the binary using vercel/pkg
             - run: ./dist/monika -v
               name: Test if printing the version is not error
@@ -51,3 +52,9 @@ jobs:
             - run: npm pack
             - run: npm install -g ./hyperjumptech-monika-*.tgz
             - run: npm run prod_test
+            - run: |
+                echo "No node18 target supported yet, using node16..."
+                npm run pkg -- -t node16-linux-x64
+              name: Pack the binary using vercel/pkg
+            - run: ./dist/monika -v
+              name: Test if printing the version is not error


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
This PR solves #1031 

## How did you implement / how did you fix it  
1. Add some steps to building Monika using PKG according to the environment matrixes
2. Run the built Monika by checking the version (previously when it broke, it showed an error even if we checked the version)

## How to test  
1. Run the workflow manually

## Are there any screenshots/videos?
No, but take a look at the action in my fork: https://github.com/dennypradipta/monika/actions/runs/4719370222/jobs/8370101810

## Additional context

1. Approximately 9~10 extra minutes are needed to build and run the Monika binary.
2. In the `build-on-node-js-18` action, I use node16 because there is no explicit node18 target in pkg (nodeRanges available: node8, node10, node12, node14, node16 or latest)