### PR TITLE
fix(http): handle axios error code UNABLE_TO_VERIFY_LEAF_SIGNATURE

### DIFF
--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -332,6 +332,7 @@ To make it easier to troubleshoot HTTP requests, we have mapped low-level errors
 | 24   | Request / response size mismatch with Content-Length header value |
 | 25   | Missing HTTP client pool                                          |
 | 26   | Expected error, exact reason is shown on runtime                  |
+| 27   | Unable to verify the first / leaf certificate                     |
 | 99   | Others                                                            |
 | 599  | Connection aborted                                                |
 

--- a/src/components/probe/prober/http/request.ts
+++ b/src/components/probe/prober/http/request.ts
@@ -423,6 +423,8 @@ function handleAxiosError(
   }
 }
 
+// suppress switch-case complexity since this is dead-simple mapping to error code
+// eslint-disable-next-line complexity
 function getErrorStatusWithExplanation(error: unknown): {
   status: number
   description: string
@@ -570,6 +572,14 @@ function getErrorStatusWithExplanation(error: unknown): {
         status: 17,
         description:
           "EPROTO: There are issues with the website's SSL/TLS certificates, incompatible protocols, or other SSL-related problems.",
+      }
+    }
+
+    case 'UNABLE_TO_VERIFY_LEAF_SIGNATURE': {
+      return {
+        status: 27,
+        description:
+          'ELEAFSIGNATURE: Unable to verify the first / leaf certificate.',
       }
     }
 


### PR DESCRIPTION
# Monika Pull Request (PR)
This PR resolves #1266 

## What feature/issue does this PR add

1. Handle axios error code `UNABLE_TO_VERIFY_LEAF_SIGNATURE`

## How did you implement / how did you fix it

1. Map error code `UNABLE_TO_VERIFY_LEAF_SIGNATURE` to error code 27
2. Map error code `UNABLE_TO_VERIFY_LEAF_SIGNATURE` to error codename `ELEAFSIGNATURE`
3. Add documentation for error code 27

## How to test

1. Create `monika.yml` config below
```yaml
probes:
  - id: 'Example'
    requests:
      - url: https://kemendesa.go.id/
```
2. `npm run start -- -r 1`
3. On 5th failure, expect to see warning log `id:Example ERROR: EINVALIDLEAFSIGN: Unable to verify the first / leaf certificate., NOTIF: Service probably down`