### PR TITLE
Issue 1142 - Ci/CD broken workflow

### DIFF
--- a/.github/workflows/auto-pr-schemastore.yml
+++ b/.github/workflows/auto-pr-schemastore.yml
@@ -49,7 +49,6 @@ jobs:
         run : |
           cd src
           npm ci
-          npm run build -w packages/notification
           npm run build
 
       - name: Create Pull Request


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add
1. Fixes issue #1142 
2. Broken auto PR github action

## How did you implement / how did you fix it
1. An unneeded step was accidentally added to the pipeline to fix a previous pipeline issue
2. Remove offending step

Context: 
The line `npm run build -w packages/notification` is for building monika to eventually test. But in that job, it is for building and testing schemastore not Monika.