### PR TITLE
Fix: Validation on Alert Assertion

### DIFF
--- a/src/components/config/validation/validator/probe.test.ts
+++ b/src/components/config/validation/validator/probe.test.ts
@@ -28,6 +28,8 @@ import type { Probe } from '../../../../interfaces/probe'
 
 import { FAILED_REQUEST_ASSERTION } from '../../../../looper'
 import { validateProbes } from './probe'
+import { resetContext, setContext } from '../../../../../src/context'
+import type { MonikaFlags } from '../../../../../src/flag'
 
 describe('Probe validation', () => {
   describe('Probe sanitization', () => {
@@ -155,6 +157,53 @@ describe('Probe validation', () => {
       // assert
       expect(result[0].alerts[0].assertion).eq('')
       expect(result[0].alerts[0].message).eq(FAILED_REQUEST_ASSERTION.message)
+    })
+
+    it('should throws an error if alert assertion is invalid', () => {
+      // arrange
+      const probe = {
+        id: 'Example',
+        requests: [{ url: 'https://example.com' }],
+        alerts: [{ assertion: 'response.time > 1000 ms' }],
+      } as unknown as Probe
+
+      // act & assert
+      expect(validateProbes([probe])).to.eventually.throw()
+    })
+
+    it.only('should skips the probe if alert assertion is invalid', async () => {
+      // arrange
+      setContext({
+        flags: {
+          symonKey: 'bDF8j',
+          symonUrl: 'https://example.com',
+        } as MonikaFlags,
+      })
+      const probes = [
+        {
+          id: 'Example',
+          requests: [{ url: 'https://example.com' }],
+          alerts: [{ assertion: 'response.time > 1000 ms' }],
+        },
+        {
+          id: 'Example 2',
+          requests: [{ url: 'https://example.com' }],
+          alerts: [{ assertion: 'response.time > 1000' }],
+        },
+        {
+          id: 'Example 3',
+          requests: [{ url: 'https://example.com' }],
+          alerts: [{ assertion: 'response.status == 200' }],
+        },
+      ] as unknown as Probe[]
+
+      // act
+      const validatedProbe = await validateProbes(probes)
+
+      // assert
+      expect(validatedProbe).to.deep.eq(probes.filter((_, index) => index > 0))
+
+      resetContext()
     })
   })
 })

