### PR TITLE
Tweak trigger to deploy notification package

### DIFF
--- a/.github/workflows/npm-notification-publish.yml
+++ b/.github/workflows/npm-notification-publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - 'package/notification'
+      - 'package/notification/**'
     branches:
       - 'main'
 

--- a/packages/notification/README.md
+++ b/packages/notification/README.md
@@ -14,11 +14,21 @@ See the main `README.md` in the Monika repository for contributing details.
 
 The notification package is released to npm. When creating a PR for the package, please ensure that:
 
-1. Linter is run
-2. The changes work with the main Monika app
-3. The command `npm run build` from packages/notification ran and builds.
-4. The versions in package.json are updated
+1. Linter is run.
+2. The changes work with the main Monika application.
+3. The command `npm run build` from packages/notification ran and builds without error.
+4. The versions in ./package.json are properly incremented.
 5. Create a PR to merge to `main`.
+
+If releasing Monika application:
+
+1. Ensure that the notification dependency is updated:
+
+```yaml
+ "dependencies": {
+ "@hyperjumptech/monika-notification": x.y.z // enter the correct version here
+
+```
 
 ## References
 


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

1. Solves #1192 
2. Publish to npm not triggering

## How did you implement / how did you fix it

1. Add wildcard to path trigger
reference: [Github document](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-paths)
2. Add more detail to README doc

h/t @raosan for the link

