### PR TITLE
Fix: Wrong SQLite Migration File Path

### DIFF
--- a/src/components/logger/history.ts
+++ b/src/components/logger/history.ts
@@ -32,7 +32,6 @@ import type { Notification } from '@hyperjumptech/monika-notification'
 import { log } from '../../utils/pino'
 import { getConfig } from '../config'
 import { getErrorMessage } from '../../utils/catch-error-handler'
-import { fileURLToPath } from 'url'
 const sqlite3 = verboseSQLite()
 const dbPath = path.resolve(process.cwd(), 'monika-logs.db')
 
@@ -136,7 +135,7 @@ export function setDatabase(
 
 async function migrate() {
   await database().migrate({
-    migrationsPath: path.dirname(fileURLToPath('../../../db/migrations')),
+    migrationsPath: path.join(__dirname, '../../../db/migrations'),
   })
 }
 


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

Fix wrong SQLite migration file path. It resolves #1216.

## How did you implement / how did you fix it

Revert the previous file changes.

## How to test

Run `rm -rf monika-logs.db && npm start`.

## Screenshot

### Before
![image](https://github.com/hyperjumptech/monika/assets/15191978/49bd1dc9-07a3-48cc-bc97-a3b7b53b72b8)

### After
![image](https://github.com/hyperjumptech/monika/assets/15191978/4eb4f710-0c90-4ab0-a44a-d50207e4411f)

