### PR TITLE
Refactoring: Extract the Get Config Function

### DIFF
--- a/src/components/config/get.test.ts
+++ b/src/components/config/get.test.ts
@@ -1,0 +1,75 @@
+/**********************************************************************************
+ * MIT License                                                                    *
+ *                                                                                *
+ * Copyright (c) 2021 Hyperjump Technology                                        *
+ *                                                                                *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy   *
+ * of this software and associated documentation files (the "Software"), to deal  *
+ * in the Software without restriction, including without limitation the rights   *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      *
+ * copies of the Software, and to permit persons to whom the Software is          *
+ * furnished to do so, subject to the following conditions:                       *
+ *                                                                                *
+ * The above copyright notice and this permission notice shall be included in all *
+ * copies or substantial portions of the Software.                                *
+ *                                                                                *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  *
+ * SOFTWARE.                                                                      *
+ **********************************************************************************/
+
+import { expect } from '@oclif/test'
+import type { Config } from '../../interfaces/config'
+import { addDefaultNotifications } from './get'
+
+describe('Add default notification', () => {
+  it('should add default notification', () => {
+    // arrange
+    const config: Partial<Config> = {
+      probes: [],
+    }
+
+    // act
+    const newConfig = addDefaultNotifications(config)
+
+    // assert
+    expect(newConfig).deep.eq({
+      probes: [],
+      notifications: [{ id: 'default', type: 'desktop', data: undefined }],
+    })
+  })
+
+  it('should add default notification (empty config)', () => {
+    // arrange
+    const config: Partial<Config> = {}
+
+    // act
+    const newConfig = addDefaultNotifications(config)
+
+    // assert
+    expect(newConfig).deep.eq({
+      notifications: [{ id: 'default', type: 'desktop', data: undefined }],
+    })
+  })
+
+  it('should override existing notification', () => {
+    // arrange
+    const config: Partial<Config> = {
+      notifications: [
+        { id: '1', type: 'webhook', data: 'https://example.com' },
+      ],
+    }
+
+    // act
+    const newConfig = addDefaultNotifications(config)
+
+    // assert
+    expect(newConfig).deep.eq({
+      notifications: [{ id: 'default', type: 'desktop', data: undefined }],
+    })
+  })
+})

--- a/src/components/config/get.ts
+++ b/src/components/config/get.ts
@@ -1,0 +1,123 @@
+import type { MonikaFlags } from '../../context/monika-flags'
+import type { Config } from '../../interfaces/config'
+import { log } from '../../utils/pino'
+import { parseConfig } from './parse'
+
+export type ConfigType =
+  | 'monika'
+  | 'har'
+  | 'insomnia'
+  | 'postman'
+  | 'sitemap'
+  | 'text'
+
+export async function getConfigFrom(flags: MonikaFlags): Promise<Config> {
+  const defaultConfigs = await parseDefaultConfig(flags)
+  const nonDefaultConfig = setDefaultNotifications(
+    defaultConfigs,
+    await getNonDefaultFlags(flags)
+  )
+
+  return mergeConfigs(defaultConfigs, nonDefaultConfig)
+}
+
+// mergeConfigs merges configs by overwriting each other
+// with initial value taken from nonDefaultConfig
+export function mergeConfigs(
+  defaultConfigs: Partial<Config>[],
+  nonDefaultConfig: Partial<Config>
+): Config {
+  if (defaultConfigs.length === 0 && nonDefaultConfig !== undefined) {
+    return nonDefaultConfig as Config
+  }
+
+  // eslint-disable-next-line unicorn/no-array-reduce
+  const mergedConfig = defaultConfigs.reduce((prev, current) => {
+    return {
+      ...prev,
+      ...current,
+      notifications: current.notifications || prev.notifications,
+      probes: current.probes || prev.probes,
+    }
+  }, nonDefaultConfig || {})
+
+  return mergedConfig as Config
+}
+
+export function addDefaultNotifications(
+  config: Partial<Config>
+): Partial<Config> {
+  log.info('Notifications not found, using desktop as default...')
+  return {
+    ...config,
+    notifications: [{ id: 'default', type: 'desktop', data: undefined }],
+  }
+}
+
+async function parseDefaultConfig(
+  flags: MonikaFlags
+): Promise<Partial<Config>[]> {
+  return Promise.all(
+    flags.config.map((source) => parseConfigType(source, 'monika', flags))
+  )
+}
+
+async function parseConfigType(
+  source: string,
+  configType: ConfigType,
+  flags: MonikaFlags
+): Promise<Partial<Config>> {
+  const parsed = await parseConfig(source, configType, flags)
+
+  return {
+    ...parsed,
+    probes: parsed.probes?.map((probe) => {
+      const requests =
+        probe?.requests?.map((request) => ({
+          ...request,
+          timeout: request.timeout ?? 10_000,
+        })) ?? []
+
+      const interval = () => {
+        if (typeof probe?.interval === 'number') return probe.interval
+        return requests.length * 10 === 0 ? 10 : requests.length * 10
+      }
+
+      return { ...probe, interval: interval(), requests }
+    }),
+  }
+}
+
+async function getNonDefaultFlags(
+  flags: MonikaFlags
+): Promise<Partial<Config>> {
+  let result = {}
+
+  if (flags.har) {
+    result = await parseConfigType(flags.har, 'har', flags)
+  } else if (flags.postman) {
+    result = await parseConfigType(flags.postman, 'postman', flags)
+  } else if (flags.insomnia) {
+    result = await parseConfigType(flags.insomnia, 'insomnia', flags)
+  } else if (flags.sitemap) {
+    result = await parseConfigType(flags.sitemap, 'sitemap', flags)
+  } else if (flags.text) {
+    result = await parseConfigType(flags.text, 'text', flags)
+  }
+
+  return result
+}
+
+function setDefaultNotifications(
+  defaultConfigs: Partial<Config>[],
+  nonDefaultConfig: Partial<Config>
+): Partial<Config> {
+  const hasDefaultConfig = defaultConfigs.length > 0
+  const hasNonDefaultConfig = Object.keys(nonDefaultConfig).length > 0
+
+  if (!hasDefaultConfig && hasNonDefaultConfig) {
+    return addDefaultNotifications(nonDefaultConfig)
+  }
+
+  return nonDefaultConfig
+}


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
As a part of refactoring, I extracted the get config function to make it reusable in other part of the code

## How did you implement / how did you fix it  
1. Split the sanitize flag, get config, merge config, and update config phase
2. Extract the get config function

## How to test  
1. Run the test
2. Run Monika as usual
