### PR TITLE
Refactor: Make HTTP Prober a Subclass

### DIFF
--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -39,7 +39,7 @@ import {
 } from '../../utils/probe-state'
 import { RequestLog } from '../logger'
 import { sendAlerts } from '../notification'
-import { probeHTTP } from './prober'
+import { probeHTTP } from './prober/http'
 import { createProbers } from './prober/factory'
 
 interface ProbeStatusProcessed {

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -170,7 +170,17 @@ export async function doProbe({
       return
     }
 
-    await probeNonHTTP(probe, probeCtx.cycle, notifications)
+    const probers = createProbers({
+      counter: probeCtx.cycle,
+      notifications,
+      probeConfig: probe,
+    })
+
+    await Promise.all(
+      probers.map(async (prober) => {
+        await prober.probe()
+      })
+    )
 
     setProbeFinish(probe.id)
   }, getRandomTimeoutMilliseconds())
@@ -204,22 +214,4 @@ function getRandomTimeoutMilliseconds(): number {
   return [1000, 2000, 3000].sort(() => {
     return Math.random() - 0.5
   })[0]
-}
-
-async function probeNonHTTP(
-  probe: Probe,
-  checkOrder: number,
-  notifications: Notification[]
-) {
-  const probers = createProbers({
-    counter: checkOrder,
-    notifications,
-    probeConfig: probe,
-  })
-
-  await Promise.all(
-    probers.map(async (prober) => {
-      await prober.probe()
-    })
-  )
 }

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -39,7 +39,6 @@ import {
 } from '../../utils/probe-state'
 import { RequestLog } from '../logger'
 import { sendAlerts } from '../notification'
-import { probeHTTP } from './prober/http'
 import { createProbers } from './prober/factory'
 
 interface ProbeStatusProcessed {
@@ -172,7 +171,6 @@ export async function doProbe({
     }
 
     await probeNonHTTP(probe, probeCtx.cycle, notifications)
-    await probeHTTP(probe, probeCtx.cycle, notifications)
 
     setProbeFinish(probe.id)
   }, getRandomTimeoutMilliseconds())

