### PR TITLE
Refactor: Use Abort Controller to Cancel Running Probe

### DIFF
--- a/src/looper/index.ts
+++ b/src/looper/index.ts
@@ -150,17 +150,24 @@ export function setPauseProbeInterval(pause: boolean): void {
 }
 
 type StartProbingArgs = {
+  signal: AbortSignal
   probes: Probe[]
   notifications: Notification[]
 }
 
 export function startProbing({
+  signal,
   probes,
   notifications,
-}: StartProbingArgs): () => void {
+}: StartProbingArgs): void {
   initializeProbeStates(probes)
 
   const probeInterval = setInterval(() => {
+    if (signal?.aborted) {
+      clearInterval(probeInterval)
+      return
+    }
+
     const { repeat, stun } = getContext().flags
 
     if (repeat) {
@@ -196,6 +203,4 @@ export function startProbing({
       }
     }
   }, 1000)
-
-  return () => clearInterval(probeInterval)
 }


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
Use abort controller to cancel running probe. Currently, when there is a config changes, probe interval is clear. But it only clear the interval, not the running request. I added abort controller to make it easy to cancel the request in the future. 

## How did you implement / how did you fix it  
1. Implement abort controller
2. Clear the interval when abort is called

## How to test  
1. Run Monika
2. Change the config

## Video
https://github.com/hyperjumptech/monika/assets/15191978/5f70d592-cec3-4065-b3f6-a419a6562de8