### PR TITLE
Fix: Webhook Notification is Not Working

### DIFF
--- a/packages/notification/channel/__test__/webhook.test.ts
+++ b/packages/notification/channel/__test__/webhook.test.ts
@@ -1,7 +1,35 @@
+/**********************************************************************************
+ * MIT License                                                                    *
+ *                                                                                *
+ * Copyright (c) 2021 Hyperjump Technology                                        *
+ *                                                                                *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy   *
+ * of this software and associated documentation files (the "Software"), to deal  *
+ * in the Software without restriction, including without limitation the rights   *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      *
+ * copies of the Software, and to permit persons to whom the Software is          *
+ * furnished to do so, subject to the following conditions:                       *
+ *                                                                                *
+ * The above copyright notice and this permission notice shall be included in all *
+ * copies or substantial portions of the Software.                                *
+ *                                                                                *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  *
+ * SOFTWARE.                                                                      *
+ **********************************************************************************/
+
 import chai, { expect } from 'chai'
 import spies from 'chai-spies'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
 
 import { validateNotification } from '../../validator/notification'
+import { send } from '../webhook'
+import type { NotificationMessage } from '..'
 
 chai.use(spies)
 
@@ -49,5 +77,82 @@ describe('notificationChecker - webhookNotification', () => {
         throw error
       }).to.throw(message)
     }
+  })
+})
+
+describe('Webhook Notification', () => {
+  describe('Send', () => {
+    let body: Record<string, any> = {}
+    const server = setupServer(
+      rest.post('https://example.com', (req, res, ctx) => {
+        body = req.body as Record<string, any>
+
+        return res(ctx.status(200))
+      })
+    )
+
+    beforeEach(() => server.listen())
+    afterEach(() => {
+      body = {}
+      server.close()
+    })
+
+    it('should send notification through webhook', async () => {
+      // act
+      await send({ url: 'https://example.com' }, {
+        meta: {
+          alertQuery: 'response.status != 200',
+          probeID: 'ua53D',
+          url: 'https://example.com',
+          time: '2022-09-27 18:00:00.000',
+          type: 'incident',
+        },
+      } as unknown as NotificationMessage)
+
+      // assert
+      expect(body).deep.eq({
+        body: {
+          alert: 'response.status != 200',
+          url: 'https://example.com',
+          time: '2022-09-27 18:00:00.000',
+        },
+      })
+    })
+
+    it('should send notification through webhook and use probeID as an identifier', async () => {
+      // act
+      await send({ url: 'https://example.com' }, {
+        meta: {
+          alertQuery: 'response.status != 200',
+          probeID: 'ua53D',
+          time: '2022-09-27 18:00:00.000',
+          type: 'incident',
+        },
+      } as unknown as NotificationMessage)
+
+      // assert
+      expect(body).deep.eq({
+        body: {
+          alert: 'response.status != 200',
+          url: 'ua53D',
+          time: '2022-09-27 18:00:00.000',
+        },
+      })
+    })
+
+    it('should not send notification if notification type is not incident', async () => {
+      // act
+      await send({ url: 'https://example.com' }, {
+        meta: {
+          alertQuery: 'response.status != 200',
+          probeID: 'ua53D',
+          time: '2022-09-27 18:00:00.000',
+          type: 'start',
+        },
+      } as unknown as NotificationMessage)
+
+      // assert
+      expect(body).deep.eq({})
+    })
   })
 })

--- a/packages/notification/channel/__test__/webhook.test.ts
+++ b/packages/notification/channel/__test__/webhook.test.ts
@@ -97,7 +97,7 @@ describe('Webhook Notification', () => {
       server.close()
     })
 
