### PR TITLE
Fix: Monika Multi Node

### DIFF
--- a/src/symon/index.ts
+++ b/src/symon/index.ts
@@ -197,14 +197,6 @@ export default class SymonClient {
     this.monikaId = await this.handshake()
     log.info('[Symon] Handshake')
 
-    this.sendStatus({ isOnline: true })
-      .then(() => {
-        log.info('[Symon] Send status succeed')
-      })
-      .catch((error) => {
-        log.error(`[Symon] Send status failed. ${(error as Error).message}`)
-      })
-
     const probeChangesCheckedAt = new Date()
 
     await this.fetchProbesAndUpdateConfig()


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add?

Implement a multi-node Monika with a probe changes mechanism to update the probe.

## How did you implement / how did you fix it

The implementation checks for probe assignment data changes. If there are changes, Monika will re-fetch probe configuration data.

## How to test

Run multiple instances of Monika in Symon mode. Run `npm start -- --symonUrl=[symonUrl] --symonKey=[symonKey] --symonLocationId=[symonLocationId] --symon-api-version=v2 --symonGetProbesIntervalMs=5000`.

## Video

https://github.com/hyperjumptech/monika/assets/15191978/0ef55d5a-eb75-4472-9294-d2aeb5919f56

