### PR TITLE
Fix: Change Response Time Default Alert Message

### DIFF
--- a/src/looper/index.ts
+++ b/src/looper/index.ts
@@ -72,7 +72,7 @@ export function sanitizeProbe(isSymonMode: boolean, probe: Probe): Probe {
   const isAlertsEmpty = alerts === undefined || alerts.length === 0
   if (!isSymonMode && isHTTPProbe && isAlertsEmpty) {
     log.warn(
-      `Warning: Probe ${id} has no Alerts configuration defined. Using the default response.status != 200 and response.time > 20000`
+      `Warning: Probe ${id} has no Alerts configuration defined. Using the default response.status != 200 and response.time > 2000`
     )
   }
 


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add
Change a typo from 20000 to 2000 in the response time default alert Message

## How did you implement / how did you fix it
Change 20000 to 2000

## How to test
1. Run Monika with the following configuration

```yaml
probes:
  - id: default-alert
    requests:
      - url: https://google.com
```
