### PR TITLE
Test: Set Monika Repeat Flag to 1 in the Command Test

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -65,6 +65,8 @@ describe('monika', () => {
       cmd.run([
         '--config',
         'https://raw.githubusercontent.com/hyperjumptech/monika/main/monika.example.yml',
+        '--repeat',
+        '1',
       ])
     )
     .it('detects valid remote config', (ctx) => {
@@ -109,6 +111,8 @@ describe('monika', () => {
       cmd.run([
         '--config',
         resolve('./test/testConfigs/probes/noProbeName.yml'),
+        '--repeat',
+        '1',
       ])
     )
     .it('runs with config without probe name', (ctx) => {
@@ -136,6 +140,8 @@ describe('monika', () => {
       cmd.run([
         '--config',
         resolve('./test/testConfigs/probes/noProbeAlerts.yml'),
+        '--repeat',
+        '1',
       ])
     )
     .it('runs with config without probe alerts', (ctx) => {
@@ -191,6 +197,8 @@ describe('monika', () => {
       cmd.run([
         '--config',
         resolve('./test/testConfigs/probes/stringProbeRequestAlert.yml'),
+        '--repeat',
+        '1',
       ])
     )
     .it(
@@ -206,6 +214,8 @@ describe('monika', () => {
       cmd.run([
         '--config',
         resolve('./test/testConfigs/probes/objectProbeRequestAlert.yml'),
+        '--repeat',
+        '1',
       ])
     )
     .it(
@@ -221,6 +231,8 @@ describe('monika', () => {
       cmd.run([
         '--config',
         resolve('./test/testConfigs/probes/multipleProbeRequests.yml'),
+        '--repeat',
+        '1',
       ])
     )
     .it('runs with multiple probe requests config', (ctx) => {
@@ -233,6 +245,8 @@ describe('monika', () => {
       cmd.run([
         '--config',
         resolve('./test/testConfigs/probes/chainingRequests.yml'),
+        '--repeat',
+        '1',
       ])
     )
     .it('runs with chaining probe requests config', (ctx) => {
@@ -247,6 +261,8 @@ describe('monika', () => {
         '--config',
         resolve('./test/testConfigs/mailgun/mailgunconfig.yml'),
         '--verbose',
+        '--repeat',
+        '1',
       ])
     )
     .it('runs with mailgun config', (ctx) => {
@@ -275,6 +291,8 @@ describe('monika', () => {
         '--config',
         resolve('./test/testConfigs/sendgrid/sendgridconfig.yml'),
         '--verbose',
+        '--repeat',
+        '1',
       ])
     )
     .it('runs with sendgrid config', (ctx) => {
@@ -302,6 +320,8 @@ describe('monika', () => {
         '--config',
         resolve('./test/testConfigs/smtp/smtpconfig.yml'),
         '--verbose',
+        '--repeat',
+        '1',
       ])
     )
     .it('runs with SMTP config', (ctx) => {
@@ -332,6 +352,8 @@ describe('monika', () => {
         '--config',
         resolve('./test/testConfigs/webhook/webhookconfig.yml'),
         '--verbose',
+        '--repeat',
+        '1',
       ])
     )
     .it('runs with Webhook config', (ctx) => {
@@ -347,6 +369,8 @@ describe('monika', () => {
         '--config',
         resolve('./test/testConfigs/discord/discordconfig.yml'),
         '--verbose',
+        '--repeat',
+        '1',
       ])
     )
     .it('runs with Discord config', (ctx) => {
@@ -361,6 +385,8 @@ describe('monika', () => {
         '--config',
         resolve('./test/testConfigs/teams/teamsconfig.yml'),
         '--verbose',
+        '--repeat',
+        '1',
       ])
     )
     .it('runs with Teams config', (ctx) => {
@@ -388,6 +414,8 @@ describe('monika', () => {
         '--config',
         resolve('./test/testConfigs/monika-notif/monikaNotifconfig.yml'),
         '--verbose',
+        '--repeat',
+        '1',
       ])
     )
     .it('runs with Monika-Notif config', (ctx) => {
@@ -399,7 +427,12 @@ describe('monika', () => {
   test
     .stdout()
     .do(() =>
-      cmd.run(['--config', resolve('./test/testConfigs/fullConfig.yml')])
+      cmd.run([
+        '--config',
+        resolve('./test/testConfigs/fullConfig.yml'),
+        '--repeat',
+        '1',
+      ])
     )
     .it('runs with full config', (ctx) => {
       expect(ctx.stdout).to.contain('Starting Monika.')
@@ -412,6 +445,8 @@ describe('monika', () => {
         '--config',
         resolve('./test/testConfigs/simple-1p-1n.yaml'),
         resolve('./test/testConfigs/simple-1p-2n.yaml'),
+        '--repeat',
+        '1',
       ])
     )
     .it('runs multiple config override', (ctx) => {
@@ -426,6 +461,8 @@ describe('monika', () => {
         '-c',
         resolve('./test/testConfigs/manyNotif.yml'),
         resolve('./test/testConfigs/simple-1p-1n.yaml'),
+        '--repeat',
+        '1',
       ])
     )
     .it(
@@ -444,6 +481,8 @@ describe('monika', () => {
         '--config',
         resolve('./test/testConfigs/fullConfig.yml'),
         resolve('./test/testConfigs/manyNotif.yml'),
+        '--repeat',
+        '1',
       ])
     )
     .it('runs multiple config override', (ctx) => {
@@ -453,7 +492,14 @@ describe('monika', () => {
 
   test
     .stdout()
-    .do(() => cmd.run(['--har', resolve('./test/testConfigs/harTest.har')]))
+    .do(() =>
+      cmd.run([
+        '--har',
+        resolve('./test/testConfigs/harTest.har'),
+        '--repeat',
+        '1',
+      ])
+    )
     .it('runs with har file config', (ctx) => {
       expect(ctx.stdout).to.contain('Starting Monika.')
     })
@@ -464,6 +510,8 @@ describe('monika', () => {
       cmd.run([
         '--insomnia',
         resolve('./src/components/config/__tests__/petstore.insomnia.yaml'),
+        '--repeat',
+        '1',
       ])
     )
     .it('runs with insomnia file config', (ctx) => {
@@ -476,6 +524,8 @@ describe('monika', () => {
       cmd.run([
         '--postman',
         resolve('./test/testConfigs/simple.postman_collection.json'),
+        '--repeat',
+        '1',
       ])
     )
     .it('runs with postman file', (ctx) => {
@@ -491,6 +541,8 @@ describe('monika', () => {
         resolve('./test/testConfigs/manyProbes.yml'),
         '--har',
         resolve('./test/testConfigs/harTest.har'),
+        '--repeat',
+        '1',
       ])
     )
     .it('merge har file with other config', (ctx) => {
@@ -506,6 +558,8 @@ describe('monika', () => {
         '-c',
         resolve('./test/testConfigs/manyNotif.yml'),
         resolve('./test/testConfigs/manyProbes.yml'),
+        '--repeat',
+        '1',
       ])
     )
     .it('probes from har file will override regardless flag order', (ctx) => {
@@ -521,6 +575,8 @@ describe('monika', () => {
         resolve('./test/testConfigs/manyProbes.yml'),
         '--postman',
         resolve('./test/testConfigs/simple.postman_collection.json'),
+        '--repeat',
+        '1',
       ])
     )
     .it('merge postman file with other config', (ctx) => {
@@ -536,6 +592,8 @@ describe('monika', () => {
         '-c',
         resolve('./test/testConfigs/manyNotif.yml'),
         resolve('./test/testConfigs/manyProbes.yml'),
+        '--repeat',
+        '1',
       ])
     )
     .it(


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

Currently, when testing Monika, it continues to run in the background even though we no longer need it. To make it exit, we need to set the repeat flag to 1.

## How did you implement / how did you fix it

Set Monika's repeat flag to 1 in the `./test/index.test.ts` file.

## How to test

Run `npm run clean && NODE_ENV=test mocha --require ts-node/register ./test/index.test.ts`.

## Video

### Before

https://github.com/hyperjumptech/monika/assets/15191978/0718d37a-4009-403a-80c7-e412a7c1d7ae

### After

https://github.com/hyperjumptech/monika/assets/15191978/5f06b6c7-d809-4f58-b64b-7b4f77c6b860