-    it('should send notification through webhook', async () => {
+    it('should send incident notification', async () => {
       // act
       await send({ url: 'https://example.com' }, {
         meta: {
@@ -119,7 +119,7 @@ describe('Webhook Notification', () => {
       })
     })
 
-    it('should send notification through webhook and use probeID as an identifier', async () => {
+    it('should send incident notification and use probeID as an identifier', async () => {
       // act
       await send({ url: 'https://example.com' }, {
         meta: {
@@ -140,7 +140,7 @@ describe('Webhook Notification', () => {
       })
     })
 
-    it('should not send notification if notification type is not incident', async () => {
+    it('should not send recovery notification', async () => {
       // act
       await send({ url: 'https://example.com' }, {
         meta: {
@@ -152,7 +152,13 @@ describe('Webhook Notification', () => {
       } as unknown as NotificationMessage)
 
       // assert
-      expect(body).deep.eq({})
+      expect(body).deep.eq({
+        body: {
+          alert: 'response.status != 200',
+          url: 'ua53D',
+          time: '2022-09-27 18:00:00.000',
+        },
+      })
     })
   })
 })

--- a/packages/notification/channel/webhook.ts
+++ b/packages/notification/channel/webhook.ts
@@ -36,12 +36,24 @@ export const validator = Joi.object().keys({
 
 export const send = async (
   { url }: NotificationData,
-  { body }: NotificationMessage
+  { meta }: NotificationMessage
 ): Promise<void> => {
+  if (meta.type !== 'incident') {
+    return
+  }
+
+  const { alertQuery, probeID, time } = meta
+
   await sendHttpRequest({
     method: 'POST',
     url,
-    data: body,
+    data: {
+      body: {
+        url: meta.url || probeID,
+        time,
+        alert: alertQuery,
+      },
+    },
   })
 }
 

--- a/packages/notification/channel/webhook.ts
+++ b/packages/notification/channel/webhook.ts
@@ -38,7 +38,7 @@ export const send = async (
   { url }: NotificationData,
   { meta }: NotificationMessage
 ): Promise<void> => {
-  if (meta.type !== 'incident') {
+  if (meta.type !== 'incident' && meta.type !== 'recovery') {
     return
   }
 

--- a/src/components/probe/index.test.ts
+++ b/src/components/probe/index.test.ts
@@ -40,14 +40,15 @@ import { afterEach, beforeEach } from 'mocha'
 import { getContext, resetContext, setContext } from '../../context'
 
 let urlRequestTotal = 0
-let notificationAlert = ''
+let notificationAlert: Record<string, any> = {}
 const server = setupServer(
   rest.get('https://example.com', (_, res, ctx) => {
     urlRequestTotal += 1
     return res(ctx.status(200))
   }),
   rest.post('https://example.com/webhook', (req, res, ctx) => {
-    notificationAlert = req.body?.toString() || ''
+    notificationAlert = req.body as Record<string, string>
+
     return res(ctx.status(200))
   })
 )
@@ -72,7 +73,7 @@ const probes: Probe[] = [
 beforeEach(() => server.listen())
 afterEach(() => {
   urlRequestTotal = 0
-  notificationAlert = ''
+  notificationAlert = {}
   server.close()
 })
 
@@ -249,7 +250,8 @@ describe('Probe processing', () => {
       await sleep(2 * seconds)
 
       // assert
-      expect(notificationAlert).includes('The request failed')
+      expect(notificationAlert.body.url).eq('https://example.com')
+      expect(notificationAlert.body.alert).eq('response.status == 200')
     }).timeout(10_000)
 
     it('should send recovery notification', async () => {
@@ -296,7 +298,8 @@ describe('Probe processing', () => {
       await sleep(2 * seconds)
 
       // assert
-      expect(notificationAlert).includes('Target is back to normal')
+      expect(notificationAlert.body.url).eq('https://example.com')
+      expect(notificationAlert.body.alert).eq('response.status == 200')
     }).timeout(10_000)
   })
 

--- a/src/components/probe/index.test.ts
+++ b/src/components/probe/index.test.ts
@@ -299,7 +299,7 @@ describe('Probe processing', () => {
 
       // assert
       expect(notificationAlert.body.url).eq('https://example.com')
-      expect(notificationAlert.body.alert).eq('response.status == 200')
+      expect(notificationAlert.body.alert).eq('response.status != 200')
     }).timeout(10_000)
   })
 


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add
Fix webhook notification is not working

## How did you implement / how did you fix it
### Before

https://github.com/hyperjumptech/monika/assets/15191978/322c37c2-7c34-4ac3-bbb9-632bba77c6b6


### After

https://github.com/hyperjumptech/monika/assets/15191978/0673c848-768e-4c79-8f6e-814e94f9c949


## How to test
1. Run a server that print the request body
2. Run Monika with the following configuration

### Webhook notification server example
```json
{
  "name": "webhook-notification",
  "version": "0.0.1",
  "description": "A server to test webhook notification",
  "main": "index.js",
  "scripts": {
    "dev": "nodemon index.ts",
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "keywords": [
    "webhook",
    "monika"
  ],
  "author": "haricnugraha@gmail.com",
  "license": "MIT",
  "dependencies": {
    "express": "4.18.2"
  },
  "devDependencies": {
    "@types/express": "^4.17.17",
    "@types/node": "^20.5.0",
    "nodemon": "^3.0.1",
    "ts-node": "^10.9.1",
    "typescript": "^5.1.6"
  },
  "compilerOptions": {
    "outDir": "./dist"
  }
}
```

```typescript
import type { Request, Response } from "express";
import express from "express";

const app = express();
const port = 3000;

app.use(express.json());

app.post("/", (req: Request, res: Response) => {
  console.log(req.body);

  res.json(req.body);
});

app.listen(port, () => {
  console.log(`Example app listening on port ${port}`);
});
```

### Monika configuration
```yaml
probes:
  - id: HTTPBin
    requests:
      - url: https://httpbin.org/status/404
    incidentThreshold: 1
    recoveryThreshold: 1
    interval: 5
notifications:
  - type: webhook
    id: webhook-01
    data:
      url: http://localhost:3000
```