### PR TITLE
feat(native fetch): create --experimental-fetch as toggle feature

### DIFF
--- a/docs/src/pages/guides/cli-options.md
+++ b/docs/src/pages/guides/cli-options.md
@@ -283,6 +283,14 @@ You can also set the maximum of delay by using the `--retryMaxDelayMs` flag. Def
 monika --retryMaxDelayMs 30000
 ```
 
+## Experimental Native Node Fetch
+
+Monika use Axios as HTTP client by default, use `--experimental-fetch` to switch to native fetch provided by Node.js runtime.
+
+```sh
+monika --experimental-fetch
+```
+
 ## Follow Redirects
 
 By default Monika will follow redirects 21 times. You can set the value of `--follow-redirects` flag to tell Monika to follow redirects as many as you want. If you don't want to follow redirects, set the value to zero.

--- a/src/commands/monika.ts
+++ b/src/commands/monika.ts
@@ -105,6 +105,12 @@ export default class Monika extends Command {
         'Create config from HAR (-H), postman (-p), insomnia (-I), sitemap (--sitemap), textfile (--text) export file, or open Monika Configuration Generator using default browser',
     }),
 
+    'experimental-fetch': Flags.boolean({
+      default: monikaFlagsDefaultValue['experimental-fetch'],
+      description:
+        'Use native fetch Node.js API instead of Axios for HTTP client',
+    }),
+
     flush: Flags.boolean({
       description: 'Flush logs',
     }),

--- a/src/components/logger/startup-message.test.ts
+++ b/src/components/logger/startup-message.test.ts
@@ -426,5 +426,21 @@ describe('Startup message', () => {
       // assert
       expect(logMessage).include('config file')
     })
+
+    it('should show experimental fetch toggle', () => {
+      // act
+      logStartupMessage({
+        config: defaultConfig,
+        flags: {
+          config: ['./monika.yaml'],
+          verbose: false,
+          'experimental-fetch': true,
+        },
+        isFirstRun: false,
+      })
+
+      // assert
+      expect(logMessage).include('Using native Node.js fetch for HTTP client')
+    })
   })
 })

--- a/src/components/logger/startup-message.test.ts
+++ b/src/components/logger/startup-message.test.ts
@@ -427,6 +427,7 @@ describe('Startup message', () => {
       expect(logMessage).include('config file')
     })
 
+    // delete test on removing toggle
     it('should show experimental fetch toggle', () => {
       // act
       logStartupMessage({
@@ -441,6 +442,25 @@ describe('Startup message', () => {
 
       // assert
       expect(logMessage).include('Using native Node.js fetch for HTTP client')
+    })
+
+    // delete test on removing toggle
+    it('should hide experimental fetch toggle', () => {
+      // act
+      logStartupMessage({
+        config: defaultConfig,
+        flags: {
+          config: ['./monika.yaml'],
+          verbose: false,
+          'experimental-fetch': false,
+        },
+        isFirstRun: false,
+      })
+
+      // assert
+      expect(logMessage).not.include(
+        'Using native Node.js fetch for HTTP client'
+      )
     })
   })
 })

--- a/src/components/logger/startup-message.ts
+++ b/src/components/logger/startup-message.ts
@@ -37,7 +37,10 @@ import { createProber } from '../probe/prober/factory'
 
 type LogStartupMessage = {
   config: Config
-  flags: Pick<MonikaFlags, 'config' | 'symonKey' | 'symonUrl' | 'verbose'>
+  flags: Pick<
+    MonikaFlags,
+    'config' | 'symonKey' | 'symonUrl' | 'verbose' | 'experimental-fetch'
+  >
   isFirstRun: boolean
 }
 
@@ -57,6 +60,10 @@ export function logStartupMessage({
     } else if (configSource.length > 0) {
       log.info(`Using config file: ${path.resolve(configSource)}`)
     }
+  }
+
+  if (flags['experimental-fetch']) {
+    log.info('Using native Node.js fetch for HTTP client')
   }
 
   const startupMessage = generateStartupMessage({

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -37,6 +37,7 @@ export type MonikaFlags = {
   'config-filename': string
   'config-interval': number
   'create-config': boolean
+  'experimental-fetch'?: boolean
   flush: boolean
   'follow-redirects': number
   force: boolean
@@ -76,6 +77,7 @@ export const monikaFlagsDefaultValue: MonikaFlags = {
   'config-filename': 'monika.yml',
   'config-interval': 900,
   'create-config': false,
+  'experimental-fetch': false,
   flush: false,
   'follow-redirects': 21,
   force: false,


### PR DESCRIPTION
# Monika Pull Request (PR)
This PR resolves #1237 

## What feature does this PR add
1. Create `--experimental-fetch` as toggle feature flag to change HTTP client

## How did you implement
1. Added new flag `--experimental-fetch`
2. Added new tests for startup message

## How to test

1. `npm run test`
3. Compare startup message `npm run start` with `npm run start -- --experimental-fetch`

## Screenshot
![image](https://github.com/hyperjumptech/monika/assets/9563873/f042b972-2d0d-4686-a19a-aa75fb4904c0)
