### PR TITLE
Fix: Algolia Build in the Docs Action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,7 +72,7 @@ jobs:
           node-version: 20.x
 
       - name: 📥 Install deps
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Install jq
         run: sudo apt-get install -y jq


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

This feature hopefully fixes #1244 

## How did you implement / how did you fix it

Previously there were PR for fixing docs build (#1250) but it still does not fix Algolia. Turns out that in the Algolia step, it still uses npm ci without `--peer-legacy-deps`.

## How to test

Run the action.

Here is the successful result: https://github.com/hyperjumptech/monika/actions/runs/8245601503