### PR TITLE
Refactoring: Separate Initialize and Update Config

### DIFF
--- a/src/components/config/index.test.ts
+++ b/src/components/config/index.test.ts
@@ -23,7 +23,7 @@
  **********************************************************************************/
 
 import { expect } from '@oclif/test'
-import { getConfig } from '.'
+import { getConfig, isSymonModeFrom } from '.'
 import { resetContext, setContext } from '../../context'
 
 describe('getConfig', () => {
@@ -56,5 +56,51 @@ describe('getConfig', () => {
 
     // assert
     expect(getConfig()).to.deep.eq(config)
+  })
+})
+
+describe('isSymonModeFrom', () => {
+  it('should return true', () => {
+    // act
+    const isSymonMode = isSymonModeFrom({
+      symonKey: 'secret-key',
+      symonUrl: 'https://example.com',
+    })
+
+    // assert
+    expect(isSymonMode).eq(true)
+  })
+
+  it('should return false when symon key and url is empty', () => {
+    // act
+    const isSymonMode = isSymonModeFrom({
+      symonKey: '',
+      symonUrl: '',
+    })
+
+    // assert
+    expect(isSymonMode).eq(false)
+  })
+
+  it('should return false when symon key is empty', () => {
+    // act
+    const isSymonMode = isSymonModeFrom({
+      symonKey: '',
+      symonUrl: 'https://example.com',
+    })
+
+    // assert
+    expect(isSymonMode).eq(false)
+  })
+
+  it('should return false when symon url is empty', () => {
+    // act
+    const isSymonMode = isSymonModeFrom({
+      symonKey: 'secret-key',
+      symonUrl: '',
+    })
+
+    // assert
+    expect(isSymonMode).eq(false)
   })
 })

--- a/src/components/config/index.test.ts
+++ b/src/components/config/index.test.ts
@@ -22,60 +22,39 @@
  * SOFTWARE.                                                                      *
  **********************************************************************************/
 
-import type { Config } from '../interfaces/config'
-import { monikaFlagsDefaultValue } from './monika-flags'
-import type { MonikaFlags } from './monika-flags'
+import { expect } from '@oclif/test'
+import { getConfig } from '.'
+import { resetContext, setContext } from '../../context'
 
-type Incident = {
-  probeID: string
-  probeRequestURL: string
-  createdAt: Date
-}
+describe('getConfig', () => {
+  afterEach(() => {
+    resetContext()
+  })
 
-type Context = {
-  // userAgent example: @hyperjumptech/monika/1.2.3 linux-x64 node-14.17.0
-  userAgent: string
-  incidents: Incident[]
-  config?: Config
-  flags: MonikaFlags
-}
+  it('should throw error when config is empty', () => {
+    expect(() => getConfig()).to.throw(
+      'Configuration setup has not been run yet'
+    )
+  })
 
-type NewContext = Partial<Context>
+  it('should return config', () => {
+    // arrange
+    const config = {
+      probes: [
+        {
+          id: '1',
+          name: 'example',
+          interval: 1000,
+          incidentThreshold: 1,
+          recoveryThreshold: 1,
+          alerts: [],
+          requests: [{ body: '', url: 'https://example.com', timeout: 1000 }],
+        },
+      ],
+    }
+    setContext({ config })
 
-const initialContext: Context = {
-  userAgent: '',
-  incidents: [],
-  flags: {
-    config: monikaFlagsDefaultValue.config,
-    'config-filename': monikaFlagsDefaultValue['config-filename'],
-    'config-interval': monikaFlagsDefaultValue['config-interval'],
-    'create-config': false,
-    flush: false,
-    'follow-redirects': monikaFlagsDefaultValue['follow-redirects'],
-    force: false,
-    help: false,
-    'keep-verbose-logs': false,
-    logs: false,
-    'max-start-delay': monikaFlagsDefaultValue['max-start-delay'],
-    'one-probe': false,
-    repeat: 0,
-    stun: monikaFlagsDefaultValue.stun,
-    summary: false,
-    verbose: false,
-    version: undefined,
-  },
-}
-
-let context: Context = initialContext
-
-export function getContext(): Context {
-  return context
-}
-
-export function setContext(newContext: NewContext): void {
-  context = { ...context, ...newContext }
-}
-
-export function resetContext(): void {
-  context = initialContext
-}
+    // assert
+    expect(getConfig()).to.deep.eq(config)
+  })
+})

