### PR TITLE
Feat: Configurable Follow HTTP Redirect for Probe Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,37 @@ See this [docs](https://turbo.build/repo/docs/handbook/workspaces#workspaces-whi
 
 ### How to Test Probe Locally
 
-If you need to test a probe locally, there are predefined services in /dev/docker-compose.yaml. You are **encouraged** to add other services that can be probed by Monika. Run `cd dev && docker compose up` to run those services.
+If you need to test a probe locally, there are predefined services in `/dev/docker-compose.yaml`. You are **encouraged** to add other services that can be probed by Monika. Run `cd dev && docker compose up` to run those services.
 
 #### Available Services
 
 Use the following Monika config to probe the service.
+
+##### HTTPBin
+
+```yaml
+probes:
+  - id: 'should not follow redirect'
+    requests:
+      - url: http://localhost:3000/status/302
+        followRedirects: 0
+    alerts:
+      - assertion: response.status != 302
+        message: You should not follow redirect
+  - id: 'should follow redirect with default config'
+    requests:
+      - url: http://localhost:3000/absolute-redirect/20
+    alerts:
+      - assertion: response.status == 302
+        message: You are not follow redirect
+  - id: 'should follow redirect with customize config'
+    requests:
+      - url: http://localhost:3000/status/302
+        followRedirects: 2
+    alerts:
+      - assertion: response.status == 302
+        message: You are not follow redirect
+```
 
 ##### MariaDB
 

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -1,4 +1,8 @@
 services:
+  httpbin:
+    image: kennethreitz/httpbin
+    ports:
+      - 3000:80
   mariadb:
     image: mariadb:11
     container_name: monika_mariadb

--- a/dev/httpbin/docker-compose.yaml
+++ b/dev/httpbin/docker-compose.yaml
@@ -1,5 +1,0 @@
-services:
-  httpbin:
-    image: kennethreitz/httpbin
-    ports:
-      - 3000:80

--- a/dev/httpbin/docker-compose.yaml
+++ b/dev/httpbin/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  httpbin:
+    image: kennethreitz/httpbin
+    ports:
+      - 3000:80

--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -50,6 +50,7 @@ probes:
           - assertion: response.status != 200
             message: Status not 2xx
         allowUnauthorized: true
+        followRedirects: 1
     incidentThreshold: 3
     alerts:
       - assertion: response.status != 200
@@ -72,6 +73,7 @@ Details of the field are given in the table below.
 | alerts (optional)            | The condition which will trigger an alert, and the subsequent notification method to send out the alert. See below for further details on alerts and notifications. See [alerts](./alerts) section for detailed information.                                                                                                                                                                                                                                                                                                                                                                      |
 | ping (optional)              | (boolean), If set true then send a PING to the specified url instead.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | allowUnauthorized (optional) | (boolean), If set to true, will make https agent to not check for ssl certificate validity                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| followRedirects (optional)   | The request follows redirects as many times as specified here. If unspecified, it will fallback to the value set by the [follow redirects flag](https://monika.hyperjump.tech/guides/cli-options#follow-redirects)                                                                                                                                                                                                                                                                                                                                                                                |
 
 ## Request Body
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cli-test": "bats test/bats/cli.bats",
     "test:watch": "npm run clean && NODE_ENV=test mocha {packages,src,test}/**/*.test.ts --watch --watch-files {packages,src,test}/**/*",
     "prod_test": "npm run prod_test:bin && npm run prod_test:cli",
-    "prod_test:bin": "mocha prod_test/binary-test.ts --timeout=100000",
+    "prod_test:bin": "mocha prod_test/binary-test.ts --timeout=60000",
     "prod_test:cli": "mocha prod_test/test.ts --timeout=60000",
     "version": "oclif readme && git add README.md",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cli-test": "bats test/bats/cli.bats",
     "test:watch": "npm run clean && NODE_ENV=test mocha {packages,src,test}/**/*.test.ts --watch --watch-files {packages,src,test}/**/*",
     "prod_test": "npm run prod_test:bin && npm run prod_test:cli",
-    "prod_test:bin": "mocha prod_test/binary-test.ts --timeout=60000",
+    "prod_test:bin": "mocha prod_test/binary-test.ts --timeout=100000",
     "prod_test:cli": "mocha prod_test/test.ts --timeout=60000",
     "version": "oclif readme && git add README.md",
     "format": "prettier --write .",

--- a/prod_test/binary-test.ts
+++ b/prod_test/binary-test.ts
@@ -57,7 +57,6 @@ describe('Binary CLI Testing', () => {
 
   it('shows initializing file when no config', async () => {
     // arrange
-    console.info('init')
     const { spawn, cleanup, exists, removeFile } = await prepareEnvironment()
     const assertText1 = 'No Monika configuration available, initializing...'
     const assertText2 =
@@ -65,24 +64,19 @@ describe('Binary CLI Testing', () => {
 
     // act
     const prevConfig = await exists('./monika.yml')
-    console.info(prevConfig)
     if (prevConfig) {
       await removeFile('./monika.yml')
     }
 
-    console.info('getStdout')
     const { getStdout, waitForText } = await spawn(monikaPath, '-r 1')
-    console.info('waitForText')
     await waitForText(assertText2)
     const stdout = getStdout().join('\r\n')
-    console.info(stdout)
 
     // assert
     expect(stdout).to.contain(assertText1)
     expect(stdout).to.contain(assertText2)
 
     await cleanup()
-    console.info('end')
   })
 
   it('shows starting message with valid json config', async () => {

--- a/prod_test/binary-test.ts
+++ b/prod_test/binary-test.ts
@@ -57,6 +57,7 @@ describe('Binary CLI Testing', () => {
 
   it('shows initializing file when no config', async () => {
     // arrange
+    console.info('init')
     const { spawn, cleanup, exists, removeFile } = await prepareEnvironment()
     const assertText1 = 'No Monika configuration available, initializing...'
     const assertText2 =
@@ -64,19 +65,24 @@ describe('Binary CLI Testing', () => {
 
     // act
     const prevConfig = await exists('./monika.yml')
+    console.info(prevConfig)
     if (prevConfig) {
       await removeFile('./monika.yml')
     }
 
+    console.info('getStdout')
     const { getStdout, waitForText } = await spawn(monikaPath, '-r 1')
+    console.info('waitForText')
     await waitForText(assertText2)
     const stdout = getStdout().join('\r\n')
+    console.info(stdout)
 
     // assert
     expect(stdout).to.contain(assertText1)
     expect(stdout).to.contain(assertText2)
 
     await cleanup()
+    console.info('end')
   })
 
   it('shows starting message with valid json config', async () => {

--- a/src/commands/monika.ts
+++ b/src/commands/monika.ts
@@ -36,7 +36,7 @@ import { closeLog, openLogfile } from '../components/logger/history'
 import { logStartupMessage } from '../components/logger/startup-message'
 import { scheduleSummaryNotification } from '../components/notification/schedule-notification'
 import { sendMonikaStartMessage } from '../components/notification/start-message'
-import { setContext } from '../context'
+import { getContext, setContext } from '../context'
 import events from '../events'
 import {
   type MonikaFlags,
@@ -410,7 +410,7 @@ export default class Monika extends Command {
           signal,
         })
 
-        if (process.env.NODE_ENV === 'test') {
+        if (getContext().isTest) {
           break
         }
 

--- a/src/components/config/__tests__/expected.sitemap-oneprobe.yml
+++ b/src/components/config/__tests__/expected.sitemap-oneprobe.yml
@@ -6,22 +6,27 @@ probes:
         method: GET
         timeout: 10000
         body: ''
+        followRedirects: 21
       - url: https://de.wiktionary.org/wiki/hyperjump
         method: GET
         timeout: 10000
         body: ''
+        followRedirects: 21
       - url: https://id.wiktionary.org/wiki/hyperjump
         method: GET
         timeout: 10000
         body: ''
+        followRedirects: 21
       - url: https://en.wiktionary.org/wiki/hyperjump
         method: GET
         timeout: 10000
         body: ''
+        followRedirects: 21
       - url: https://monika.hyperjump.tech/index
         method: GET
         timeout: 10000
         body: ''
+        followRedirects: 21
     interval: 900
     alerts:
       - assertion: response.status < 200 or response.status > 299

--- a/src/components/config/__tests__/expected.textfile.yml
+++ b/src/components/config/__tests__/expected.textfile.yml
@@ -6,6 +6,7 @@ probes:
         method: GET
         timeout: 10000
         body: {}
+        followRedirects: 21
     interval: 900
     alerts:
       - assertion: response.status < 200 or response.status > 299
@@ -19,6 +20,7 @@ probes:
         method: GET
         timeout: 10000
         body: {}
+        followRedirects: 21
     interval: 900
     alerts:
       - assertion: response.status < 200 or response.status > 299

--- a/src/components/config/index.test.ts
+++ b/src/components/config/index.test.ts
@@ -147,7 +147,14 @@ describe('updateConfig', () => {
           id: '1',
           name: '',
           interval: 1000,
-          requests: [{ url: 'https://example.com', body: '', timeout: 1000 }],
+          requests: [
+            {
+              url: 'https://example.com',
+              body: '',
+              followRedirects: 21,
+              timeout: 1000,
+            },
+          ],
           alerts: [],
         },
       ],
@@ -181,7 +188,14 @@ describe('updateConfig', () => {
           id: '1',
           name: '',
           interval: 1000,
-          requests: [{ url: 'https://example.com', body: '', timeout: 1000 }],
+          requests: [
+            {
+              url: 'https://example.com',
+              body: '',
+              followRedirects: 21,
+              timeout: 1000,
+            },
+          ],
           alerts: [],
         },
       ],

--- a/src/components/config/index.ts
+++ b/src/components/config/index.ts
@@ -62,7 +62,6 @@ type WatchConfigFileParams = {
   path: string
 }
 
-const isTestEnvironment = process.env.CI || process.env.NODE_ENV === 'test'
 const emitter = getEventEmitter()
 
 const defaultConfigs: Partial<Config>[] = []
@@ -103,7 +102,8 @@ export const updateConfig = async (config: Config): Promise<void> => {
     log.info('Config file update detected')
   } catch (error: unknown) {
     const message = getErrorMessage(error)
-    if (isTestEnvironment) {
+
+    if (getContext().isTest) {
       // return error during tests
       throw new Error(message)
     }
@@ -220,7 +220,7 @@ function scheduleRemoteConfigFetcher({
 }
 
 function watchConfigFile({ flags, path }: WatchConfigFileParams) {
-  const isWatchConfigFile = !(isTestEnvironment || flags.repeat !== 0)
+  const isWatchConfigFile = !(getContext().isTest || flags.repeat !== 0)
   if (isWatchConfigFile) {
     const watcher = watch(path)
     watcher.on('change', async () => {

--- a/src/components/config/parse-sitemap.ts
+++ b/src/components/config/parse-sitemap.ts
@@ -24,11 +24,12 @@
 
 import type { Config } from '../../interfaces/config'
 import { XMLParser } from 'fast-xml-parser'
+import { getContext } from '../../context'
 import { monikaFlagsDefaultValue } from '../../flag'
 import type { MonikaFlags } from '../../flag'
 import type { Probe, ProbeAlert } from '../../interfaces/probe'
+import type { RequestConfig } from '../../interfaces/request'
 import Joi from 'joi'
-import { RequestConfig } from 'src/interfaces/request'
 
 const sitemapValidator = Joi.object({
   config: Joi.object({
@@ -95,6 +96,7 @@ const generateProbesFromXmlOneProbe = (parseResult: unknown) => {
         method: 'GET',
         timeout: 10_000,
         body: '',
+        followRedirects: getContext().flags['follow-redirects'],
       },
     ]
     if (item['xhtml:link']) {
@@ -106,6 +108,7 @@ const generateProbesFromXmlOneProbe = (parseResult: unknown) => {
             method: 'GET',
             timeout: 10_000,
             body: '',
+            followRedirects: getContext().flags['follow-redirects'],
           },
         ]
       }

--- a/src/components/config/parse-text.ts
+++ b/src/components/config/parse-text.ts
@@ -46,6 +46,7 @@
  * SOFTWARE.                                                                      *
  **********************************************************************************/
 
+import { getContext } from '../../context'
 import type { Config } from '../../interfaces/config'
 import { monikaFlagsDefaultValue } from '../../flag'
 import type { Probe, ProbeAlert } from '../../interfaces/probe'
@@ -67,6 +68,7 @@ export const parseConfigFromText = (configString: string): Config => {
               method: 'GET',
               timeout: 10_000,
               body: {} as JSON,
+              followRedirects: getContext().flags['follow-redirects'],
             },
           ],
           interval: monikaFlagsDefaultValue['config-interval'],

--- a/src/components/config/validation/validator/probe.test.ts
+++ b/src/components/config/validation/validator/probe.test.ts
@@ -28,7 +28,7 @@ import type { Probe } from '../../../../interfaces/probe'
 
 import { FAILED_REQUEST_ASSERTION } from '../../../../looper'
 import { validateProbes } from './probe'
-import { resetContext, setContext } from '../../../../context'
+import { getContext, resetContext, setContext } from '../../../../context'
 import type { MonikaFlags } from '../../../../flag'
 
 describe('Probe validation', () => {
@@ -175,6 +175,7 @@ describe('Probe validation', () => {
       // arrange
       setContext({
         flags: {
+          ...getContext().flags,
           symonKey: 'bDF8j',
           symonUrl: 'https://example.com',
         } as MonikaFlags,

--- a/src/components/config/validation/validator/probe.ts
+++ b/src/components/config/validation/validator/probe.ts
@@ -259,6 +259,10 @@ export async function validateProbes(probes: Probe[]): Promise<Probe[]> {
                     joi.number(),
                     joi.bool()
                   ),
+                followRedirects: joi
+                  .number()
+                  .min(0)
+                  .default(getContext().flags['follow-redirects']),
                 headers: joi.object().allow(null),
                 id: joi.string().allow(''),
                 interval: joi.number().min(1),

--- a/src/components/logger/startup-message.test.ts
+++ b/src/components/logger/startup-message.test.ts
@@ -37,7 +37,13 @@ const defaultConfig: Config = {
       name: 'Acme Inc.',
       interval: 3000,
       requests: [
-        { url: 'https://example.com', headers: {}, body: '', timeout: 0 },
+        {
+          url: 'https://example.com',
+          headers: {},
+          body: '',
+          followRedirects: 21,
+          timeout: 0,
+        },
       ],
       alerts: [
         {
@@ -240,6 +246,7 @@ describe('Startup message', () => {
                     url: 'https://example.com',
                     headers: {},
                     body: '',
+                    followRedirects: 21,
                     timeout: 0,
                   },
                 ],

--- a/src/components/notification/alert-message.ts
+++ b/src/components/notification/alert-message.ts
@@ -32,7 +32,7 @@ import { getContext } from '../../context'
 import type { NotificationMessage } from '@hyperjumptech/monika-notification'
 import { ProbeRequestResponse } from '../../interfaces/request'
 import { ProbeAlert } from '../../interfaces/probe'
-import { publicIpAddress, publicNetworkInfo } from '../../utils/public-ip'
+import { getPublicNetworkInfo, publicIpAddress } from '../../utils/public-ip'
 import { getIncidents } from '../incident'
 
 const getLinuxDistro = promisify(getos)
@@ -40,6 +40,7 @@ const getLinuxDistro = promisify(getos)
 export const getMonikaInstance = async (ipAddress: string): Promise<string> => {
   const osHostname = hostname()
 
+  const publicNetworkInfo = getPublicNetworkInfo()
   if (publicNetworkInfo) {
     const { city, isp } = publicNetworkInfo
 

--- a/src/components/probe/prober/http/index.test.ts
+++ b/src/components/probe/prober/http/index.test.ts
@@ -66,6 +66,7 @@ const probes: Probe[] = [
       {
         url: 'https://example.com',
         body: '',
+        followRedirects: 21,
         timeout: 30,
       },
     ],
@@ -205,6 +206,7 @@ describe('HTTP Probe processing', () => {
         {
           url: 'https://example.com',
           body: '',
+          followRedirects: 21,
           timeout: 30,
         },
       ],
@@ -314,11 +316,18 @@ describe('HTTP Probe processing', () => {
         })
       })
     )
-    const probe = {
+    const probe: Probe = {
       ...probes[0],
       id: 'fj43l',
       incidentThreshold: 1,
-      requests: [{ url: 'https://example.com', body: '', timeout: 30 }],
+      requests: [
+        {
+          url: 'https://example.com',
+          body: '',
+          followRedirects: 21,
+          timeout: 30,
+        },
+      ],
       alerts: [
         { id: 'jFQBd', assertion: 'response.status != 200', message: '' },
       ],
@@ -348,10 +357,10 @@ describe('HTTP Probe processing', () => {
     await sleep(3 * seconds)
 
     // assert
-    expect(notificationAlert?.[probe.requests[0].url]?.body?.url).eq(
+    expect(notificationAlert?.[probe.requests![0].url]?.body?.url).eq(
       'https://example.com'
     )
-    expect(notificationAlert?.[probe.requests[0].url]?.body?.alert).eq(
+    expect(notificationAlert?.[probe.requests![0].url]?.body?.alert).eq(
       'response.status != 200'
     )
   }).timeout(10_000)

--- a/src/components/probe/prober/http/index.ts
+++ b/src/components/probe/prober/http/index.ts
@@ -22,7 +22,6 @@
  * SOFTWARE.                                                                      *
  **********************************************************************************/
 
-import { monikaFlagsDefaultValue } from '../../../../flag'
 import { BaseProber, NotificationType, type ProbeParams } from '..'
 import { getContext } from '../../../../context'
 import events from '../../../../events'
@@ -57,11 +56,6 @@ export class HTTPProber extends BaseProber {
       responses.push(
         // eslint-disable-next-line no-await-in-loop
         await httpRequest({
-          isVerbose: getContext().flags.verbose,
-          maxRedirects:
-            getContext().flags['follow-redirects'] ||
-            monikaFlagsDefaultValue['follow-redirects'],
-          isEnableFetch: getContext().flags['native-fetch'],
           requestConfig: { ...requestConfig, signal },
           responses,
         })

--- a/src/components/probe/prober/http/request.test.ts
+++ b/src/components/probe/prober/http/request.test.ts
@@ -26,6 +26,7 @@ import { expect } from '@oclif/test'
 import { HttpResponse, http } from 'msw'
 import { setupServer } from 'msw/node'
 
+import { getContext, resetContext, setContext } from '../../../../context'
 import type {
   ProbeRequestResponse,
   RequestConfig,
@@ -38,9 +39,14 @@ describe('probingHTTP', () => {
   describe('httpRequest function', () => {
     before(() => {
       server.listen()
+      setContext({
+        ...getContext(),
+        flags: { ...getContext().flags, 'follow-redirects': 0 },
+      })
     })
     afterEach(() => {
       server.resetHandlers()
+      resetContext()
     })
     after(() => {
       server.close()
@@ -93,7 +99,6 @@ describe('probingHTTP', () => {
           try {
             // eslint-disable-next-line no-await-in-loop
             const resp = await httpRequest({
-              maxRedirects: 0,
               requestConfig: request,
               responses,
             })
@@ -142,7 +147,6 @@ describe('probingHTTP', () => {
       }
 
       const result = await httpRequest({
-        maxRedirects: 0,
         requestConfig: request,
         responses: [],
       })
@@ -182,7 +186,6 @@ describe('probingHTTP', () => {
 
       // act
       const res = await httpRequest({
-        maxRedirects: 0,
         requestConfig: request,
         responses: [],
       })
@@ -226,7 +229,6 @@ describe('probingHTTP', () => {
 
       // act
       const res = await httpRequest({
-        maxRedirects: 0,
         requestConfig: request,
         responses: [],
       })
@@ -270,7 +272,6 @@ describe('probingHTTP', () => {
 
       // act
       const res = await httpRequest({
-        maxRedirects: 0,
         requestConfig: request,
         responses: [],
       })
@@ -314,7 +315,6 @@ describe('probingHTTP', () => {
 
       // act
       const res = await httpRequest({
-        maxRedirects: 0,
         requestConfig: request,
         responses: [],
       })
@@ -325,6 +325,13 @@ describe('probingHTTP', () => {
 
     it('Should handle HTTP redirect with axios', async () => {
       // arrange
+      setContext({
+        ...getContext(),
+        flags: {
+          ...getContext().flags,
+          'follow-redirects': 3,
+        },
+      })
       server.use(
         http.get(
           'https://example.com/get',
@@ -355,11 +362,10 @@ describe('probingHTTP', () => {
         method: 'GET',
         body: '',
         timeout: 10_000,
+        followRedirects: 3,
       }
 
       const res = await httpRequest({
-        isEnableFetch: true,
-        maxRedirects: 3,
         requestConfig,
         responses: [],
       })
@@ -398,11 +404,10 @@ describe('probingHTTP', () => {
         method: 'GET',
         body: '',
         timeout: 10_000,
+        followRedirects: 3,
       }
 
       const res = await httpRequest({
-        isEnableFetch: false,
-        maxRedirects: 3,
         requestConfig,
         responses: [],
       })
@@ -446,7 +451,6 @@ describe('probingHTTP', () => {
 
       // act
       const res = await httpRequest({
-        maxRedirects: 0,
         requestConfig: request,
         responses: [],
       })

--- a/src/components/probe/prober/index.test.ts
+++ b/src/components/probe/prober/index.test.ts
@@ -78,7 +78,14 @@ describe('Prober', () => {
           id: 'bcDnX',
           interval: 2,
           name: 'Example',
-          requests: [{ body: '', timeout: 30_000, url: 'https://example.com' }],
+          requests: [
+            {
+              body: '',
+              followRedirects: 21,
+              timeout: 30_000,
+              url: 'https://example.com',
+            },
+          ],
         },
       }
 
@@ -115,7 +122,14 @@ describe('Prober', () => {
             createdAt: new Date(),
             recoveredAt: null,
           },
-          requests: [{ body: '', timeout: 30_000, url: 'https://example.com' }],
+          requests: [
+            {
+              body: '',
+              followRedirects: 21,
+              timeout: 30_000,
+              url: 'https://example.com',
+            },
+          ],
         },
       }
 
@@ -153,7 +167,14 @@ describe('Prober', () => {
             createdAt: new Date(),
             recoveredAt: new Date(),
           },
-          requests: [{ body: '', timeout: 30_000, url: 'https://example.com' }],
+          requests: [
+            {
+              body: '',
+              followRedirects: 21,
+              timeout: 30_000,
+              url: 'https://example.com',
+            },
+          ],
         },
       }
 
@@ -191,7 +212,14 @@ describe('Prober', () => {
             createdAt: new Date(),
             recoveredAt: null,
           },
-          requests: [{ body: '', timeout: 30_000, url: 'https://example.com' }],
+          requests: [
+            {
+              body: '',
+              followRedirects: 21,
+              timeout: 30_000,
+              url: 'https://example.com',
+            },
+          ],
         },
       }
 
@@ -233,6 +261,7 @@ describe('Prober', () => {
           requests: [
             {
               body: '',
+              followRedirects: 21,
               timeout: 30_000,
               url: 'https://example.com',
               alerts: [
@@ -295,6 +324,7 @@ describe('Prober', () => {
           requests: [
             {
               body: '',
+              followRedirects: 21,
               timeout: 30_000,
               url: 'https://example.com',
               alerts: [
@@ -347,6 +377,7 @@ describe('Prober', () => {
           requests: [
             {
               body: '',
+              followRedirects: 21,
               timeout: 30_000,
               url: 'https://example.com',
               alerts: [
@@ -408,6 +439,7 @@ describe('Prober', () => {
           requests: [
             {
               body: '',
+              followRedirects: 21,
               timeout: 30_000,
               url: 'https://example.com',
               alerts: [

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -38,6 +38,7 @@ type Context = {
   // userAgent example: @hyperjumptech/monika/1.2.3 linux-x64 node-14.17.0
   userAgent: string
   incidents: Incident[]
+  isTest: boolean
   config?: Omit<Config, 'probes'>
   flags: MonikaFlags
 }
@@ -47,6 +48,7 @@ type NewContext = Partial<Context>
 const initialContext: Context = {
   userAgent: '',
   incidents: [],
+  isTest: process.env.CI === 'true' || process.env.NODE_ENV === 'test',
   flags: monikaFlagsDefaultValue,
 }
 

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -48,7 +48,7 @@ type NewContext = Partial<Context>
 const initialContext: Context = {
   userAgent: '',
   incidents: [],
-  isTest: process.env.CI === 'true' || process.env.NODE_ENV === 'test',
+  isTest: process.env.NODE_ENV === 'test',
   flags: monikaFlagsDefaultValue,
 }
 

--- a/src/events/subscribers/application.ts
+++ b/src/events/subscribers/application.ts
@@ -26,6 +26,7 @@ import { hostname } from 'os'
 import { getConfig } from '../../components/config'
 import { sendNotifications } from '@hyperjumptech/monika-notification'
 import { getMessageForTerminate } from '../../components/notification/alert-message'
+import { getContext } from '../../context'
 import events from '../../events'
 import { getEventEmitter } from '../../utils/events'
 import getIp from '../../utils/ip'
@@ -34,9 +35,7 @@ import { log } from '../../utils/pino'
 const eventEmitter = getEventEmitter()
 
 eventEmitter.on(events.application.terminated, async () => {
-  const isTestEnvironment = process.env.NODE_ENV === 'test'
-
-  if (!isTestEnvironment) {
+  if (!getContext().isTest) {
     const message = await getMessageForTerminate(hostname(), getIp())
     const config = getConfig()
 

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -24,7 +24,7 @@
 
 import type { Config as IConfig } from '@oclif/core'
 import { isSymonModeFrom, setupConfig } from '../components/config'
-import { setContext } from '../context'
+import { getContext, setContext } from '../context'
 import events from '../events'
 import type { MonikaFlags } from '../flag'
 import { tlsChecker } from '../jobs/tls-check'
@@ -49,7 +49,6 @@ export default async function init(
   cliConfig: IConfig
 ): Promise<void> {
   const eventEmitter = getEventEmitter()
-  const isTestEnvironment = process.env.CI || process.env.NODE_ENV === 'test'
   const isSymonMode = isSymonModeFrom(flags)
 
   setContext({ userAgent: cliConfig.userAgent })
@@ -67,7 +66,7 @@ export default async function init(
       )
   } else {
     // if note verbose, remove location details
-    ;`Monika is running.`
+    log.info('Monika is running.')
   }
 
   // check if connected to STUN Server and getting the public IP in the same time
@@ -107,7 +106,7 @@ export default async function init(
     // check TLS when Monika starts
     tlsChecker()
 
-    if (!isTestEnvironment) {
+    if (!getContext().isTest) {
       // load cron jobs
       jobsLoader()
     }

--- a/src/looper/index.ts
+++ b/src/looper/index.ts
@@ -93,7 +93,7 @@ export async function loopCheckSTUNServer(interval: number): Promise<unknown> {
   if (interval === -1) return
 
   // if interval = 0 get ip once and exit. No need to setup interval.
-  if (interval === 0 || process.env.CI || process.env.NODE_ENV === 'test') {
+  if (interval === 0 || getContext().isTest) {
     await getPublicIp()
     return
   }

--- a/src/monika-config-schema.json
+++ b/src/monika-config-schema.json
@@ -302,6 +302,13 @@
           "body": {
             "$ref": "#/definitions/body"
           },
+          "followRedirects": {
+            "title": "Follow Redirects",
+            "description": "The request follows redirects as many times as specified here",
+            "type": "integer",
+            "examples": ["21"],
+            "default": "21"
+          },
           "headers": {
             "$ref": "#/definitions/headers"
           }

--- a/src/plugins/metrics/prometheus/collector.test.ts
+++ b/src/plugins/metrics/prometheus/collector.test.ts
@@ -59,6 +59,7 @@ describe('Prometheus collector', () => {
             {
               url: '',
               body: '',
+              followRedirects: 21,
               timeout: 0,
             },
           ],
@@ -167,6 +168,7 @@ describe('Prometheus collector', () => {
             {
               url: '',
               body: '',
+              followRedirects: 21,
               timeout: 0,
             },
           ],

--- a/src/symon/index.test.ts
+++ b/src/symon/index.test.ts
@@ -26,7 +26,7 @@ import { expect } from '@oclif/test'
 import { type DefaultBodyType, HttpResponse, http } from 'msw'
 import { setupServer } from 'msw/node'
 
-import { monikaFlagsDefaultValue, type MonikaFlags } from '../flag'
+import { monikaFlagsDefaultValue } from '../flag'
 import type { Config } from '../interfaces/config'
 import type { Probe } from '../interfaces/probe'
 
@@ -54,7 +54,14 @@ const config: Config = {
       id: '2',
       name: 'Example',
       interval: 10,
-      requests: [{ url: 'https://example.com', body: '', timeout: 2000 }],
+      requests: [
+        {
+          url: 'https://example.com',
+          body: '',
+          followRedirects: 21,
+          timeout: 2000,
+        },
+      ],
       alerts: [],
     },
   ],
@@ -103,11 +110,12 @@ describe('Symon initiate', () => {
     resetContext()
     setContext({
       flags: {
+        ...getContext().flags,
         symonUrl: 'http://localhost:4000',
         symonKey: 'random-key',
         symonGetProbesIntervalMs:
           monikaFlagsDefaultValue.symonGetProbesIntervalMs,
-      } as MonikaFlags,
+      },
     })
 
     // reset probe cache
@@ -127,9 +135,10 @@ describe('Symon initiate', () => {
     setContext({
       userAgent: 'v1.5.0',
       flags: {
+        ...getContext().flags,
         symonUrl: 'http://localhost:4000',
         symonKey: 'random-key',
-      } as MonikaFlags,
+      },
     })
     let body: DefaultBodyType = {}
     // mock the outgoing requests
@@ -277,7 +286,14 @@ describe('Symon initiate', () => {
       id: '3',
       name: 'New Probe',
       interval: 2,
-      requests: [{ url: 'https://example.com', body: '', timeout: 2000 }],
+      requests: [
+        {
+          url: 'https://example.com',
+          body: '',
+          followRedirects: 21,
+          timeout: 2000,
+        },
+      ],
       alerts: [],
     }
     server.use(
@@ -291,10 +307,11 @@ describe('Symon initiate', () => {
     const symonGetProbesIntervalMs = 100
     setContext({
       flags: {
+        ...getContext().flags,
         symonUrl: 'http://localhost:4000',
         symonKey: 'random-key',
         symonGetProbesIntervalMs,
-      } as MonikaFlags,
+      },
     })
     const symon = new SymonClient({
       symonUrl: 'http://localhost:4000',
@@ -343,10 +360,11 @@ describe('Symon initiate', () => {
     const symonGetProbesIntervalMs = 100
     setContext({
       flags: {
+        ...getContext().flags,
         symonUrl: 'http://localhost:4000',
         symonKey: 'random-key',
         symonGetProbesIntervalMs,
-      } as MonikaFlags,
+      },
     })
     const symon = new SymonClient({
       symonUrl: 'http://localhost:4000',
@@ -396,10 +414,11 @@ describe('Symon initiate', () => {
     const symonGetProbesIntervalMs = 100
     setContext({
       flags: {
+        ...getContext().flags,
         symonUrl: 'http://localhost:4000',
         symonKey: 'random-key',
         symonGetProbesIntervalMs,
-      } as MonikaFlags,
+      },
     })
     const symon = new SymonClient({
       symonUrl: 'http://localhost:4000',
@@ -449,10 +468,11 @@ describe('Symon initiate', () => {
     const symonGetProbesIntervalMs = 100
     setContext({
       flags: {
+        ...getContext().flags,
         symonUrl: 'http://localhost:4000',
         symonKey: 'random-key',
         symonGetProbesIntervalMs,
-      } as MonikaFlags,
+      },
     })
     const symon = new SymonClient({
       symonUrl: 'http://localhost:4000',

--- a/src/utils/pino.ts
+++ b/src/utils/pino.ts
@@ -25,11 +25,12 @@
 import fs from 'fs'
 import path from 'path'
 import { pino, transport } from 'pino'
+import { getContext } from '../context'
 
 export const log = pino(getOptions())
 
 function getOptions() {
-  if (process.env.NODE_ENV === 'test') {
+  if (getContext().isTest) {
     return {
       base: undefined,
       level: 'error',

--- a/src/utils/probe-state.test.ts
+++ b/src/utils/probe-state.test.ts
@@ -23,6 +23,8 @@
  **********************************************************************************/
 
 import { expect } from 'chai'
+import sinon from 'sinon'
+
 import type { Probe } from '../interfaces/probe'
 import {
   getProbeContext,
@@ -31,7 +33,6 @@ import {
   setProbeFinish,
   setProbeRunning,
 } from './probe-state'
-import sinon from 'sinon'
 
 describe('probe-state', () => {
   const timeNow = new Date()
@@ -54,7 +55,14 @@ describe('probe-state', () => {
           id: '1',
           interval: 1,
           name: 'Example',
-          requests: [{ url: 'https://example.com', body: '', timeout: 2 }],
+          requests: [
+            {
+              url: 'https://example.com',
+              body: '',
+              followRedirects: 21,
+              timeout: 2,
+            },
+          ],
         },
       ]
 
@@ -79,7 +87,14 @@ describe('probe-state', () => {
           id: '1',
           interval: 1,
           name: 'Example',
-          requests: [{ url: 'https://example.com', body: '', timeout: 2 }],
+          requests: [
+            {
+              url: 'https://example.com',
+              body: '',
+              followRedirects: 21,
+              timeout: 2,
+            },
+          ],
           lastEvent: {
             createdAt: lastEventCreatedAt,
           },
@@ -109,7 +124,14 @@ describe('probe-state', () => {
           id: '1',
           interval: 1,
           name: 'Example',
-          requests: [{ url: 'https://example.com', body: '', timeout: 2 }],
+          requests: [
+            {
+              url: 'https://example.com',
+              body: '',
+              followRedirects: 21,
+              timeout: 2,
+            },
+          ],
           lastEvent: {
             recoveredAt: lastEventCreatedAt,
           },
@@ -137,7 +159,14 @@ describe('probe-state', () => {
           id: '1',
           interval: 1,
           name: 'Example',
-          requests: [{ url: 'https://example.com', body: '', timeout: 2 }],
+          requests: [
+            {
+              url: 'https://example.com',
+              body: '',
+              followRedirects: 21,
+              timeout: 2,
+            },
+          ],
           lastEvent: {
             createdAt: lastEventCreatedAt,
             recoveredAt: lastEventCreatedAt,
@@ -167,7 +196,14 @@ describe('probe-state', () => {
           id: '1',
           interval: 1,
           name: 'Example',
-          requests: [{ url: 'https://example.com', body: '', timeout: 2 }],
+          requests: [
+            {
+              url: 'https://example.com',
+              body: '',
+              followRedirects: 21,
+              timeout: 2,
+            },
+          ],
         },
       ]
 
@@ -187,7 +223,14 @@ describe('probe-state', () => {
           id: '1',
           interval: 1,
           name: 'Example',
-          requests: [{ url: 'https://example.com', body: '', timeout: 2 }],
+          requests: [
+            {
+              url: 'https://example.com',
+              body: '',
+              followRedirects: 21,
+              timeout: 2,
+            },
+          ],
         },
       ]
 
@@ -208,7 +251,14 @@ describe('probe-state', () => {
           id: '1',
           interval: 1,
           name: 'Example',
-          requests: [{ url: 'https://example.com', body: '', timeout: 2 }],
+          requests: [
+            {
+              url: 'https://example.com',
+              body: '',
+              followRedirects: 21,
+              timeout: 2,
+            },
+          ],
         },
       ]
 
@@ -228,7 +278,14 @@ describe('probe-state', () => {
           id: '1',
           interval: 1,
           name: 'Example',
-          requests: [{ url: 'https://example.com', body: '', timeout: 2 }],
+          requests: [
+            {
+              url: 'https://example.com',
+              body: '',
+              followRedirects: 21,
+              timeout: 2,
+            },
+          ],
         },
       ]
 
@@ -248,7 +305,14 @@ describe('probe-state', () => {
           id: '1',
           interval: 1,
           name: 'Example',
-          requests: [{ url: 'https://example.com', body: '', timeout: 2 }],
+          requests: [
+            {
+              url: 'https://example.com',
+              body: '',
+              followRedirects: 21,
+              timeout: 2,
+            },
+          ],
         },
       ]
 
@@ -269,7 +333,14 @@ describe('probe-state', () => {
           id: '1',
           interval: 1,
           name: 'Example',
-          requests: [{ url: 'https://example.com', body: '', timeout: 2 }],
+          requests: [
+            {
+              url: 'https://example.com',
+              body: '',
+              followRedirects: 21,
+              timeout: 2,
+            },
+          ],
         },
       ]
 
@@ -292,7 +363,14 @@ describe('probe-state', () => {
           id: '1',
           interval: 1,
           name: 'Example',
-          requests: [{ url: 'https://example.com', body: '', timeout: 2 }],
+          requests: [
+            {
+              url: 'https://example.com',
+              body: '',
+              followRedirects: 21,
+              timeout: 2,
+            },
+          ],
         },
       ]
 
@@ -314,7 +392,14 @@ describe('probe-state', () => {
           id: '1',
           interval: 1,
           name: 'Example',
-          requests: [{ url: 'https://example.com', body: '', timeout: 2 }],
+          requests: [
+            {
+              url: 'https://example.com',
+              body: '',
+              followRedirects: 21,
+              timeout: 2,
+            },
+          ],
         },
       ]
 
@@ -336,7 +421,14 @@ describe('probe-state', () => {
           id: '1',
           interval: 1,
           name: 'Example',
-          requests: [{ url: 'https://example.com', body: '', timeout: 2 }],
+          requests: [
+            {
+              url: 'https://example.com',
+              body: '',
+              followRedirects: 21,
+              timeout: 2,
+            },
+          ],
         },
       ]
 

--- a/src/utils/public-ip.ts
+++ b/src/utils/public-ip.ts
@@ -42,7 +42,7 @@ type PublicNetwork = {
 
 export let publicIpAddress = ''
 export let isConnectedToSTUNServer = true
-export let publicNetworkInfo: PublicNetwork | undefined
+let publicNetworkInfo: PublicNetwork | undefined
 
 /**
  * pokeStun sends a poke/request to stun server
@@ -64,14 +64,14 @@ async function pokeStun(): Promise<string> {
   throw new Error('stun inaccessible') // could not connect to STUN server
 }
 
-export async function getPublicNetworkInfo(): Promise<PublicNetwork> {
+async function fetchPublicNetworkInfo(): Promise<PublicNetwork> {
   const publicIp = await pokeStun()
   const response = await sendHttpRequest({
     url: `http://ip-api.com/json/${publicIp}`,
   })
   const { country, city, isp } = response.data
 
-  publicNetworkInfo = {
+  return {
     country,
     city,
     hostname: hostname(),
@@ -79,8 +79,22 @@ export async function getPublicNetworkInfo(): Promise<PublicNetwork> {
     privateIp: getIp(),
     publicIp,
   }
+}
 
+async function setPublicNetworkInfo(publicNetwork: PublicNetwork) {
+  publicNetworkInfo = publicNetwork
+}
+
+export function getPublicNetworkInfo(): PublicNetwork | undefined {
   return publicNetworkInfo
+}
+
+// cache location & ISP info
+export async function fetchAndCacheNetworkInfo() {
+  const publicNetwork = await fetchPublicNetworkInfo()
+  await setPublicNetworkInfo(publicNetwork)
+
+  return publicNetwork
 }
 
 /**

--- a/src/utils/public-ip.ts
+++ b/src/utils/public-ip.ts
@@ -44,8 +44,6 @@ export let publicIpAddress = ''
 export let isConnectedToSTUNServer = true
 export let publicNetworkInfo: PublicNetwork | undefined
 
-const isTestEnvironment = process.env.CI || process.env.NODE_ENV === 'test'
-
 /**
  * pokeStun sends a poke/request to stun server
  * @returns Promise<string>
@@ -53,7 +51,7 @@ const isTestEnvironment = process.env.CI || process.env.NODE_ENV === 'test'
 async function pokeStun(): Promise<string> {
   // for testing, bypass ping/stun server... apparently ping cannot run in github actions
   // reference: https://github.com/actions/virtual-environments/issues/1519
-  if (isTestEnvironment) {
+  if (getContext().isTest) {
     return '192.168.1.1' // adding for specific asserts in other tests
   }
 

--- a/test/others/hide-ip.test.ts
+++ b/test/others/hide-ip.test.ts
@@ -30,12 +30,12 @@ import * as IpUtil from '../../src/utils/public-ip'
 
 describe('Monika should hide ip unless verbose', () => {
   let getPublicIPStub: sinon.SinonStub
-  let getPublicNetworkInfoStub: sinon.SinonStub
+  let fetchAndCacheNetworkInfoStub: sinon.SinonStub
 
   beforeEach(() => {
     getPublicIPStub = sinon.stub(IpUtil, 'getPublicIp' as never)
-    getPublicNetworkInfoStub = sinon
-      .stub(IpUtil, 'getPublicNetworkInfo' as never)
+    fetchAndCacheNetworkInfoStub = sinon
+      .stub(IpUtil, 'fetchAndCacheNetworkInfo' as never)
       .callsFake(async () => ({
         country: 'Earth',
         city: 'Gotham',
@@ -48,7 +48,7 @@ describe('Monika should hide ip unless verbose', () => {
 
   afterEach(() => {
     getPublicIPStub.restore()
-    getPublicNetworkInfoStub.restore()
+    fetchAndCacheNetworkInfoStub.restore()
   })
 
   test
@@ -56,8 +56,8 @@ describe('Monika should hide ip unless verbose', () => {
     .do(() =>
       cmd.run(['--config', resolve('./test/testConfigs/simple-1p-1n.yaml')])
     )
-    .it('should not call getPublicNetworkInfo()', () => {
-      sinon.assert.notCalled(getPublicNetworkInfoStub)
+    .it('should not call fetchAndCacheNetworkInfo()', () => {
+      sinon.assert.notCalled(fetchAndCacheNetworkInfoStub)
     })
 
   test
@@ -69,7 +69,7 @@ describe('Monika should hide ip unless verbose', () => {
         '--verbose',
       ])
     )
-    .it('should call getPublicNetworkInfo() when --verbose', () => {
-      sinon.assert.calledOnce(getPublicNetworkInfoStub)
+    .it('should call fetchAndCacheNetworkInfo() when --verbose', () => {
+      sinon.assert.calledOnce(fetchAndCacheNetworkInfoStub)
     })
 })


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

This PR adds the configuration for following redirects on the probe request level. This resolves #1259.

## How did you implement / how did you fix it

- Refactor : Moved global variables to the context to prevent recreation in multiple places.
- Refactor: Extracted logging running information and the function to fetch and cache public network information.
- Refactor: Extracted initialization of Prometheus function.
- Docs: Added documentation for following redirects.
- Feat: Added the follow redirects JSON schema property.
- [Feat: Implemented following redirects on the request level](https://github.com/hyperjumptech/monika/commit/3c1f816b8427606cc98597dae6bf91f4c686cfe6) (The additional feature)
- Fix: Adjusted affected codes

## How to test

1. Run `httpbin` `docker compose -f ./dev/docker-compose.yaml up httpbin -d `.
2. Run Monika with the following configuration. Run `npm start -- -r 1`.

```yaml
probes:
  - id: 'should not follow redirect'
    requests:
      - url: http://localhost:3000/status/302
        followRedirects: 0
    alerts:
      - assertion: response.status != 302
        message: You should not follow redirect
  - id: 'should follow redirect with default config'
    requests:
      - url: http://localhost:3000/absolute-redirect/20
    alerts:
      - assertion: response.status == 302
        message: You are not follow redirect
  - id: 'should follow redirect with customize config'
    requests:
      - url: http://localhost:3000/status/302
        followRedirects: 2
    alerts:
      - assertion: response.status == 302
        message: You are not follow redirect
```

You should see the following output:
<img width="1063" alt="Screenshot 2024-04-16 at 4 50 25 PM" src="https://github.com/hyperjumptech/monika/assets/15191978/9039f3b6-8e58-458a-8d72-ec053dca0c04">

