### PR TITLE
Feat: Improve Error Message When Request URL is not Using Protocol

### DIFF
--- a/src/components/config/validation/validator/request.ts
+++ b/src/components/config/validation/validator/request.ts
@@ -26,8 +26,6 @@ import { RequestConfig } from '../../../../interfaces/request'
 import { HTTPMethods } from '../../../../utils/http'
 import { isValidURL } from '../../../../utils/is-valid-url'
 
-const PROBE_REQUEST_INVALID_URL =
-  'Probe request URL should start with http:// or https://'
 const PROBE_REQUEST_INVALID_METHOD =
   'Probe request method is invalid! Valid methods are GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS, PURGE, LINK, and UNLINK'
 const PROBE_REQUEST_NO_URL = 'Probe request URL does not exists'
@@ -45,7 +43,7 @@ const checkProbeRequestProperties = (
 
       // if not a ping request and url not valid, return INVLID_URL error
       if (ping !== true && !isValidURL(url)) {
-        return PROBE_REQUEST_INVALID_URL
+        return `Probe request URL (${url}) should start with http:// or https://`
       }
 
       if (!HTTPMethods.has(method?.toUpperCase() ?? 'GET'))

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -167,7 +167,7 @@ describe('monika', () => {
     )
     .catch((error) => {
       expect(error.message).to.contain(
-        'Probe request URL should start with http:// or https://'
+        'Probe request URL (something/something) should start with http:// or https://'
       )
     })
     .it('runs with config with invalid probe request URL')


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
Improve error message when request URL is not using http/https

## How did you implement / how did you fix it  
Add url to the error message to help point out which url cause the error

## How to test  
Run Monika with the following config

```yaml
probes:
  - id: "Yahoo News Japan"
    requests:
      - url: news.yahoo.co.jp
```

## Screenshots
### Before
![Screenshot from 2023-06-15 12-06-14](https://github.com/hyperjumptech/monika/assets/15191978/feb1cd80-2e33-482e-8660-29c376f1ad68)

### After
![image](https://github.com/hyperjumptech/monika/assets/15191978/ad331f7c-bc10-4ac6-b8b3-677150fa1451)