--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -77,12 +77,15 @@ export const getConfig = (): Config => {
   return config
 }
 
-export async function* getConfigIterator(
-  skipConfigCheck = true
-): AsyncGenerator<Config, void, undefined> {
+export async function* getConfigIterator(): AsyncGenerator<
+  Config,
+  void,
+  undefined
+> {
   const config = getConfig()
+  const { flags } = getContext()
 
-  if (!skipConfigCheck && !config)
+  if (!isSymonModeFrom(flags) && !config)
     throw new Error('Configuration setup has not been run yet')
 
   yield config

--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -95,11 +95,11 @@ export const updateConfig = async (
     }
   }
 
-  const newConfigVersion = config.version || md5Hash(config)
-  const hasChangeConfig = getContext()?.config?.version !== newConfigVersion
+  const version = md5Hash(config)
+  const hasChangeConfig = getContext()?.config?.version !== version
 
   if (hasChangeConfig) {
-    const newConfig = { ...config, version: newConfigVersion }
+    const newConfig = { ...config, version }
 
     setContext({ config: newConfig })
     emitter.emit(events.config.updated, newConfig)

--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -319,3 +319,10 @@ export const createConfig = async (flags: MonikaFlags): Promise<void> => {
     log.info(`${file} file has been created.`)
   }
 }
+
+export function isSymonModeFrom({
+  symonKey,
+  symonUrl,
+}: Pick<MonikaFlags, 'symonKey' | 'symonUrl'>): boolean {
+  return Boolean(symonUrl) && Boolean(symonKey)
+}

--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -26,7 +26,6 @@ import chokidar from 'chokidar'
 import { CliUx } from '@oclif/core'
 import { existsSync, writeFileSync } from 'fs'
 import isUrl from 'is-url'
-import pEvent from 'p-event'
 
 import events from '../../events'
 import type { Config } from '../../interfaces/config'
@@ -77,24 +76,6 @@ export const getConfig = (): Config => {
   return config
 }
 
-export async function* getConfigIterator(): AsyncGenerator<
-  Config,
-  void,
-  undefined
-> {
-  const config = getConfig()
-  const { flags } = getContext()
-
-  if (!isSymonModeFrom(flags) && !config)
-    throw new Error('Configuration setup has not been run yet')
-
-  yield config
-
-  if (!isTestEnvironment) {
-    yield* pEvent.iterator<string, Config>(emitter, events.config.updated)
-  }
-}
-
 export const updateConfig = async (
   config: Config,
   validate = true
@@ -115,9 +96,9 @@ export const updateConfig = async (
   }
 
   const newConfigVersion = config.version || md5Hash(config)
-  const hasConfigChange = getContext()?.config?.version !== newConfigVersion
+  const hasChangeConfig = getContext()?.config?.version !== newConfigVersion
 
-  if (hasConfigChange) {
+  if (hasChangeConfig) {
     const newConfig = { ...config, version: newConfigVersion }
 
     setContext({ config: newConfig })

--- a/src/components/logger/startup-message.test.ts
+++ b/src/components/logger/startup-message.test.ts
@@ -72,10 +72,13 @@ describe('Startup message', () => {
       // act
       logStartupMessage({
         config: { probes: [] },
-        configFlag: [],
+        flags: {
+          config: [],
+          symonKey: 'secret-key',
+          symonUrl: 'https://example.com',
+          verbose: false,
+        },
         isFirstRun: false,
-        isSymonMode: true,
-        isVerbose: false,
       })
 
       // assert
@@ -89,10 +92,8 @@ describe('Startup message', () => {
         // arrange
         logStartupMessage({
           config: { probes: [] },
-          configFlag: [],
+          flags: { config: [], symonKey: '', symonUrl: '', verbose: false },
           isFirstRun: false,
-          isSymonMode: false,
-          isVerbose: false,
         })
 
         // assert
@@ -105,10 +106,8 @@ describe('Startup message', () => {
         // arrange
         logStartupMessage({
           config: defaultConfig,
-          configFlag: [],
+          flags: { config: [], symonKey: '', symonUrl: '', verbose: false },
           isFirstRun: true,
-          isSymonMode: false,
-          isVerbose: false,
         })
 
         // assert
@@ -119,10 +118,8 @@ describe('Startup message', () => {
         // arrange
         logStartupMessage({
           config: defaultConfig,
-          configFlag: [],
+          flags: { config: [], symonKey: '', symonUrl: '', verbose: false },
           isFirstRun: false,
-          isSymonMode: false,
-          isVerbose: false,
         })
 
         // assert
@@ -133,10 +130,8 @@ describe('Startup message', () => {
         // arrange
         logStartupMessage({
           config: defaultConfig,
-          configFlag: [],
+          flags: { config: [], symonKey: '', symonUrl: '', verbose: false },
           isFirstRun: true,
-          isSymonMode: false,
-          isVerbose: false,
         })
 
         // assert
@@ -151,10 +146,8 @@ describe('Startup message', () => {
             ...defaultConfig,
             notifications: [],
           },
-          configFlag: [],
+          flags: { config: [], symonKey: '', symonUrl: '', verbose: false },
           isFirstRun: true,
-          isSymonMode: false,
-          isVerbose: false,
         })
 
         // assert
@@ -177,10 +170,8 @@ describe('Startup message', () => {
               },
             ],
           },
-          configFlag: [],
+          flags: { config: [], symonKey: '', symonUrl: '', verbose: true },
           isFirstRun: true,
-          isSymonMode: false,
-          isVerbose: true,
         })
         // assert
         expect(consoleLogMessage).include('uYJaw')
@@ -206,10 +197,8 @@ describe('Startup message', () => {
               },
             ],
           },
-          configFlag: [],
+          flags: { config: [], symonKey: '', symonUrl: '', verbose: true },
           isFirstRun: true,
-          isSymonMode: false,
-          isVerbose: true,
         })
         // assert
         expect(consoleLogMessage).include('uYJaw')
@@ -224,10 +213,8 @@ describe('Startup message', () => {
         // arrange
         logStartupMessage({
           config: defaultConfig,
-          configFlag: [],
+          flags: { config: [], symonKey: '', symonUrl: '', verbose: true },
           isFirstRun: true,
-          isSymonMode: false,
-          isVerbose: true,
         })
         // assert
         expect(consoleLogMessage).include('GET')
@@ -260,10 +247,8 @@ describe('Startup message', () => {
               },
             ],
           },
-          configFlag: [],
+          flags: { config: [], symonKey: '', symonUrl: '', verbose: true },
           isFirstRun: true,
-          isSymonMode: false,
-          isVerbose: true,
         })
         // assert
         expect(consoleLogMessage).include('POST')
@@ -276,10 +261,8 @@ describe('Startup message', () => {
         // arrange
         logStartupMessage({
           config: defaultConfig,
-          configFlag: [],
+          flags: { config: [], symonKey: '', symonUrl: '', verbose: true },
           isFirstRun: true,
-          isSymonMode: false,
-          isVerbose: true,
         })
         // assert
         expect(consoleLogMessage).include(
@@ -304,10 +287,8 @@ describe('Startup message', () => {
               },
             ],
           },
-          configFlag: [],
+          flags: { config: [], symonKey: '', symonUrl: '', verbose: true },
           isFirstRun: true,
-          isSymonMode: false,
-          isVerbose: true,
         })
         // assert
         expect(consoleLogMessage).include(
@@ -324,10 +305,8 @@ describe('Startup message', () => {
             ...defaultConfig,
             notifications: [{ id: 'UVIsL', type: 'desktop', data: undefined }],
           },
-          configFlag: [],
+          flags: { config: [], symonKey: '', symonUrl: '', verbose: true },
           isFirstRun: true,
-          isSymonMode: false,
-          isVerbose: true,
         })
         // assert
         expect(consoleLogMessage).include('Notifications')
@@ -354,10 +333,8 @@ describe('Startup message', () => {
               },
             ],
           },
-          configFlag: [],
+          flags: { config: [], symonKey: '', symonUrl: '', verbose: true },
           isFirstRun: true,
-          isSymonMode: false,
-          isVerbose: true,
         })
         // assert
         expect(consoleLogMessage).include('john@example.com, jane@example.com')
@@ -383,10 +360,8 @@ describe('Startup message', () => {
               },
             ],
           },
-          configFlag: [],
+          flags: { config: [], symonKey: '', symonUrl: '', verbose: true },
           isFirstRun: true,
-          isSymonMode: false,
-          isVerbose: true,
         })
         // assert
         expect(consoleLogMessage).include('https://example.com')
