### PR TITLE
Fix GitHub Actions Injection Vulnerability

### DIFF
--- a/.github/workflows/teams-notify.yml
+++ b/.github/workflows/teams-notify.yml
@@ -11,23 +11,27 @@ on:
     types: [opened]
   pull_request_target:
     types: [opened, reopened]
-
+permissions:
+  issues: read
+  pull-requests: read
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
     - name: Set variables
       id: set_variables
+      env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
       run: |
         if [ "$GITHUB_EVENT_NAME" = "issues" ]; then
-            echo "::set-output name=webhook_title::New issue opened: ${{ github.event.issue.title }}" 
+            echo "::set-output name=webhook_title::New issue opened: $ISSUE_TITLE" 
             echo "::set-output name=webhook_text::${{ github.event.issue.html_url }}" 
         else
-            echo "::set-output name=webhook_title::New PR opened: ${{ github.event.pull_request.title }}" 
+            echo "::set-output name=webhook_title::New PR opened: $PR_TITLE" 
             echo "::set-output name=webhook_text::${{ github.event.pull_request.html_url }}"   
         fi
-      env:
-        GITHUB_EVENT_NAME: ${{ github.event_name }}
     - name: Notify Teams
       uses: joelwmale/webhook-action@fd99bb3b8272237103e349e9bb4d9b0ead9a217c
       with:


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. This PR fixes a vulnerability where the issue announcement workflow is vulnerable to injection via a pull request or issue (see https://cycode.com/blog/github-actions-vulnerabilities/). Even though it does not check out code from a PR the workflow has a GITHUB_TOKEN with write access. It is possible to obtain this by dumping the runner's memory. I am happy to prove it if you would like.

## How did you implement / how did you fix it  
1.  The fix is to limit the workflow permissions to read on issues and PRs and to save the titles to environment variables prior to using them in a script run step.

## How to test  
1. To validate the bug, create an issue with the following title `TestIssue" && echo "RCE" && ls -la / && echo "FooBar`


