### PR TITLE
fix: missing send error field when an error response exists

### DIFF
--- a/src/components/probe/prober/http/request.ts
+++ b/src/components/probe/prober/http/request.ts
@@ -209,13 +209,13 @@ export async function httpRequest({
         const { status, description } = getErrorStatusWithExplanation(error)
 
         return {
-          data: description,
+          data: '',
           body: '',
           status,
           headers: '',
           responseTime,
           result: probeRequestResult.failed,
-          error: (error as AxiosError).message,
+          error: description,
         }
       }
     }

--- a/src/components/probe/prober/http/request.ts
+++ b/src/components/probe/prober/http/request.ts
@@ -198,7 +198,7 @@ export async function httpRequest({
           status: error?.response?.status,
           headers: error?.response?.headers,
           responseTime,
-          result: probeRequestResult.failed,
+          result: probeRequestResult.success,
           error: error?.response?.data,
         }
       }

--- a/src/components/probe/prober/http/request.ts
+++ b/src/components/probe/prober/http/request.ts
@@ -193,12 +193,13 @@ export async function httpRequest({
       // 400, 500 get here
       if (error?.response) {
         return {
-          data: error?.response?.data,
-          body: error?.response?.data,
-          status: error?.response?.status as number,
+          data: '',
+          body: '',
+          status: error?.response?.status,
           headers: error?.response?.headers,
           responseTime,
-          result: probeRequestResult.success,
+          result: probeRequestResult.failed,
+          error: error?.response?.data,
         }
       }
 

--- a/src/symon/index.ts
+++ b/src/symon/index.ts
@@ -291,7 +291,8 @@ export default class SymonClient {
     validation,
     alertId,
   }: NotificationEvent) {
-    const { data, headers, responseTime, status } = validation.response
+    const { data, headers, responseTime, status, error } = validation.response
+
     this.httpClient
       .post('/events', {
         monikaId: this.monikaId,
@@ -303,6 +304,7 @@ export default class SymonClient {
           size: headers['content-length'],
           status, // status is http status code
           time: responseTime,
+          error,
         },
       })
       .then(() => {


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

1. This PR adds an `error` field when an error response exists
2. This PR changes result from `success` to `failed`

## How to test

1. Run Monika with an invalid URL to get the error
4. Expectation: The error field must be sent