--- a/src/components/config/validation/validator/probe.test.ts
+++ b/src/components/config/validation/validator/probe.test.ts
@@ -203,7 +203,7 @@ describe('Probe validation', () => {
       // assert
       expect(
         validatedProbes.find(({ id }) => id === 'Example')?.alerts
-      ).deep.eq([])
+      ).deep.eq([''])
       expect(
         validatedProbes.find(({ id }) => id === 'Example 2')?.alerts
       ).deep.eq([{ assertion: 'response.time > 1000' }])

--- a/src/components/config/validation/validator/probe.test.ts
+++ b/src/components/config/validation/validator/probe.test.ts
@@ -171,7 +171,7 @@ describe('Probe validation', () => {
       expect(validateProbes([probe])).to.eventually.throw()
     })
 
-    it.only('should skips the probe if alert assertion is invalid', async () => {
+    it('should set the alerts empty if the probe if alert assertion is invalid in Symon mode', async () => {
       // arrange
       setContext({
         flags: {
@@ -198,10 +198,18 @@ describe('Probe validation', () => {
       ] as unknown as Probe[]
 
       // act
-      const validatedProbe = await validateProbes(probes)
+      const validatedProbes = await validateProbes(probes)
 
       // assert
-      expect(validatedProbe).to.deep.eq(probes.filter((_, index) => index > 0))
+      expect(
+        validatedProbes.find(({ id }) => id === 'Example')?.alerts
+      ).deep.eq([])
+      expect(
+        validatedProbes.find(({ id }) => id === 'Example 2')?.alerts
+      ).deep.eq([{ assertion: 'response.time > 1000' }])
+      expect(
+        validatedProbes.find(({ id }) => id === 'Example 3')?.alerts
+      ).deep.eq([{ assertion: 'response.status == 200' }])
 
       resetContext()
     })

--- a/src/components/config/validation/validator/probe.ts
+++ b/src/components/config/validation/validator/probe.ts
@@ -61,7 +61,7 @@ export async function validateProbes(probes: Probe[]): Promise<Probe[]> {
           isValidProbeAlert(alert)
         } catch (error: unknown) {
           if (isSymonModeFrom(getContext().flags)) {
-            log.error((error as Error).message)
+            log.error((error as Error)?.message)
             return ''
           }
 
@@ -338,7 +338,11 @@ function parseAlertStringTime(str: string): number {
 
 function isValidProbeAlert(alert: ProbeAlert | string) {
   if (typeof alert !== 'string') {
-    const expression = alert.assertion || alert.query || ''
+    const expression = alert.assertion || alert.query
+    if (!expression) {
+      return
+    }
+
     const data = {
       response: {
         size: 0,

--- a/src/components/config/validation/validator/probe.ts
+++ b/src/components/config/validation/validator/probe.ts
@@ -352,14 +352,28 @@ function validateAlerts(alerts: (ProbeAlert | string)[]) {
     try {
       isValidProbeAlert(alert)
     } catch {
-      throw new Error(`Probe alert format is invalid! (${alert})`)
+      throw new Error(
+        `Probe alert format is invalid! (${JSON.stringify(alert, null, 1)})`
+      )
     }
   }
 }
 
 function isValidProbeAlert(alert: ProbeAlert | string) {
   if (typeof alert !== 'string') {
-    compileExpression(alert.assertion || alert.query || '')
+    const expression = alert.assertion || alert.query || ''
+    const data = {
+      response: {
+        size: 0,
+        status: 200,
+        time: 0,
+        body: '',
+        headers: {},
+      },
+    }
+    const filter = compileExpression(expression, Object.keys(data))
+
+    filter(data)
     return
   }
 

--- a/src/components/config/validation/validator/probe.ts
+++ b/src/components/config/validation/validator/probe.ts
@@ -30,6 +30,7 @@ import { getContext } from '../../../../context'
 import { FAILED_REQUEST_ASSERTION } from '../../../../looper'
 import { compileExpression } from '../../../../utils/expression-parser'
 import { isValidURL } from '../../../../utils/is-valid-url'
+import { log } from '../../../../utils/pino'
 import {
   DEFAULT_INCIDENT_THRESHOLD,
   DEFAULT_INTERVAL,
@@ -58,9 +59,10 @@ export async function validateProbes(probes: Probe[]): Promise<Probe[]> {
       .custom((alert) => {
         try {
           isValidProbeAlert(alert)
-        } catch {
+        } catch (error: unknown) {
           if (isSymonModeFrom(getContext().flags)) {
-            return
+            log.error((error as Error).message)
+            return ''
           }
 
           throw new Error(


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add?

Fix alert assertion validation. This will resolves #1177.

## How did you implement / how did you fix it?

- Add some tests.
- Compile alert assertion expression to the data with default value instead of empty array.
- Move manual validation into [Joi](https://github.com/hapijs/joi).

## How to test

### Standalone

Run with the following configuration

```yaml
probes:
  - id: "1"
    requests:
      - url: https://github.com
        alerts:
          - assertion: response.size >= 10000 ms
            message: Response size is {{ response.size }}, expecting less than 10000
```

### Symon

Use `response.size >= 10000 ms` as an alert assertion in a probe.

## Video

### Standalone

https://github.com/hyperjumptech/monika/assets/15191978/1689a58a-be59-41bf-89da-ad872e204204

### Symon mode

https://github.com/hyperjumptech/monika/assets/15191978/4425d36d-ced9-446e-9c09-03933b46e3ec
