### PR TITLE
feat(node.js fetch): #1268 implement redirect for fetch

### DIFF
--- a/src/components/probe/prober/http/index.ts
+++ b/src/components/probe/prober/http/index.ts
@@ -22,6 +22,7 @@
  * SOFTWARE.                                                                      *
  **********************************************************************************/
 
+import { monikaFlagsDefaultValue } from '../../../../flag'
 import { BaseProber, NotificationType, type ProbeParams } from '..'
 import { getContext } from '../../../../context'
 import events from '../../../../events'
@@ -56,6 +57,11 @@ export class HTTPProber extends BaseProber {
       responses.push(
         // eslint-disable-next-line no-await-in-loop
         await httpRequest({
+          isVerbose: getContext().flags.verbose,
+          maxRedirects:
+            getContext().flags['follow-redirects'] ||
+            monikaFlagsDefaultValue['follow-redirects'],
+          isEnableFetch: getContext().flags['native-fetch'],
           requestConfig: { ...requestConfig, signal },
           responses,
         })

--- a/src/components/probe/prober/http/request.test.ts
+++ b/src/components/probe/prober/http/request.test.ts
@@ -91,6 +91,7 @@ describe('probingHTTP', () => {
           try {
             // eslint-disable-next-line no-await-in-loop
             const resp = await httpRequest({
+              maxRedirects: 0,
               requestConfig: request,
               responses,
             })
@@ -138,6 +139,7 @@ describe('probingHTTP', () => {
       }
 
       const result = await httpRequest({
+        maxRedirects: 0,
         requestConfig: request,
         responses: [],
       })
@@ -176,6 +178,7 @@ describe('probingHTTP', () => {
 
       // act
       const res = await httpRequest({
+        maxRedirects: 0,
         requestConfig: request,
         responses: [],
       })
@@ -218,6 +221,7 @@ describe('probingHTTP', () => {
 
       // act
       const res = await httpRequest({
+        maxRedirects: 0,
         requestConfig: request,
         responses: [],
       })
@@ -260,6 +264,7 @@ describe('probingHTTP', () => {
 
       // act
       const res = await httpRequest({
+        maxRedirects: 0,
         requestConfig: request,
         responses: [],
       })
@@ -302,11 +307,57 @@ describe('probingHTTP', () => {
 
       // act
       const res = await httpRequest({
+        maxRedirects: 0,
         requestConfig: request,
         responses: [],
       })
 
       // assert
+      expect(res.status).to.eq(200)
+    })
+
+    it('Should handle HTTP redirect', async () => {
+      // arrange
+      server.use(
+        http.get(
+          'https://example.com/get',
+          () => new HttpResponse(null, { status: 200 })
+        ),
+        http.get(
+          'https://example.com/redirect/:nredirect',
+          async ({ params }) => {
+            const { nredirect } = params
+            const castRedirect = Number(nredirect)
+            return new HttpResponse(null, {
+              status: 302,
+              headers: [
+                [
+                  'Location',
+                  castRedirect === 1
+                    ? 'https://example.com/get'
+                    : `https://example.com/redirect/${castRedirect - 1}`,
+                ],
+              ],
+            })
+          }
+        )
+      )
+
+      const requestConfig: RequestConfig = {
+        url: 'https://example.com/redirect/3',
+        method: 'GET',
+        body: {} as never,
+        timeout: 10_000,
+      }
+
+      const res = await httpRequest({
+        isEnableFetch: true,
+        maxRedirects: 3,
+        requestConfig,
+        responses: [],
+      })
+
+      console.log(JSON.stringify(res))
       expect(res.status).to.eq(200)
     })
 
@@ -345,6 +396,7 @@ describe('probingHTTP', () => {
 
       // act
       const res = await httpRequest({
+        maxRedirects: 0,
         requestConfig: request,
         responses: [],
       })

--- a/src/components/probe/prober/http/request.ts
+++ b/src/components/probe/prober/http/request.ts
@@ -251,6 +251,14 @@ async function probeHttpFetch({
   }
 }): Promise<ProbeRequestResponse> {
   if (isVerbose) log.info(`Probing ${renderedURL} with Node.js fetch`)
+  console.log(
+    'renderedURL =',
+    renderedURL,
+    '| requestParams =',
+    JSON.stringify(requestParams),
+    '| maxRedirects =',
+    maxRedirects
+  )
   const response = await sendHttpRequestFetch({
     ...requestParams,
     allowUnauthorizedSsl: allowUnauthorized,


### PR DESCRIPTION
# Monika Pull Request (PR)

This PR resolves #1268 

## What feature/issue does this PR add

1. Handle HTTP status code 3xx for Node.js fetch implementation

## How did you implement / how did you fix it

1. Manually handle status code 3xx on Node.js fetch function
2. Move HTTP client's dependency to flag to parameter function
3. Add tests

## How to test

1. `npm run test`
2. Create `monika.yml` config file below

```YAML
probes:
  - id: 'Example'
    requests:
      - url: https://httpbin.org/redirect/3
        timeout: 60000
    interval: 5
    incidentThreshold: 1
    recoveryThreshold: 1
    alerts:
      - assertion: response.time >= 60000
        message: HTTP response time is {{ response.time }}, expecting 10000
```

3. `npm run start -- --native-fetch -c monika.yml -r 1`