### PR TITLE
Chore: Drop Node.js 14 Support

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,34 +11,32 @@ on:
   pull_request:
     branches:
       - main
-      
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - node-version: 14.x
-            targets: node14
           - node-version: 16.x
             targets: node16
     steps:
       - uses: actions/checkout@v3
-      - name: 'Use Node.js ${{ matrix.node-version }}'
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: '${{ matrix.node-version }}'
+          node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test && npx codecov
       - run: npm pack
       - run: npm install -g ./hyperjumptech-monika-*.tgz
       - run: npm run prod_test
-      - run: 'npm run pkg -- -t ${{ matrix.targets }}-linux-x64'
+      - run: npm run pkg -- -t ${{ matrix.targets }}-linux-x64
         name: Pack the binary using vercel/pkg
       - run: ./dist/monika -v
         name: Test if printing the version is not error
-        
+
   build-on-node-js-18:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can find many ways to install Monika and how to start monitoring from the [Q
 ## Contributing
 
 Monika is a Node.js application written in TypeScript using the [oclif framework](https://oclif.io/).  
-It was developed on **node v14 (LTS)**, and **npm v6**.
+It was developed on **node v16 (LTS)**, and **npm v8**.
 
 To start developing, clone this repository, then install the dependencies:
 

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "singleQuote": true
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "files": [
     "/bin",


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
Drop Node.js 14 support

## How did you implement / how did you fix it  
1. Remove Node.js 14 on CI
2. Update Node.js version on readme and package.json

## How to test  
1. Run Monika as usual
2. Run test. `npm run test`
