### PR TITLE
Remove mention of snapcraft temporarily

### DIFF
--- a/docs/src/pages/quick-start.md
+++ b/docs/src/pages/quick-start.md
@@ -35,9 +35,7 @@ Alternatively, Monika for macOS can be installed from its prebuilt binary. Head 
 
 ### Linux
 
-The recommended approach is to use [Snapcraft](https://snapcraft.io/), a universal package manager for Linux. Check [Monika page on Snapcraft](https://snapcraft.io/monika) for more detailed information.
-
-Alternatively, Monika for Linux can be automatically downloaded and installed by running an installation script as follows:
+Monika for Linux can be automatically downloaded and installed by running an installation script as follows:
 
 ```bash
 curl https://raw.githubusercontent.com/hyperjumptech/monika/main/scripts/monika-install.sh | sh


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

1. Having issues with the `oclif pack tarball` and workspaces
2. While we fix it/find alternative, disable mention of snapcraft for now.

## How did you implement / how did you fix it

1. Only removed reference to snapcraft in the `quick-start.md`

## Testing

1. standard `npm run test` should run without errors.
2. pipelines should run without errors.
