### PR TITLE
Refactor: Convert TODO Comments Into Issues

### DIFF
--- a/docs/src/pages/guides/tls-checkers.md
+++ b/docs/src/pages/guides/tls-checkers.md
@@ -7,7 +7,8 @@ You can check TLS validity and set the threshold to send notification before the
 
 ```yaml
 probes:
-  - requests:
+  - id: 'Example'
+    requests:
       - url: http://example.com
 certificate:
   domains:

--- a/docs/src/pages/quick-start.md
+++ b/docs/src/pages/quick-start.md
@@ -9,7 +9,7 @@ There are many ways to install Monika. However, currently only x64 architecture 
 
 ### Windows
 
-The recommendeded approach is to use [Chocolatey](https://community.chocolatey.org/packages/monika), a popular package manager for Windows. Check [Monika page on Chocolatey](https://community.chocolatey.org/packages/monika) for more detailed information.
+The recommended approach is to use [Chocolatey](https://community.chocolatey.org/packages/monika), a popular package manager for Windows. Check [Monika page on Chocolatey](https://community.chocolatey.org/packages/monika) for more detailed information.
 
 If you have installed Chocolatey in your PC, then run the following command to install Monika:
 

--- a/packages/notification/channel/mailgun.ts
+++ b/packages/notification/channel/mailgun.ts
@@ -26,6 +26,8 @@ import FormData from 'form-data'
 import Joi from 'joi'
 import type { NotificationMessage } from '.'
 import Mailgen from 'mailgen'
+
+import { getSender } from '../utils/default-sender'
 import { sendHttpRequest } from '../utils/http'
 
 export type NotificationData = {
@@ -109,10 +111,8 @@ function getContent({
   subject: string
   domain: string
 }): Content {
-  // TODO: Read from ENV Variables
-  const DEFAULT_SENDER_NAME = 'Monika'
+  const DEFAULT_SENDER_NAME = getSender().name
   const from = `${DEFAULT_SENDER_NAME} <mailgun@${domain}>`
-
   const mailGenerator = new Mailgen({
     theme: 'default',
     product: {

--- a/packages/notification/channel/smtp.ts
+++ b/packages/notification/channel/smtp.ts
@@ -26,6 +26,7 @@ import * as nodemailer from 'nodemailer'
 import Mailgen from 'mailgen'
 import Joi from 'joi'
 
+import { getSender } from '../utils/default-sender'
 import type { NotificationMessage } from '.'
 
 type NotificationData = {
@@ -51,8 +52,7 @@ export const send = async (
   { hostname, password, port, recipients, username }: NotificationData,
   { body, subject }: NotificationMessage
 ): Promise<void> => {
-  // TODO: Read from ENV Variables
-  const DEFAULT_EMAIL = 'monika@hyperjump.tech'
+  const DEFAULT_EMAIL = getSender().email
   const DEFAULT_SENDER_NAME = 'Monika'
   const transporter = nodemailer.createTransport({
     host: hostname,

--- a/packages/notification/index.ts
+++ b/packages/notification/index.ts
@@ -22,13 +22,23 @@
  * SOFTWARE.                                                                      *
  **********************************************************************************/
 
-import { channels, Notification, NotificationMessage } from './channel'
+import {
+  channels,
+  type Notification,
+  type NotificationMessage,
+} from './channel'
 import { getErrorMessage } from './utils/catch-error-handler'
+import { type InputSender, updateSender } from './utils/default-sender'
 
 async function sendNotifications(
   notifications: Notification[],
-  message: NotificationMessage
+  message: NotificationMessage,
+  sender?: InputSender
 ): Promise<void> {
+  if (sender) {
+    updateSender(sender)
+  }
+
   await Promise.all(
     notifications.map(async ({ data, type }) => {
       const channel = channels[type]

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperjumptech/monika-notification",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "description": "notification package for monika",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/notification/utils/default-sender.ts
+++ b/packages/notification/utils/default-sender.ts
@@ -1,0 +1,19 @@
+type Sender = {
+  name: string
+  email: string
+}
+
+export type InputSender = Partial<Sender>
+
+let defaultSender: Sender = {
+  name: 'Monika',
+  email: 'monika@hyperjump.tech',
+}
+
+export function getSender(): Sender {
+  return defaultSender
+}
+
+export function updateSender(sender: InputSender) {
+  defaultSender = { ...defaultSender, ...sender }
+}

--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -232,7 +232,6 @@ function watchConfigFile({ flags, path }: WatchConfigFileParams) {
 }
 
 const getPathAndTypeFromFlag = (flags: MonikaFlags) => {
-  // TODO: Assuming the first index of config is the primary config
   let path = flags.config?.[0]
   let type = 'monika'
 

--- a/src/components/logger/flush.test.ts
+++ b/src/components/logger/flush.test.ts
@@ -52,8 +52,6 @@ describe('Flush command', () => {
 
   describe('Not force', () => {
     test
-      // TODO: Remove skip
-      .skip()
       // arrange
       .stub(ux.ux, 'prompt', (stub) => stub.resolves('n'))
       .stdout()
@@ -65,8 +63,6 @@ describe('Flush command', () => {
       })
 
     test
-      // TODO: Remove skip
-      .skip()
       // arrange
       .stub(ux.ux, 'prompt', (stub) => stub.resolves('Y'))
       .stdout()

--- a/src/components/logger/flush.test.ts
+++ b/src/components/logger/flush.test.ts
@@ -23,10 +23,7 @@
  **********************************************************************************/
 
 import sinon from 'sinon'
-import { ux } from '@oclif/core'
-import { test } from '@oclif/test'
 import * as history from './history'
-import cmd from '../../commands/monika'
 import { flush } from './flush'
 
 let flushAllLogsStub: sinon.SinonStub
@@ -48,29 +45,5 @@ describe('Flush command', () => {
       // assert
       sinon.assert.calledOnce(flushAllLogsStub)
     })
-  })
-
-  describe('Not force', () => {
-    test
-      // arrange
-      .stub(ux.ux, 'prompt', (stub) => stub.resolves('n'))
-      .stdout()
-      // act
-      .do(() => cmd.run(['--flush']))
-      .it('should cancel flush', () => {
-        // assert
-        sinon.assert.notCalled(flushAllLogsStub)
-      })
-
-    test
-      // arrange
-      .stub(ux.ux, 'prompt', (stub) => stub.resolves('Y'))
-      .stdout()
-      // act
-      .do(() => cmd.run(['--flush']))
-      .it('should flush', () => {
-        // assert
-        sinon.assert.calledOnce(flushAllLogsStub)
-      })
   })
 })

--- a/src/components/logger/history.ts
+++ b/src/components/logger/history.ts
@@ -135,7 +135,6 @@ export function setDatabase(
 
 async function migrate() {
   await database().migrate({
-    // TODO: Current vercel/pkg is dependent with CommonJS
     // eslint-disable-next-line unicorn/prefer-module
     migrationsPath: path.join(__dirname, '../../../db/migrations'),
   })
@@ -448,7 +447,6 @@ export async function saveProbeRequestLog({
   const now = Math.round(Date.now() / 1000)
   const requestConfig = probe.requests?.[requestIndex]
 
-  // TODO: limit data stored.
   const responseBody = requestConfig?.saveBody
     ? typeof probeRes.data === 'string'
       ? probeRes.data

--- a/src/components/probe/prober/http/index.ts
+++ b/src/components/probe/prober/http/index.ts
@@ -260,7 +260,6 @@ function getProbeResultMessage({
   request,
   response,
 }: ProbeResultMessageParams): string {
-  // TODO: make this more generic not probe dependent
   if (request?.ping) {
     return response?.body as string
   }

--- a/src/utils/open-website.ts
+++ b/src/utils/open-website.ts
@@ -44,8 +44,7 @@ export const open = (url: string): void => {
     }
 
     default: {
-      // TODO: Handle new OS
-      break
+      throw new Error(`Unknown operating system: ${operatingSystem}`)
     }
   }
 }

--- a/src/utils/pino.ts
+++ b/src/utils/pino.ts
@@ -43,7 +43,6 @@ function getOptions() {
     hideObject: true,
   }
 
-  // TODO: Current vercel/pkg is dependent with CommonJS
   // eslint-disable-next-line unicorn/prefer-module
   const project = path.join(__dirname, '../../tsconfig.json')
   const dev = fs.existsSync(project)


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

- Convert a TODO comment into an issue #1260. 
- Make the hardcoded notification sender changeable through a parameter.
- Separate sending error notification for the TLS checker function due to poor abstraction.
- Remove irrelevant TODO comments.

It will resolve #1010.

## How to test

Run the following configuration. You should receive a TLS error notification (Please set your own notification):

```yaml
probes:
  - id: example
    requests:
      - url: 'https://example.com'
certificate:
  domains:
    - example.com
    - expired.badssl.com
  reminder: 30
```

### Before
<img width="606" alt="Screenshot 2024-03-26 at 12 02 17 PM" src="https://github.com/hyperjumptech/monika/assets/15191978/f3c813d6-b06b-440f-b706-8b8f89c512a1">

### After (unchanged)
<img width="596" alt="Screenshot 2024-03-26 at 12 03 12 PM" src="https://github.com/hyperjumptech/monika/assets/15191978/b8fdc159-8ee9-4990-8c2c-8b9a2fd8ff09">