@@ -407,10 +382,8 @@ describe('Startup message', () => {
               },
             ],
           },
-          configFlag: [],
+          flags: { config: [], symonKey: '', symonUrl: '', verbose: true },
           isFirstRun: true,
-          isSymonMode: false,
-          isVerbose: true,
         })
         // assert
         expect(consoleLogMessage).include('https://example.com')
@@ -423,10 +396,13 @@ describe('Startup message', () => {
       // act
       logStartupMessage({
         config: defaultConfig,
-        configFlag: ['https://example.com/monika.yaml'],
+        flags: {
+          config: ['https://example.com/monika.yaml'],
+          symonKey: '',
+          symonUrl: '',
+          verbose: false,
+        },
         isFirstRun: false,
-        isSymonMode: false,
-        isVerbose: false,
       })
 
       // assert
@@ -437,10 +413,13 @@ describe('Startup message', () => {
       // act
       logStartupMessage({
         config: defaultConfig,
-        configFlag: ['./monika.yaml'],
+        flags: {
+          config: ['./monika.yaml'],
+          symonKey: '',
+          symonUrl: '',
+          verbose: false,
+        },
         isFirstRun: false,
-        isSymonMode: false,
-        isVerbose: false,
       })
 
       // assert

--- a/src/components/logger/startup-message.ts
+++ b/src/components/logger/startup-message.ts
@@ -46,25 +46,24 @@ export function logStartupMessage({
   flags,
   isFirstRun,
 }: LogStartupMessage): void {
+  if (isSymonModeFrom(flags)) {
+    log.info('Running in Symon mode')
+    return
+  }
+
+  for (const configSource of flags.config) {
+    if (isUrl(configSource)) {
+      log.info(`Using remote config: ${configSource}`)
+    } else if (configSource.length > 0) {
+      log.info(`Using config file: ${path.resolve(configSource)}`)
+    }
+  }
+
   const startupMessage = generateStartupMessage({
     config,
     flags,
     isFirstRun,
   })
-
-  if (isSymonModeFrom(flags)) {
-    log.info(startupMessage)
-    return
-  }
-
-  for (const cfg of flags.config) {
-    if (isUrl(cfg)) {
-      log.info('Using remote config:', cfg)
-    } else if (cfg.length > 0) {
-      log.info(`Using config file: ${path.resolve(cfg)}`)
-    }
-  }
-
   console.log(startupMessage)
 }
 
@@ -73,10 +72,6 @@ function generateStartupMessage({
   flags,
   isFirstRun,
 }: LogStartupMessage): string {
-  if (isSymonModeFrom(flags)) {
-    return 'Running in Symon mode'
-  }
-
   const { notifications = [], probes } = config
   const notificationTotal = notifications.length
   const probeTotal = probes.length

--- a/src/components/notification/schedule-notification.test.ts
+++ b/src/components/notification/schedule-notification.test.ts
@@ -38,7 +38,10 @@ describe('Schedule notification', () => {
   describe('Schedule summary notification', () => {
     it('should not schedule notification on Symon mode', () => {
       // act
-      scheduleSummaryNotification({ isSymonMode: true })
+      scheduleSummaryNotification({
+        config: {},
+        flags: { symonKey: 'secret-key', symonUrl: 'https://example.com' },
+      })
 
       // assert
       sinon.assert.notCalled(cronScheduleStub)
@@ -47,8 +50,8 @@ describe('Schedule notification', () => {
     it('should not schedule notification if status notification flag is false', () => {
       // act
       scheduleSummaryNotification({
-        isSymonMode: false,
-        statusNotificationFlag: 'false',
+        config: {},
+        flags: { 'status-notification': 'false' },
       })
 
       // assert
@@ -58,9 +61,10 @@ describe('Schedule notification', () => {
     it('should schedule notification based on notification flag value', () => {
       // act
       scheduleSummaryNotification({
-        isSymonMode: false,
-        statusNotificationFlag: '* * * * *',
-        statusNotificationConfig: '0 0 0 0 0',
+        config: { 'status-notification': '0 0 0 0 0' },
+        flags: {
+          'status-notification': '* * * * *',
+        },
       })
 
       // assert
@@ -71,8 +75,8 @@ describe('Schedule notification', () => {
     it('should schedule notification based on notification config value', () => {
       // act
       scheduleSummaryNotification({
-        isSymonMode: false,
-        statusNotificationConfig: '0 0 0 0 0',
+        config: { 'status-notification': '0 0 0 0 0' },
+        flags: {},
       })
 
       // assert
@@ -82,9 +86,7 @@ describe('Schedule notification', () => {
 
     it('should schedule notification use default schedule', () => {
       // act
-      scheduleSummaryNotification({
-        isSymonMode: false,
-      })
+      scheduleSummaryNotification({ config: {}, flags: {} })
 
       // assert
       sinon.assert.calledOnce(cronScheduleStub)
@@ -95,12 +97,8 @@ describe('Schedule notification', () => {
   describe('Reset schedule notification', () => {
     it('should stop all running scheduled notification', () => {
       // arrange
-      scheduleSummaryNotification({
-        isSymonMode: false,
-      })
-      scheduleSummaryNotification({
-        isSymonMode: false,
-      })
+      scheduleSummaryNotification({ config: {}, flags: {} })
+      scheduleSummaryNotification({ config: {}, flags: {} })
 
       // act
       resetScheduledTasks()

--- a/src/components/notification/schedule-notification.test.ts
+++ b/src/components/notification/schedule-notification.test.ts
@@ -2,10 +2,7 @@ import cron from 'node-cron'
 import sinon from 'sinon'
 import chai, { expect } from 'chai'
 import spies from 'chai-spies'
-import {
-  resetScheduledTasks,
-  scheduleSummaryNotification,
-} from './schedule-notification'
+import { scheduleSummaryNotification } from './schedule-notification'
 
 chai.use(spies)
 
@@ -31,7 +28,6 @@ describe('Schedule notification', () => {
   afterEach(() => {
     sinon.restore()
     cronExpression = ''
-    resetScheduledTasks()
     taskStopCalledTotal = 0
   })
 
@@ -96,12 +92,9 @@ describe('Schedule notification', () => {
 
   describe('Reset schedule notification', () => {
     it('should stop all running scheduled notification', () => {
-      // arrange
-      scheduleSummaryNotification({ config: {}, flags: {} })
-      scheduleSummaryNotification({ config: {}, flags: {} })
-
       // act
-      resetScheduledTasks()
+      scheduleSummaryNotification({ config: {}, flags: {} })
+      scheduleSummaryNotification({ config: {}, flags: {} })
 
       // arrange
       expect(taskStopCalledTotal).eq(2)

--- a/src/components/notification/schedule-notification.ts
+++ b/src/components/notification/schedule-notification.ts
@@ -1,11 +1,13 @@
 import cron from 'node-cron'
 import type { ScheduledTask } from 'node-cron'
+import type { MonikaFlags } from '../../context/monika-flags'
+import type { Config } from '../../interfaces/config'
 import { getSummaryAndSendNotif } from '../../jobs/summary-notification'
+import { isSymonModeFrom } from '../config'
 
 type scheduleSummaryNotification = {
-  isSymonMode: boolean
-  statusNotificationConfig?: string
-  statusNotificationFlag?: string
+  config: Pick<Config, 'status-notification'>
+  flags: Pick<MonikaFlags, 'status-notification' | 'symonKey' | 'symonUrl'>
 }
 
 let scheduledTasks: ScheduledTask[] = []
@@ -20,11 +22,10 @@ export function resetScheduledTasks(): void {
 }
 
 export function scheduleSummaryNotification({
-  isSymonMode,
-  statusNotificationConfig,
-  statusNotificationFlag,
+  config,
+  flags,
 }: scheduleSummaryNotification): void {
-  if (isSymonMode || statusNotificationFlag === 'false') {
+  if (isSymonModeFrom(flags) || flags['status-notification'] === 'false') {
     return
   }
 
@@ -33,8 +34,8 @@ export function scheduleSummaryNotification({
   // because the value can also come from config file
   const DEFAULT_SCHEDULE_CRON_EXPRESSION = '0 6 * * *'
   const schedule =
-    statusNotificationFlag ||
-    statusNotificationConfig ||
+    flags['status-notification'] ||
+    config['status-notification'] ||
     DEFAULT_SCHEDULE_CRON_EXPRESSION
 
   const scheduledStatusUpdateTask = cron.schedule(

--- a/src/components/notification/schedule-notification.ts
+++ b/src/components/notification/schedule-notification.ts
@@ -13,7 +13,7 @@ type scheduleSummaryNotification = {
 let scheduledTasks: ScheduledTask[] = []
 
 // Stop and clear all previous cron tasks
-export function resetScheduledTasks(): void {
+function resetScheduledTasks(): void {
   for (const task of scheduledTasks) {
     task.stop()
   }
@@ -28,6 +28,8 @@ export function scheduleSummaryNotification({
   if (isSymonModeFrom(flags) || flags['status-notification'] === 'false') {
     return
   }
+
+  resetScheduledTasks()
 
   // defaults to 6 AM
   // default value is not defined in flag configuration,

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -34,6 +34,7 @@ import validateResponse, {
 import { getEventEmitter } from '../../utils/events'
 import { log } from '../../utils/pino'
 import { setProbeFinish, setProbeRunning } from '../../utils/probe-state'
+import { isSymonModeFrom } from '../config'
 import { RequestLog } from '../logger'
 import { sendAlerts } from '../notification'
 import { processThresholds } from '../notification/process-server-status'
@@ -172,7 +173,7 @@ function responseProcessing({
   index,
 }: respProsessingParams): void {
   const { flags } = getContext()
-  const isSymonMode = Boolean(flags.symonUrl) && Boolean(flags.symonKey)
+  const isSymonMode = isSymonModeFrom(flags)
   const eventEmitter = getEventEmitter()
   const isVerbose = isSymonMode || flags['keep-verbose-logs']
   const { alerts } = probe

--- a/src/components/probe/prober/http/index.ts
+++ b/src/components/probe/prober/http/index.ts
@@ -1,3 +1,4 @@
+import { isSymonModeFrom } from '../../../config'
 import { checkThresholdsAndSendAlert } from '../..'
 import { getContext } from '../../../../context'
 import events from '../../../../events'
@@ -24,7 +25,7 @@ export async function probeHTTP(
 ): Promise<void> {
   const eventEmitter = getEventEmitter()
   const { flags } = getContext()
-  const isSymonMode = Boolean(flags.symonUrl) && Boolean(flags.symonKey)
+  const isSymonMode = isSymonModeFrom(flags)
   const isVerbose = isSymonMode || flags['keep-verbose-logs']
   const responses = []
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,11 @@
 import { Command, Errors, Flags, Interfaces } from '@oclif/core'
 
 import { flush, help } from './commands'
-import { createConfig, getConfigIterator } from './components/config'
+import {
+  createConfig,
+  getConfigIterator,
+  isSymonModeFrom,
+} from './components/config'
 import { printAllLogs } from './components/logger'
 import { closeLog, openLogfile } from './components/logger/history'
 import { logStartupMessage } from './components/logger/startup-message'
@@ -293,7 +297,7 @@ class Monika extends Command {
 
       await initLoaders(_flags, this.config)
 
-      const isSymonMode = Boolean(_flags.symonUrl) && Boolean(_flags.symonKey)
+      const isSymonMode = isSymonModeFrom(_flags)
       if (isSymonMode) {
         symonClient = new SymonClient({
           url: _flags.symonUrl as string,

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -23,7 +23,7 @@
  **********************************************************************************/
 
 import type { Config as IConfig } from '@oclif/core'
-import { setupConfig } from '../components/config'
+import { isSymonModeFrom, setupConfig } from '../components/config'
 import { setContext } from '../context'
 import events from '../events'
 import type { MonikaFlags } from '../context/monika-flags'
@@ -49,7 +49,7 @@ export default async function init(
 ): Promise<void> {
   const eventEmitter = getEventEmitter()
   const isTestEnvironment = process.env.CI || process.env.NODE_ENV === 'test'
-  const isSymonMode = Boolean(flags.symonUrl) && Boolean(flags.symonKey)
+  const isSymonMode = isSymonModeFrom(flags)
 
   setContext({ userAgent: cliConfig.userAgent })
 

--- a/src/looper/index.ts
+++ b/src/looper/index.ts
@@ -154,13 +154,13 @@ type StartProbingArgs = {
   notifications: Notification[]
 }
 
-export async function startProbing({
+export function startProbing({
   probes,
   notifications,
-}: StartProbingArgs): Promise<void> {
+}: StartProbingArgs): () => void {
   initializeProbeStates(probes)
 
-  setInterval(() => {
+  const probeInterval = setInterval(() => {
     const { repeat, stun } = getContext().flags
 
     if (repeat) {
@@ -196,4 +196,6 @@ export async function startProbing({
       }
     }
   }, 1000)
+
+  return () => clearInterval(probeInterval)
 }

--- a/src/symon/index.test.ts
+++ b/src/symon/index.test.ts
@@ -129,8 +129,8 @@ describe('Symon initiate', () => {
     })
 
     const symon = new SymonClient({
-      url: 'http://localhost:4000',
-      apiKey: 'abcd',
+      symonUrl: 'http://localhost:4000',
+      symonKey: 'abcd',
     })
     sinon.spy(symon, 'report')
 
@@ -208,8 +208,8 @@ describe('Symon initiate', () => {
     })
 
     const symon = new SymonClient({
-      url: 'http://localhost:4000',
-      apiKey: 'abcd',
+      symonUrl: 'http://localhost:4000',
+      symonKey: 'abcd',
     })
     sinon.spy(symon, 'report')
 
@@ -259,8 +259,8 @@ describe('Symon initiate', () => {
     })
 
     const symon = new SymonClient({
-      url: 'http://localhost:4000',
-      apiKey: 'abcd',
+      symonUrl: 'http://localhost:4000',
+      symonKey: 'abcd',
     })
     const reportSpy = sinon.spy(symon, 'report')
 
@@ -290,8 +290,8 @@ describe('Send incident or recovery event', () => {
     })
 
     const symon = new SymonClient({
-      url: 'http://localhost:4000',
-      apiKey: 'abcd',
+      symonUrl: 'http://localhost:4000',
+      symonKey: 'abcd',
     })
     sinon.spy(symon, 'report')
     symon.monikaId = '1234'

--- a/src/symon/index.test.ts
+++ b/src/symon/index.test.ts
@@ -135,6 +135,7 @@ describe('Symon initiate', () => {
     sinon.spy(symon, 'report')
 
     await symon.initiate()
+    await symon.stopReport()
     expect(symon.monikaId).equals('1234')
 
     const body = JSON.parse(sentBody)
@@ -216,6 +217,7 @@ describe('Symon initiate', () => {
     expect(symon.config).to.be.null
 
     await symon.initiate()
+    await symon.stopReport()
 
     expect(symon.config).deep.equals(config)
   })
@@ -265,6 +267,7 @@ describe('Symon initiate', () => {
     const reportSpy = sinon.spy(symon, 'report')
 
     await symon.initiate()
+    await symon.stopReport()
 
     expect(reportSpy.called).equals(true)
   })

--- a/src/symon/index.ts
+++ b/src/symon/index.ts
@@ -439,6 +439,10 @@ class SymonClient {
       log.warn(`Warning: Can't send status to Symon. ${error?.message}`)
     }
   }
+
+  async stopReport(): Promise<void> {
+    await this.bree.stop()
+  }
 }
 
 export default SymonClient

--- a/src/symon/index.ts
+++ b/src/symon/index.ts
@@ -33,6 +33,7 @@ import path from 'path'
 import { updateConfig } from '../components/config'
 import { getOSName } from '../components/notification/alert-message'
 import { getContext } from '../context'
+import type { MonikaFlags } from '../context/monika-flags'
 import events from '../events'
 import { Config } from '../interfaces/config'
 import { Probe } from '../interfaces/probe'
@@ -161,44 +162,45 @@ class SymonClient {
   })
 
   constructor({
-    url,
-    apiKey,
-    locationId,
-    monikaId,
-    reportInterval,
-    reportLimit,
-  }: {
-    url: string
-    apiKey: string
-    locationId?: string | undefined
-    monikaId?: string | undefined
-    reportInterval?: number | undefined
-    reportLimit?: number | undefined
-  }) {
+    symonUrl = '',
+    symonKey = '',
+    symonLocationId,
+    symonMonikaId,
+    symonReportInterval,
+    symonReportLimit,
+  }: Pick<
+    MonikaFlags,
+    | 'symonUrl'
+    | 'symonKey'
+    | 'symonLocationId'
+    | 'symonMonikaId'
+    | 'symonReportInterval'
+    | 'symonReportLimit'
+  >) {
     this.httpClient = axios.create({
-      baseURL: `${url}/api/v1/monika`,
+      baseURL: `${symonUrl}/api/v1/monika`,
       headers: {
-        'x-api-key': apiKey,
+        'x-api-key': symonKey,
       },
       timeout: DEFAULT_TIMEOUT,
     })
 
-    this.url = url
+    this.url = symonUrl
 
-    this.apiKey = apiKey
+    this.apiKey = symonKey
 
-    this.locationId = locationId || ''
+    this.locationId = symonLocationId || ''
 
-    this.monikaId = monikaId || ''
+    this.monikaId = symonMonikaId || ''
 
     this.fetchProbesInterval = Number.parseInt(
       process.env.FETCH_PROBES_INTERVAL ?? '60000',
       10
     )
 
-    this.reportProbesInterval = reportInterval ?? 10_000
+    this.reportProbesInterval = symonReportInterval ?? 10_000
 
-    this.reportProbesLimit = reportLimit ?? 100
+    this.reportProbesLimit = symonReportLimit ?? 100
   }
 
   async initiate(): Promise<void> {


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

Separate update config from initialize config

## How did you implement / how did you fix it

1. Add some tests
2. Move Monika config state from variable to context
3. Extract isSymonMode function
4. Change the implementation of Monika config watcher from generator functions to simple for loop. It makes the watcher more efficient because it doesn't need to skip the first loop to run.
5. Separate update config from initialize config

## Screenshot

### Before

![before](https://github.com/hyperjumptech/monika/assets/15191978/2148163e-e565-40f1-8e93-bf45b4414d71)

### After

![after](https://github.com/hyperjumptech/monika/assets/15191978/8af4617e-512b-4f5f-beeb-ed56580be2a1)

## How to test

1. Run `npm test`
2. Run Monika as usual
