### PR TITLE
Limit scope of tokens

### DIFF
--- a/.github/workflows/auto-pr-schemastore.yml
+++ b/.github/workflows/auto-pr-schemastore.yml
@@ -15,6 +15,10 @@ on:
 env:
   USERNAME: ${{ github.actor }}
   EMAIL: ${{ github.actor}}@users.noreply.github.com
+
+permissions:
+  issues: read
+  pull-requests: read
   
 jobs:
   create-auto-PR:
@@ -70,6 +74,9 @@ jobs:
 
       - name: Check outputs
         if: ${{ steps.cpr.outputs.pull-request-number }}
+        env: 
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
         run: |
-          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+          echo "Pull Request Number - $PR_NUMBER"
+          echo "Pull Request URL - $PR_URL"

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -6,6 +6,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  issues: read
+  pull-requests: read
+  
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-release-from-tag.yml
+++ b/.github/workflows/docker-release-from-tag.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+permissions:
+  issues: read
+  pull-requests: read
+  
 jobs:
   testing:
     name: Testing Release

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -14,6 +14,10 @@ env:
   ALGOLIA_ADMIN_API_KEY: undefined
   NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY: undefined
 
+permissions:
+  issues: read
+  pull-requests: read
+  
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,10 @@ env:
   ALGOLIA_ADMIN_API_KEY: ${{secrets.ALGOLIA_ADMIN_API_KEY}}
   NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY: ${{secrets.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY}}
 
+permissions:
+  issues: read
+  pull-requests: read
+  
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 7 * * *" # every day at 12AM PST
 
+permissions:
+  issues: read
+  pull-requests: read
+  
 jobs:
   nightly:
     name: 🌒 Nightly Release

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,6 +12,10 @@ on:
     branches:
       - main
 
+permissions:
+  issues: read
+  pull-requests: read
+  
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,6 +8,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  issues: read
+  pull-requests: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/package-notification-publish.yml
+++ b/.github/workflows/package-notification-publish.yml
@@ -8,6 +8,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  issues: read
+  pull-requests: read
+  
 jobs:
   publish-npm:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-snap.yml
+++ b/.github/workflows/publish-snap.yml
@@ -7,6 +7,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  issues: read
+  pull-requests: read
+  
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -11,6 +11,10 @@ on:
     types: [opened, reopened]
   workflow_dispatch: # allow manual trigger for scans    
 
+permissions:
+  issues: read
+  pull-requests: read
+
 jobs:
   sonarcloud:
     runs-on: ubuntu-latest

--- a/.github/workflows/teams-notify.yml
+++ b/.github/workflows/teams-notify.yml
@@ -12,6 +12,10 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
+permissions:
+  issues: read
+  pull-requests: read
+
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-binary.yml
+++ b/.github/workflows/upload-binary.yml
@@ -8,6 +8,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  issues: read
+  pull-requests: read    
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Improve security of github action workflow
2. References the [recommendations from here](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions) 
3. Also [this blog here](https://cycode.com/blog/github-actions-vulnerabilities/) has some decent examples

## How did you implement / how did you fix it  
1. Limit the scope of issued GITHUB_TOKEN to explicitely be type "read"
2. Sanitize "run" type actions to minimize injection ex: `run: echo ${{ sometext can be iffy }}`

