### PR TITLE
Tweak Docs Build Workflow

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -39,7 +39,7 @@ jobs:
           node-version: 20.x
 
       - name: 📥 Install deps
-        run: npm install --legacy-peer-deps
+        run: npm ci --legacy-peer-deps
 
       - name: 👷‍♂️ Build
         run: npm run build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: 20.x
 
       - name: 📥 Install deps
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: 👷‍♂️ Build
         run: npm run build


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

1. Solves #1244 
2. Fixes Doc building fails in pipeline

## How did you implement / how did you fix it

1. Using the `--legacy-peer-deps` switch to `npm` dependency install 
2. Revert npm to version 6 behaviour
 

## How to test

1. `npm run test` should run without error
2. Trigger github action to  build the docs, by pushing to repository, or trigger the github action manually.

## Screenshot

Before: Build failed
![image](https://github.com/hyperjumptech/monika/assets/964106/9c0b8d89-766e-4122-bb63-0d2bc5c10376)

After: Build is successful
![image](https://github.com/hyperjumptech/monika/assets/964106/6b4d3ad2-e920-4ebb-8a36-f1295ef354d8)
