### PR TITLE
Refactor: Extract Downtime Counter Function

### DIFF
--- a/src/components/downtime-counter/index.ts
+++ b/src/components/downtime-counter/index.ts
@@ -25,26 +25,12 @@
 import { formatDistanceToNow } from 'date-fns'
 import { getContext, setContext } from '../../context'
 
-export function updateLastIncidentData(
-  isRecovery: boolean,
-  probeID: string,
-  url: string
-): void {
-  if (isRecovery) {
-    removeDowntimeCounter({ probeID, url })
-    return
-  }
-
-  startDowntimeCounter({ probeID, url })
-}
-
 type DowntimeCounter = {
   probeID: string
   url: string
 }
 
-function startDowntimeCounter({ probeID, url }: DowntimeCounter) {
-  // set incident date time to global context to be used later on recovery notification
+export function startDowntimeCounter({ probeID, url }: DowntimeCounter): void {
   const newIncident = { probeID, probeRequestURL: url, createdAt: new Date() }
 
   setContext({ incidents: [...getContext().incidents, newIncident] })
@@ -65,7 +51,7 @@ export function getDowntimeDuration({ probeID, url }: DowntimeCounter): string {
   })
 }
 
-function removeDowntimeCounter({ probeID, url }: DowntimeCounter) {
+export function removeDowntimeCounter({ probeID, url }: DowntimeCounter): void {
   const newIncidents = getContext().incidents.filter(
     (incident) =>
       incident.probeID !== probeID && incident.probeRequestURL !== url

--- a/src/components/downtime-counter/index.ts
+++ b/src/components/downtime-counter/index.ts
@@ -30,16 +30,8 @@ export function updateLastIncidentData(
   probeID: string,
   url: string
 ): void {
-  const { incidents } = getContext()
-
   if (isRecovery) {
-    // delete last incident
-    const newIncidents = incidents.filter(
-      (incident) =>
-        incident.probeID !== probeID && incident.probeRequestURL !== url
-    )
-
-    setContext({ incidents: newIncidents })
+    removeDowntimeCounter({ probeID, url })
     return
   }
 
@@ -71,4 +63,13 @@ export function getDowntimeDuration({ probeID, url }: DowntimeCounter): string {
   return formatDistanceToNow(lastIncident.createdAt, {
     includeSeconds: true,
   })
+}
+
+function removeDowntimeCounter({ probeID, url }: DowntimeCounter) {
+  const newIncidents = getContext().incidents.filter(
+    (incident) =>
+      incident.probeID !== probeID && incident.probeRequestURL !== url
+  )
+
+  setContext({ incidents: newIncidents })
 }

--- a/src/components/downtime-counter/index.ts
+++ b/src/components/downtime-counter/index.ts
@@ -22,6 +22,7 @@
  * SOFTWARE.                                                                      *
  **********************************************************************************/
 
+import { formatDistanceToNow } from 'date-fns'
 import { getContext, setContext } from '../../context'
 
 export function updateLastIncidentData(
@@ -55,4 +56,19 @@ function startDowntimeCounter({ probeID, url }: DowntimeCounter) {
   const newIncident = { probeID, probeRequestURL: url, createdAt: new Date() }
 
   setContext({ incidents: [...getContext().incidents, newIncident] })
+}
+
+export function getDowntimeDuration({ probeID, url }: DowntimeCounter): string {
+  const lastIncident = getContext().incidents.find(
+    (incident) =>
+      incident.probeID === probeID && incident.probeRequestURL === url
+  )
+
+  if (!lastIncident) {
+    return '0 seconds'
+  }
+
+  return formatDistanceToNow(lastIncident.createdAt, {
+    includeSeconds: true,
+  })
 }

--- a/src/components/downtime-counter/index.ts
+++ b/src/components/downtime-counter/index.ts
@@ -42,8 +42,17 @@ export function updateLastIncidentData(
     return
   }
 
+  startDowntimeCounter({ probeID, url })
+}
+
+type DowntimeCounter = {
+  probeID: string
+  url: string
+}
+
+function startDowntimeCounter({ probeID, url }: DowntimeCounter) {
   // set incident date time to global context to be used later on recovery notification
   const newIncident = { probeID, probeRequestURL: url, createdAt: new Date() }
 
-  setContext({ incidents: [...incidents, newIncident] })
+  setContext({ incidents: [...getContext().incidents, newIncident] })
 }

--- a/src/components/notification/alert-message.ts
+++ b/src/components/notification/alert-message.ts
@@ -113,13 +113,12 @@ export async function getMessageForAlert({
     version: userAgent,
   }
 
-  const lastIncident = incidents.find(
-    (incident) =>
-      incident.probeID === probeID && incident.probeRequestURL === url
-  )
   const recoveryMessage = getRecoveryMessage(
     isRecovery,
-    lastIncident?.createdAt
+    incidents.find(
+      (incident) =>
+        incident.probeID === probeID && incident.probeRequestURL === url
+    )?.createdAt
   )
   const expectedMessage = getExpectedMessage(alert, response, isRecovery)
   const bodyString = `Message: ${recoveryMessage}${expectedMessage}

--- a/src/components/notification/alert-message.ts
+++ b/src/components/notification/alert-message.ts
@@ -24,7 +24,7 @@
 
 import { hostname, platform } from 'os'
 import { promisify } from 'util'
-import { format, formatDistanceToNow } from 'date-fns'
+import { format } from 'date-fns'
 import * as Handlebars from 'handlebars'
 import getos from 'getos'
 import osName from 'os-name'
@@ -33,6 +33,7 @@ import type { NotificationMessage } from '@hyperjumptech/monika-notification'
 import { ProbeRequestResponse } from '../../interfaces/request'
 import { ProbeAlert } from '../../interfaces/probe'
 import { publicIpAddress, publicNetworkInfo } from '../../utils/public-ip'
+import { getDowntimeDuration } from '../downtime-counter'
 
 const getLinuxDistro = promisify(getos)
 
@@ -148,9 +149,7 @@ function getRecoveryMessage(isRecovery: boolean, probeID: string, url: string) {
     return ''
   }
 
-  const incidentDuration = formatDistanceToNow(incidentDateTime, {
-    includeSeconds: true,
-  })
+  const incidentDuration = getDowntimeDuration({ probeID, url })
   const humanReadableIncidentDateTime = format(
     incidentDateTime,
     'yyyy-MM-dd HH:mm:ss XXX'

--- a/src/components/notification/alert-message.ts
+++ b/src/components/notification/alert-message.ts
@@ -94,7 +94,7 @@ export async function getMessageForAlert({
   isRecovery,
   response,
 }: MessageAlertProps): Promise<NotificationMessage> {
-  const { userAgent, incidents } = getContext()
+  const { userAgent } = getContext()
   const [monikaInstance, osName] = await Promise.all([
     getMonikaInstance(ipAddress),
     getOSName(),
@@ -113,13 +113,7 @@ export async function getMessageForAlert({
     version: userAgent,
   }
 
-  const recoveryMessage = getRecoveryMessage(
-    isRecovery,
-    incidents.find(
-      (incident) =>
-        incident.probeID === probeID && incident.probeRequestURL === url
-    )?.createdAt
-  )
+  const recoveryMessage = getRecoveryMessage(isRecovery, probeID, url)
   const expectedMessage = getExpectedMessage(alert, response, isRecovery)
   const bodyString = `Message: ${recoveryMessage}${expectedMessage}
 
@@ -145,7 +139,11 @@ Version: ${userAgent}`
   return message
 }
 
-function getRecoveryMessage(isRecovery: boolean, incidentDateTime?: Date) {
+function getRecoveryMessage(isRecovery: boolean, probeID: string, url: string) {
+  const incidentDateTime = getContext().incidents.find(
+    (incident) =>
+      incident.probeID === probeID && incident.probeRequestURL === url
+  )?.createdAt
   if (!isRecovery || !incidentDateTime) {
     return ''
   }

--- a/src/components/notification/index.ts
+++ b/src/components/notification/index.ts
@@ -55,16 +55,14 @@ export async function sendAlerts({
     response: validation.response,
   })
 
-  updateLastIncidentData(isRecovery, probeID, url)
-
   return sendNotifications(notifications, message)
 }
 
-function updateLastIncidentData(
+export function updateLastIncidentData(
   isRecovery: boolean,
   probeID: string,
   url: string
-) {
+): void {
   const { incidents } = getContext()
 
   if (isRecovery) {

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -38,7 +38,7 @@ import {
   setProbeRunning,
 } from '../../utils/probe-state'
 import { RequestLog } from '../logger'
-import { sendAlerts } from '../notification'
+import { sendAlerts, updateLastIncidentData } from '../notification'
 import { createProbers } from './prober/factory'
 
 interface ProbeStatusProcessed {
@@ -83,6 +83,7 @@ const probeSendNotification = async (data: ProbeSendNotification) => {
   })
 
   if ((notifications?.length ?? 0) > 0) {
+    updateLastIncidentData(statusString === 'UP', probe.id, url)
     await sendAlerts({
       probeID: probe.id,
       url,

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -38,8 +38,9 @@ import {
   setProbeRunning,
 } from '../../utils/probe-state'
 import { RequestLog } from '../logger'
-import { sendAlerts, updateLastIncidentData } from '../notification'
+import { sendAlerts } from '../notification'
 import { createProbers } from './prober/factory'
+import { updateLastIncidentData } from '../downtime-counter'
 
 interface ProbeStatusProcessed {
   probe: Probe

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -40,7 +40,10 @@ import {
 import { RequestLog } from '../logger'
 import { sendAlerts } from '../notification'
 import { createProbers } from './prober/factory'
-import { updateLastIncidentData } from '../downtime-counter'
+import {
+  removeDowntimeCounter,
+  startDowntimeCounter,
+} from '../downtime-counter'
 
 interface ProbeStatusProcessed {
   probe: Probe
@@ -122,6 +125,7 @@ export function checkThresholdsAndSendAlert(
       probe.id,
       probe.requests?.[requestIndex].url || ''
     )
+
     probeSendNotification({
       index,
       probe,
@@ -139,6 +143,19 @@ export function checkThresholdsAndSendAlert(
       }))
     )
   }
+}
+
+function updateLastIncidentData(
+  isRecovery: boolean,
+  probeID: string,
+  url: string
+): void {
+  if (isRecovery) {
+    removeDowntimeCounter({ probeID, url })
+    return
+  }
+
+  startDowntimeCounter({ probeID, url })
 }
 
 export function getProbeStatesWithValidAlert(

--- a/src/components/probe/index.ts
+++ b/src/components/probe/index.ts
@@ -83,7 +83,6 @@ const probeSendNotification = async (data: ProbeSendNotification) => {
   })
 
   if ((notifications?.length ?? 0) > 0) {
-    updateLastIncidentData(statusString === 'UP', probe.id, url)
     await sendAlerts({
       probeID: probe.id,
       url,
@@ -117,6 +116,11 @@ export function checkThresholdsAndSendAlert(
       break
     }
 
+    updateLastIncidentData(
+      (state || 'UP') === 'UP',
+      probe.id,
+      probe.requests?.[requestIndex].url || ''
+    )
     probeSendNotification({
       index,
       probe,

--- a/src/jobs/tls-check.ts
+++ b/src/jobs/tls-check.ts
@@ -24,7 +24,7 @@
 
 import { getConfig } from '../components/config'
 import { saveNotificationLog } from '../components/logger/history'
-import { sendAlerts } from '../components/notification'
+import { sendAlerts, updateLastIncidentData } from '../components/notification'
 import { checkTLS, getHostname } from '../components/tls-checker'
 import type { Notification } from '@hyperjumptech/monika-notification'
 import type { ValidatedResponse } from '../plugins/validate-response'
@@ -111,6 +111,7 @@ function sendTLSErrorNotification({
 
     // TODO: invoke sendNotifications function instead
     // looks like the sendAlerts function does not handle this
+    updateLastIncidentData(false, '', hostname)
     sendAlerts({
       probeID: '',
       url: hostname,

--- a/src/jobs/tls-check.ts
+++ b/src/jobs/tls-check.ts
@@ -24,11 +24,12 @@
 
 import { getConfig } from '../components/config'
 import { saveNotificationLog } from '../components/logger/history'
-import { sendAlerts, updateLastIncidentData } from '../components/notification'
+import { sendAlerts } from '../components/notification'
 import { checkTLS, getHostname } from '../components/tls-checker'
 import type { Notification } from '@hyperjumptech/monika-notification'
 import type { ValidatedResponse } from '../plugins/validate-response'
 import { log } from '../utils/pino'
+import { updateLastIncidentData } from '../components/downtime-counter'
 
 type SendTLSErrorNotificationProps = {
   hostname: string

--- a/src/jobs/tls-check.ts
+++ b/src/jobs/tls-check.ts
@@ -63,6 +63,7 @@ export function tlsChecker(): void {
         return
       }
 
+      updateLastIncidentData(false, '', hostname)
       sendTLSErrorNotification({
         hostname,
         notifications: notifications || [],
@@ -111,7 +112,6 @@ function sendTLSErrorNotification({
 
     // TODO: invoke sendNotifications function instead
     // looks like the sendAlerts function does not handle this
-    updateLastIncidentData(false, '', hostname)
     sendAlerts({
       probeID: '',
       url: hostname,

--- a/src/jobs/tls-check.ts
+++ b/src/jobs/tls-check.ts
@@ -29,7 +29,6 @@ import { checkTLS, getHostname } from '../components/tls-checker'
 import type { Notification } from '@hyperjumptech/monika-notification'
 import type { ValidatedResponse } from '../plugins/validate-response'
 import { log } from '../utils/pino'
-import { updateLastIncidentData } from '../components/downtime-counter'
 
 type SendTLSErrorNotificationProps = {
   hostname: string
@@ -64,7 +63,6 @@ export function tlsChecker(): void {
         return
       }
 
-      updateLastIncidentData(false, '', hostname)
       sendTLSErrorNotification({
         hostname,
         notifications: notifications || [],


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add
Currently, the downtime counter functionality is inside the send alert function. It is impossible to send alert without count the downtime which is unnecessary in some cases. So, I extracted the downtime counter function to make it reusable, more readable and decouple from the send alert function.

## How did you implement / how did you fix it
refactor: extract updateLastIncidentData function
refactor: move function
refactor: move updateLastIncidentData function
refactor: extract start downtime counter function
refactor: inline incidentDateTime statement
refactor: move incidentDateTime statement to its caller
refactor: extract get downtime duration function
refactor: extract remove downtime counter function
refactor: remove dead code
refactor: move function to its caller

## How to test
1. Run Monika as usual
2. Run the tests
