### PR TITLE
Update Teams Notifications for NonHTTTP Probes

### DIFF
--- a/packages/notification/channel/teams.ts
+++ b/packages/notification/channel/teams.ts
@@ -104,6 +104,17 @@ export function getContent({
     case 'incident':
     case 'recovery': {
       const themeColor = meta.type === 'incident' ? 'DF202E' : '8CC152'
+      let probeSource = {}
+
+      probeSource = meta.url
+        ? {
+            name: 'URL',
+            value: `[${meta.url}](${meta.url})`,
+          }
+        : {
+            name: 'ProbeID',
+            value: `${meta.probeID}`,
+          }
 
       return {
         '@type': 'MessageCard',
@@ -117,10 +128,7 @@ export function getContent({
                 name: 'Message',
                 value: summary,
               },
-              {
-                name: 'URL',
-                value: `[${meta.url}](${meta.url})`,
-              },
+              probeSource,
               {
                 name: 'Time',
                 value: meta.time,

--- a/src/components/probe/prober/http/index.ts
+++ b/src/components/probe/prober/http/index.ts
@@ -13,7 +13,7 @@ import { logResponseTime } from '../../../logger/response-time-log'
 import { processThresholds } from '../../../notification/process-server-status'
 import { httpRequest } from './request'
 
-const CONNNECTION_RECOVERY_MESSAGE = 'Probe is accessible again'
+const CONNECTION_RECOVERY_MESSAGE = 'Probe is accessible again'
 const CONNECTION_INCIDENT_MESSAGE = 'Probe not accessible'
 const isConnectionDown = new Map<string, boolean>()
 
@@ -86,7 +86,7 @@ export async function probeHTTP(
         ) {
           validatedResponse[0].alert = {
             assertion: '',
-            message: CONNNECTION_RECOVERY_MESSAGE,
+            message: CONNECTION_RECOVERY_MESSAGE,
           }
           isConnectionDown.delete(id) // connection is up, so remove from entry
         } else if (!isProbeResponsive) {


### PR DESCRIPTION
# Monika Pull Request (PR)  

## What feature/issue does this PR add  
1. Empty URL field in Notification
2. Fixes issue #962

## How did you implement / how did you fix it  
1.  Display URL or ProbeID if URL not exist.

## How to test  
1. Use a config where you probe a postgre db or a redis cache:
```yaml
probes:
  - id: 'redis-1'
    name: 'redis-test'
    redis:
      - host: 192.168.0.1
        port: 6379
    alerts:
      - assertion: response.status < 200 or response.status > 299
        message: HTTP Status is not 200
    incidentThreshold: 3
    recoveryThreshold: 3

  - id: postgres-111
    interval: 3
    incidentThreshold: 1
    recoveryThreshold: 1
    postgres:
      - uri: postgres://user:password@192.168.0.2:5432/mydb
    alerts:
      - assertion: response.status < 200 or response.status > 299
        message: HTTP Status is not 200

notifications:
  - id: desktop
    type: desktop
  - id: teams-001
    type: teams
    data:
      url: https://yourcompany.webhook.office.com/webhookb2/1122335566aabbccdded/IncomingWwebhood/aabbccddeefffgg
```
2. Spinup your postgresql or redis database
3. Run the probe: `npm start -- -c config.yaml`

## Before PR

For Postgres
![image](https://github.com/hyperjumptech/monika/assets/964106/589577ba-8b6d-4694-9a48-993146de031e)


## After PR

For Postgres
![image](https://github.com/hyperjumptech/monika/assets/964106/1169e2a5-59ad-42d0-b270-26f29652dcd4)

For Redis
![image](https://github.com/hyperjumptech/monika/assets/964106/ce1db061-6e64-403e-abe0-cb6378298325)

