### PR TITLE
Fix: Include the workers when npm pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
   "files": [
     "/bin",
     "/lib",
+    "/lib/workers",
     "/npm-shrinkwrap.json",
     "/oclif.manifest.json",
     "/scripts",


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add
This PR includes the lib/workers directory when running npm pack

## How did you implement / how did you fix it
Add the lib/workers in the package.json

## How to test
`npm pack`

## Screenshot
<img width="1509" alt="Screenshot 2023-11-08 at 15 23 37" src="https://github.com/hyperjumptech/monika/assets/16670475/a59a8fe5-135d-4790-a2c2-5c76767867f5">

Running from the installed pack:
<img width="1485" alt="Screenshot 2023-11-08 at 15 31 22" src="https://github.com/hyperjumptech/monika/assets/16670475/9a68a094-e9ea-4056-9e82-00608ac51131">



