### PR TITLE
Feat: Allow "CONNECT" and "TRACE" HTTP method

### DIFF
--- a/src/components/config/validation/validator/probe.ts
+++ b/src/components/config/validation/validator/probe.ts
@@ -207,6 +207,7 @@ export async function validateProbes(probes: Probe[]): Promise<Probe[]> {
               method: joi
                 .string()
                 .valid(
+                  'CONNECT',
                   'GET',
                   'POST',
                   'PUT',

--- a/src/components/config/validation/validator/probe.ts
+++ b/src/components/config/validation/validator/probe.ts
@@ -217,6 +217,7 @@ export async function validateProbes(probes: Probe[]): Promise<Probe[]> {
                   'OPTIONS',
                   'PURGE',
                   'LINK',
+                  'TRACE',
                   'UNLINK'
                 )
                 .default('GET')

--- a/src/monika-config-schema.json
+++ b/src/monika-config-schema.json
@@ -251,7 +251,20 @@
             "title": "HTTP Method",
             "type": "string",
             "description": "The http method",
-            "enum": ["GET", "POST", "DELETE", "PUT", "PATCH"],
+            "enum": [
+              "CONNECT",
+              "DELETE",
+              "GET",
+              "HEAD",
+              "LINK",
+              "OPTIONS",
+              "PATCH",
+              "POST",
+              "PURGE",
+              "PUT",
+              "TRACE",
+              "UNLINK"
+            ],
             "default": "GET"
           },
           "url": {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -155,6 +155,18 @@ describe('monika', () => {
     })
 
   test
+    .stdout()
+    .do(() =>
+      cmd.run([
+        '--config',
+        resolve('./test/testConfigs/probes/valid-http-method.yaml'),
+      ])
+    )
+    .it('Runs with allowed HTTP method', (ctx) => {
+      expect(ctx.stdout).to.contain('Starting Monika.')
+    })
+
+  test
     .stderr()
     .do(() =>
       cmd.run([
@@ -164,7 +176,7 @@ describe('monika', () => {
     )
     .catch((error) => {
       expect(error.message).to.contain(
-        '"Probe request method" must be one of [GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS, PURGE, LINK, UNLINK]'
+        '"Probe request method" must be one of [CONNECT, GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS, PURGE, LINK, TRACE, UNLINK'
       )
     })
     .it('runs with config with invalid probe request method')

--- a/test/testConfigs/probes/valid-http-method.yaml
+++ b/test/testConfigs/probes/valid-http-method.yaml
@@ -1,0 +1,52 @@
+probes:
+  - id: "Not defined"
+    requests:
+      - url: http://example.com
+  - id: "CONNECT"
+    requests:
+      - url: http://example.com
+        method: CONNECT
+  - id: "DELETE"
+    requests:
+      - url: http://example.com
+        method: DELETE
+  - id: "GET"
+    requests:
+      - url: http://example.com
+        method: GET
+  - id: "HEAD"
+    requests:
+      - url: http://example.com
+        method: HEAD
+  - id: "LINK"
+    requests:
+      - url: http://example.com
+        method: LINK
+  - id: "OPTIONS"
+    requests:
+      - url: http://example.com
+        method: OPTIONS
+  - id: "PATCH"
+    requests:
+      - url: http://example.com
+        method: PATCH
+  - id: "POST"
+    requests:
+      - url: http://example.com
+        method: POST
+  - id: "PURGE"
+    requests:
+      - url: http://example.com
+        method: PURGE
+  - id: "PUT"
+    requests:
+      - url: http://example.com
+        method: PUT
+  - id: "TRACE"
+    requests:
+      - url: http://example.com
+        method: TRACE
+  - id: "UNLINK"
+    requests:
+      - url: http://example.com
+        method: UNLINK

--- a/test/testConfigs/probes/valid-http-method.yaml
+++ b/test/testConfigs/probes/valid-http-method.yaml
@@ -1,52 +1,52 @@
 probes:
-  - id: "Not defined"
+  - id: 'Not defined'
     requests:
       - url: http://example.com
-  - id: "CONNECT"
+  - id: 'CONNECT'
     requests:
       - url: http://example.com
         method: CONNECT
-  - id: "DELETE"
+  - id: 'DELETE'
     requests:
       - url: http://example.com
         method: DELETE
-  - id: "GET"
+  - id: 'GET'
     requests:
       - url: http://example.com
         method: GET
-  - id: "HEAD"
+  - id: 'HEAD'
     requests:
       - url: http://example.com
         method: HEAD
-  - id: "LINK"
+  - id: 'LINK'
     requests:
       - url: http://example.com
         method: LINK
-  - id: "OPTIONS"
+  - id: 'OPTIONS'
     requests:
       - url: http://example.com
         method: OPTIONS
-  - id: "PATCH"
+  - id: 'PATCH'
     requests:
       - url: http://example.com
         method: PATCH
-  - id: "POST"
+  - id: 'POST'
     requests:
       - url: http://example.com
         method: POST
-  - id: "PURGE"
+  - id: 'PURGE'
     requests:
       - url: http://example.com
         method: PURGE
-  - id: "PUT"
+  - id: 'PUT'
     requests:
       - url: http://example.com
         method: PUT
-  - id: "TRACE"
+  - id: 'TRACE'
     requests:
       - url: http://example.com
         method: TRACE
-  - id: "UNLINK"
+  - id: 'UNLINK'
     requests:
       - url: http://example.com
         method: UNLINK


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add
Allow [CONNECT](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT) and [TRACE](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/TRACE) HTTP method.

## How did you implement / how did you fix it
1. Allow the HTTP method in the validation and json schema. 
2. Add test.

## How to test
1. Run `npm start -- -c ./test/testConfigs/probes/valid-http-method.yaml`.
2. Run the unit test.

## Screenshot

### Before
![image](https://github.com/hyperjumptech/monika/assets/15191978/4788a2a8-156a-4ce7-ba33-ee21d2e93e84)

### After
![image](https://github.com/hyperjumptech/monika/assets/15191978/a9e3a7cf-aeac-44ee-ae1a-b9a74633387d)
