### PR TITLE
Fix: Non HTTP Prober is not Running

### DIFF
--- a/src/components/config/get.ts
+++ b/src/components/config/get.ts
@@ -28,6 +28,7 @@ import { log } from '../../utils/pino'
 import { parseConfig } from './parse'
 import { validateConfigWithSchema } from './validation'
 import { validateConfig } from './validate'
+import type { RequestConfig } from '../../interfaces/request'
 
 export type ConfigType =
   | 'monika'
@@ -109,14 +110,20 @@ async function parseConfigType(
   return {
     ...parsed,
     probes: parsed.probes?.map((probe) => {
-      const requests =
-        (probe?.requests ?? [])?.map((request) => ({
+      const requests: RequestConfig[] | undefined = probe?.requests?.map(
+        (request) => ({
           ...request,
           timeout: request.timeout ?? 10_000,
-        })) ?? []
+        })
+      )
 
       const interval = () => {
         if (typeof probe?.interval === 'number') return probe.interval
+
+        if (!requests) {
+          return 10
+        }
+
         return requests.length * 10 === 0 ? 10 : requests.length * 10
       }
 


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

Fix non HTTP prober is not running

## How did you implement / how did you fix it

Remove empty array as fallback to undefined

## Video

## Before

![image](https://github.com/hyperjumptech/monika/assets/15191978/d0ece37f-15cf-41d4-8333-315c4ea64c29)

### After

https://github.com/hyperjumptech/monika/assets/15191978/c0b280ca-ebb8-4493-9d23-071ea8022130

## How to test

1. Run local probe target. Run `cd dev && docker compose up`
2. Run Monika with the following configuration. Run `npm start`

```yaml
probes:
  - id: mariadb
    interval: 2
    incidentThreshold: 1
    recoveryThreshold: 1
    mariadb:
      - host: localhost
        port: 3306
        username: mariadb_user
        password: mariadb_password
        database:
  - id: mysql
    interval: 2
    incidentThreshold: 1
    recoveryThreshold: 1
    mysql:
      - host: localhost
        port: 3307
        username: mysql_user
        password: mysql_password
        database:
  - id: mongo
    interval: 2
    incidentThreshold: 1
    recoveryThreshold: 1
    mongo:
      - uri: mongodb://mongo_user:mongo_password@localhost:27017
  - id: postgres
    interval: 2
    incidentThreshold: 1
    recoveryThreshold: 1
    postgres:
      - uri: postgres://postgres_user:postgres_password@localhost:5432/postgres_db
  - id: redis
    interval: 2
    incidentThreshold: 1
    recoveryThreshold: 1
    redis:
      - uri: redis://:redis_password@localhost:6379
```