--- a/src/components/probe/prober/factory.ts
+++ b/src/components/probe/prober/factory.ts
@@ -34,6 +34,10 @@ export function createProbers(probeMetadata: ProberMetadata): Prober[] {
   const { probeConfig } = probeMetadata
   const result: Prober[] = []
 
+  if (probeConfig?.requests) {
+    result.push(createProber(probeMetadata))
+  }
+
   if (probeConfig?.mongo) {
     result.push(createProber(probeMetadata))
   }

--- a/src/components/probe/prober/factory.ts
+++ b/src/components/probe/prober/factory.ts
@@ -22,6 +22,7 @@
  * SOFTWARE.                                                                      *
  **********************************************************************************/
 
+import { HTTPProber } from './http'
 import { MongoProber } from './mongo'
 import { MariaDBProber } from './mariadb'
 import { PostgresProber } from './postgres'
@@ -58,6 +59,10 @@ export function createProbers(probeMetadata: ProberMetadata): Prober[] {
 
 export function createProber(probeMetadata: ProberMetadata): Prober {
   const { probeConfig } = probeMetadata
+
+  if (probeConfig?.requests) {
+    return new HTTPProber(probeMetadata)
+  }
 
   if (probeConfig?.mariadb || probeConfig?.mysql) {
     return new MariaDBProber(probeMetadata)

--- a/src/components/probe/prober/http/index.ts
+++ b/src/components/probe/prober/http/index.ts
@@ -1,3 +1,27 @@
+/**********************************************************************************
+ * MIT License                                                                    *
+ *                                                                                *
+ * Copyright (c) 2021 Hyperjump Technology                                        *
+ *                                                                                *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy   *
+ * of this software and associated documentation files (the "Software"), to deal  *
+ * in the Software without restriction, including without limitation the rights   *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      *
+ * copies of the Software, and to permit persons to whom the Software is          *
+ * furnished to do so, subject to the following conditions:                       *
+ *                                                                                *
+ * The above copyright notice and this permission notice shall be included in all *
+ * copies or substantial portions of the Software.                                *
+ *                                                                                *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  *
+ * SOFTWARE.                                                                      *
+ **********************************************************************************/
+
 import { isSymonModeFrom } from '../../../config'
 import { checkThresholdsAndSendAlert } from '../..'
 import { getContext } from '../../../../context'
@@ -12,13 +36,60 @@ import { RequestLog } from '../../../logger'
 import { logResponseTime } from '../../../logger/response-time-log'
 import { processThresholds } from '../../../notification/process-server-status'
 import { httpRequest } from './request'
+import { BaseProber } from '..'
 
 const CONNECTION_RECOVERY_MESSAGE = 'Probe is accessible again'
 const CONNECTION_INCIDENT_MESSAGE = 'Probe not accessible'
 const isConnectionDown = new Map<string, boolean>()
 
+export class HTTPProber extends BaseProber {
+  async probe(): Promise<void> {
+    await probeHTTP(this.probeConfig, this.counter, this.notifications)
+  }
+
+  generateVerboseStartupMessage(): string {
+    const { description, id, interval, name } = this.probeConfig
+
+    let result = `- Probe ID: ${id}
+  Name: ${name}
+  Description: ${description || '-'}
+  Interval: ${interval}
+`
+    result += '  Requests:\n'
+    result += this.generateProbeRequestMessage()
+    result += this.generateAlertMessage()
+
+    return result
+  }
+
+  private generateProbeRequestMessage(): string {
+    let startupMessage = ''
+
+    for (const request of this.probeConfig.requests || []) {
+      const { body, headers, method, url } = request
+
+      startupMessage += `  - Request Method: ${method || `GET`}
+    Request URL: ${url}
+    Request Headers: ${JSON.stringify(headers) || `-`}
+    Request Body: ${JSON.stringify(body) || `-`}
+`
+    }
+
+    return startupMessage
+  }
+
+  private generateAlertMessage(): string {
+    const hasAlert = this.probeConfig.alerts.length > 0
+    const defaultAlertsInString =
+      '[{ "assertion": "response.status < 200 or response.status > 299", "message": "HTTP Status is not 200"}, { "assertion": "response.time > 2000", "message": "Response time is more than 2000ms" }]'
+    const alertsInString = JSON.stringify(this.probeConfig.alerts)
+
+    return `    Alerts: ${hasAlert ? alertsInString : defaultAlertsInString}\n`
+  }
+}
+
 // sending multiple http-type requests
-export async function probeHTTP(
+async function probeHTTP(
   probe: Probe,
   checkOrder: number,
   notifications: Notification[]

--- a/src/components/probe/prober/http/index.ts
+++ b/src/components/probe/prober/http/index.ts
@@ -89,7 +89,7 @@ export class HTTPProber extends BaseProber {
 }
 
 // sending multiple http-type requests
-export async function probeHTTP(
+async function probeHTTP(
   probe: Probe,
   checkOrder: number,
   notifications: Notification[]

--- a/src/components/probe/prober/http/index.ts
+++ b/src/components/probe/prober/http/index.ts
@@ -89,7 +89,7 @@ export class HTTPProber extends BaseProber {
 }
 
 // sending multiple http-type requests
-async function probeHTTP(
+export async function probeHTTP(
   probe: Probe,
   checkOrder: number,
   notifications: Notification[]

--- a/src/components/probe/prober/index.ts
+++ b/src/components/probe/prober/index.ts
@@ -35,8 +35,6 @@ import { isSymonModeFrom } from '../../config'
 import { RequestLog } from '../../logger'
 import { processThresholds } from '../../notification/process-server-status'
 
-export { probeHTTP } from './http'
-
 export type ProbeResult = {
   isAlertTriggered: boolean
   logMessage: string
@@ -75,43 +73,7 @@ export class BaseProber implements Prober {
   }
 
   generateVerboseStartupMessage(): string {
-    const { description, id, interval, name } = this.probeConfig
-
-    let result = `- Probe ID: ${id}
-  Name: ${name}
-  Description: ${description || '-'}
-  Interval: ${interval}
-`
-    result += '  Requests:\n'
-    result += this.generateProbeRequestMessage()
-    result += this.generateAlertMessage()
-
-    return result
-  }
-
-  private generateProbeRequestMessage(): string {
-    let startupMessage = ''
-
-    for (const request of this.probeConfig.requests || []) {
-      const { body, headers, method, url } = request
-
-      startupMessage += `  - Request Method: ${method || `GET`}
-    Request URL: ${url}
-    Request Headers: ${JSON.stringify(headers) || `-`}
-    Request Body: ${JSON.stringify(body) || `-`}
-`
-    }
-
-    return startupMessage
-  }
-
-  private generateAlertMessage(): string {
-    const hasAlert = this.probeConfig.alerts.length > 0
-    const defaultAlertsInString =
-      '[{ "assertion": "response.status < 200 or response.status > 299", "message": "HTTP Status is not 200"}, { "assertion": "response.time > 2000", "message": "Response time is more than 2000ms" }]'
-    const alertsInString = JSON.stringify(this.probeConfig.alerts)
-
-    return `    Alerts: ${hasAlert ? alertsInString : defaultAlertsInString}\n`
+    return ''
   }
 
   protected processProbeResults(probeResults: ProbeResult[]): void {


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add
Make the HTPP prober a subclass

## How did you implement / how did you fix it
- Create implementation of http prober based on base prober
- Make the base prober lean by removing unneeded code
- Add the http prober to the prober factory
- Inline the probe non http function

## How to test
1. Run `npm run test`
2. Run monika as usual