### PR TITLE
Fix: Undefined Notification Message

### DIFF
--- a/src/components/notification/__tests__/alert-message.test.ts
+++ b/src/components/notification/__tests__/alert-message.test.ts
@@ -43,7 +43,7 @@ describe('Alert message', () => {
       const alertMessage = await getMessageForAlert({
         probeID: 'f76fef86-7331-4bfd-a7e9-f4ba105127ac',
         url: '',
-        alert: { assertion: '' },
+        alert: { assertion: '', message: '' },
         ipAddress: '',
         isRecovery: false,
         response: {
@@ -72,7 +72,7 @@ describe('Alert message', () => {
       const alertMessage = await getMessageForAlert({
         probeID: 'f76fef86-7331-4bfd-a7e9-f4ba105127ac',
         url: '',
-        alert: { assertion: '' },
+        alert: { assertion: '', message: '' },
         ipAddress: '',
         isRecovery: false,
         response: {
@@ -108,7 +108,7 @@ describe('Alert message', () => {
       const alertMessage = await getMessageForAlert({
         probeID: 'f76fef86-7331-4bfd-a7e9-f4ba105127ac',
         url: '',
-        alert: { assertion: '' },
+        alert: { assertion: '', message: '' },
         ipAddress: '',
         isRecovery: true,
         response: {
@@ -159,7 +159,7 @@ describe('Alert message', () => {
       const alertMessage = await getMessageForAlert({
         probeID: 'f76fef86-7331-4bfd-a7e9-f4ba105127aa',
         url: '',
-        alert: { assertion: '' },
+        alert: { assertion: '', message: '' },
         ipAddress: '',
         isRecovery: true,
         response: {

--- a/src/components/notification/alert-message.ts
+++ b/src/components/notification/alert-message.ts
@@ -62,9 +62,18 @@ type MessageAlertProps = {
 
 const getExpectedMessage = (
   alert: ProbeAlert,
-  response: ProbeRequestResponse
+  response: ProbeRequestResponse,
+  isRecovery: boolean
 ): string | number => {
   const { status, data, headers, responseTime } = response
+
+  if (alert.message === '') {
+    if (isRecovery) {
+      return `The request is back to normal and passed the assertion: ${alert.assertion}`
+    }
+
+    return `The request failed because the response did not pass the query: ${alert.assertion}. The actual response status is ${status} and the response time is ${responseTime}.`
+  }
 
   return Handlebars.compile(alert.message)({
     response: {
@@ -112,7 +121,7 @@ export async function getMessageForAlert({
     isRecovery,
     lastIncident?.createdAt
   )
-  const expectedMessage = getExpectedMessage(alert, response)
+  const expectedMessage = getExpectedMessage(alert, response, isRecovery)
   const bodyString = `Message: ${recoveryMessage}${expectedMessage}
 
 ${meta.url ? `URL: ${meta.url}` : `Probe ID: ${probeID}`}

--- a/src/components/notification/alert-message.ts
+++ b/src/components/notification/alert-message.ts
@@ -62,16 +62,9 @@ type MessageAlertProps = {
 
 const getExpectedMessage = (
   alert: ProbeAlert,
-  response: ProbeRequestResponse,
-  isRecovery: boolean
+  response: ProbeRequestResponse
 ): string | number => {
   const { status, data, headers, responseTime } = response
-
-  if (!alert.message) {
-    if (isRecovery)
-      return `The request is back to normal and passed the assertion: ${alert.query}`
-    return `The request failed because the response did not pass the query: ${alert.query}. The actual response status is ${status} and the response time is ${responseTime}.`
-  }
 
   return Handlebars.compile(alert.message)({
     response: {
@@ -119,7 +112,7 @@ export async function getMessageForAlert({
     isRecovery,
     lastIncident?.createdAt
   )
-  const expectedMessage = getExpectedMessage(alert, response, isRecovery)
+  const expectedMessage = getExpectedMessage(alert, response)
   const bodyString = `Message: ${recoveryMessage}${expectedMessage}
 
 ${meta.url ? `URL: ${meta.url}` : `Probe ID: ${probeID}`}

--- a/src/components/probe/index.test.ts
+++ b/src/components/probe/index.test.ts
@@ -225,7 +225,7 @@ describe('Probe processing', () => {
       const probe = {
         ...probes[0],
         id: '2md9o',
-        alerts: [{ assertion: 'response.status == 200' }],
+        alerts: [{ assertion: 'response.status == 200', message: '' }],
       }
       initializeProbeStates([probe])
       // wait until the interval passed
@@ -264,7 +264,7 @@ describe('Probe processing', () => {
         ...probes[0],
         id: 'fj43l',
         requests: [{ url: 'https://example.com', body: '', timeout: 30 }],
-        alerts: [{ assertion: 'response.status != 200' }],
+        alerts: [{ assertion: 'response.status != 200', message: '' }],
       }
       const notifications = [
         {

--- a/src/components/probe/index.test.ts
+++ b/src/components/probe/index.test.ts
@@ -225,7 +225,12 @@ describe('Probe processing', () => {
       const probe = {
         ...probes[0],
         id: '2md9o',
-        alerts: [{ assertion: 'response.status == 200', message: '' }],
+        alerts: [
+          {
+            assertion: 'response.status == 200',
+            message: 'The request failed.',
+          },
+        ],
       }
       initializeProbeStates([probe])
       // wait until the interval passed

--- a/src/components/probe/prober/http/index.ts
+++ b/src/components/probe/prober/http/index.ts
@@ -125,7 +125,9 @@ export async function probeHTTP(
           eventEmitter.emit(events.probe.alert.triggered, {
             probe,
             requestIndex,
-            alertQuery: triggeredAlertResponse.alert.query,
+            alertQuery:
+              triggeredAlertResponse.alert.assertion ||
+              triggeredAlertResponse.alert.query,
           })
         }
 

--- a/src/interfaces/probe.ts
+++ b/src/interfaces/probe.ts
@@ -27,7 +27,7 @@ import { RequestConfig } from './request'
 export interface ProbeAlert {
   query?: string
   assertion: string
-  message?: string
+  message: string
   id?: string
 }
 

--- a/src/plugins/metrics/prometheus/collector.test.ts
+++ b/src/plugins/metrics/prometheus/collector.test.ts
@@ -64,6 +64,7 @@ describe('Prometheus collector', () => {
           alerts: [
             {
               assertion: '',
+              message: '',
             },
           ],
         },
@@ -100,6 +101,7 @@ describe('Prometheus collector', () => {
           alerts: [
             {
               assertion: '',
+              message: '',
             },
           ],
         },
@@ -181,6 +183,7 @@ describe('Prometheus collector', () => {
           alerts: [
             {
               assertion: '',
+              message: '',
             },
           ],
         },
@@ -212,6 +215,7 @@ describe('Prometheus collector', () => {
           alerts: [
             {
               assertion: '',
+              message: '',
             },
           ],
         },


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

Fix undefined alert query when notification message set to empty string

## How did you implement / how did you fix it

### Before

![image](https://github.com/hyperjumptech/monika/assets/15191978/416a4076-c9d7-482c-9e99-837cf129bd05)

### After

![image](https://github.com/hyperjumptech/monika/assets/15191978/df4ae56d-20eb-4d6b-93f2-82380ce5b221)

## How to test

1. Run Monika with the following configuration and add your chosen notification
```yaml
probes:
  - id: custom-alert
    requests:
      - url: https://httpbin.org/status/201
    incidentThreshold: 1
    recoveryThreshold: 1
    interval: 5
    alerts:
      - assertion: response.status != 200
        message: ""
```
