### PR TITLE
Feat: Add --ignoreInvalidTLS flag

### DIFF
--- a/docs/src/pages/guides/cli-options.md
+++ b/docs/src/pages/guides/cli-options.md
@@ -320,6 +320,14 @@ monika --summary
 Please note that you need to run the above command from the same working directory as the running monika you want to see/check.
 The '--summary' flag also will not work when no other monika process is running.
 
+## TLS Reject Unauthorized
+
+If there is a probe with request(s) that uses HTTPS, Monika will show an error if the target's TLS certificate is invalid. You can configure whether HTTPS requests should ignore invalid certificates using the `--ignoreInvalidTLS` flag.
+
+```bash
+monika --ignoreInvalidTLS
+```
+
 ## Verbose
 
 Like your app to be more chatty and honest revealing all its internal details? Use the `--verbose` flag.

--- a/src/commands/monika.ts
+++ b/src/commands/monika.ts
@@ -135,6 +135,12 @@ export default class Monika extends Command {
       multiple: false,
     }),
 
+    ignoreInvalidTLS: Flags.boolean({
+      description:
+        'Configures whether HTTPS requests should ignore invalid certificates',
+      default: false,
+    }),
+
     insomnia: Flags.string({
       char: 'I', // (I)nsomnia file to
       description: 'Run Monika using an Insomnia json/yaml file',

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -65,6 +65,7 @@ export type MonikaFlags = {
   symonReportLimit?: number
   symonUrl?: string
   text?: string
+  ignoreInvalidTLS?: boolean
   verbose: boolean
   version: void
 }


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add
This PR fixes #1182 

## How did you implement / how did you fix it
1. Add new flag: `--ignoreInvalidTLS`
2. If the flag is present, it will set `rejectUnauthorized` to the inverse value of `ignoreInvalidTLS` flag.
3. `allowUnauthorized` property in a probe still takes higher priority than the global flag

## How to test

Prepare the config:
```yml
notifications:
  - id: 'desktop'
    type: desktop
probes:
  - id: '1'
    name: 'Coding Horror'
    description: 'Self signed badssl'
    interval: 3 # in seconds
    requests:
      - method: GET
        url: 'https://self-signed.badssl.com'
        # allowUnauthorized: true
    alerts: []
``

1. Run `npm run start -- -c config.yml --ignoreInvalidTLS`. It should not display error.
2. Run `npm run start -- -c config.yml`. It should display error.
3. Uncomment the `allowUnauthorized` in the config file and run `npm run start -- -c config.yml`. It should not display error.

## Video


https://github.com/hyperjumptech/monika/assets/16670475/4ac37706-a523-4ac5-bbc1-f3afd3c1faea

