### PR TITLE
fix(http prober): crash on request probe type

### DIFF
--- a/src/interfaces/request.ts
+++ b/src/interfaces/request.ts
@@ -22,8 +22,7 @@
  * SOFTWARE.                                                                      *
  **********************************************************************************/
 
-import type { HeadersInit } from 'undici'
-import type { ProbeAlert } from './probe'
+import { ProbeAlert } from './probe'
 
 // RequestTypes are used to define the type of request that is being made.
 export type RequestTypes =
@@ -64,7 +63,7 @@ export interface RequestConfig extends Omit<RequestInit, 'headers' | 'body'> {
   body: object | string
   timeout: number // request timeout
   alerts?: ProbeAlert[]
-  headers?: HeadersInit
+  headers?: object
   ping?: boolean // is this request for a ping?
   allowUnauthorized?: boolean // ignore ssl cert?
 }


### PR DESCRIPTION
# Monika Pull Request (PR)
This PR resolves #1263 

## What feature/issue does this PR add
1. Fix crash caused by wrong typing

## How did you implement / how did you fix it
1. Revert #1256 for request config type of `HeadersInit` back to `object`
2. Revert HTTP prober related to type change

## How to test
1. Unit test Axios HTTP prober with `npm run test`.
    - Expect successful run.
2. Run Monika to test Symon client with `monika --symonUrl <URL> --symonKey <UUID> --follow-redirects=5 --retryInitialDelayMs=150000 --ignoreInvalidTLS`.
    - Expect successful run with no crash happen.
3. Force Monika to use Node.js fetch `sed -i ".bak" "s/flags\[\'native\-fetch\'\]/true/g" "src/components/probe/prober/http/request.ts"`
4. Unit test Node.js fetch implementation `npm run test`
    - Expect successful run.