### PR TITLE
Fix: Monika exits when connected to Symon with an empty probe

### DIFF
--- a/src/components/config/index.test.ts
+++ b/src/components/config/index.test.ts
@@ -29,6 +29,7 @@ import type { Config } from '../../interfaces/config'
 import events from '../../events'
 import { md5Hash } from '../../utils/hash'
 import { getEventEmitter } from '../../utils/events'
+import type { MonikaFlags } from '../../context/monika-flags'
 
 describe('getConfig', () => {
   afterEach(() => {
@@ -39,6 +40,19 @@ describe('getConfig', () => {
     expect(() => getConfig()).to.throw(
       'Configuration setup has not been run yet'
     )
+  })
+
+  it('should return empty array when config is empty in Symon mode', () => {
+    // arrange
+    setContext({
+      flags: {
+        symonKey: 'bDF8j',
+        symonUrl: 'https://example.com',
+      } as MonikaFlags,
+    })
+
+    // act and assert
+    expect(getConfig()).deep.eq({ probes: [] })
   })
 
   it('should return config', () => {

--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -67,9 +67,17 @@ const defaultConfigs: Partial<Config>[] = []
 let nonDefaultConfig: Partial<Config>
 
 export const getConfig = (): Config => {
-  const { config } = getContext()
+  const { config, flags } = getContext()
 
-  if (!config) throw new Error('Configuration setup has not been run yet')
+  if (!config) {
+    if (!isSymonModeFrom(flags)) {
+      throw new Error('Configuration setup has not been run yet')
+    }
+
+    return {
+      probes: [],
+    }
+  }
 
   return config
 }


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add
Monika exits when connected to Symon with an empty probe. It will fix #1121.

## How did you implement / how did you fix it
Don't throw error when config is empty in Symon mode.

## How to test
1. Run Symon.
2. Run Monika in Symon mode.
3. Connect Monika through operator dashboard.
4. Assign to some probe.

## Video

https://github.com/hyperjumptech/monika/assets/15191978/666714a2-0c7a-4fb8-85a4-0fe61aa1f228

