### PR TITLE
Fix: Make TLS Probe Independent

### DIFF
--- a/src/components/config/index.test.ts
+++ b/src/components/config/index.test.ts
@@ -67,15 +67,10 @@ describe('getValidatedConfig', () => {
     })
 
     // act & assert
-    expect(getValidatedConfig()).deep.eq({
-      notifications: [],
-      probes: [],
-      'status-notification': '0 6 * * *',
-      version: 'efde57d3b97ff787384fc2afde824615',
-    })
+    expect(getValidatedConfig().version).eq('efde57d3b97ff787384fc2afde824615')
   })
 
-  it('should return empty array when config is empty in Symon mode', () => {
+  it('should return empty array for probes when config is empty in Symon mode', () => {
     // arrange
     setContext({
       flags: sanitizeFlags({
@@ -85,12 +80,7 @@ describe('getValidatedConfig', () => {
     })
 
     // act and assert
-    expect(getValidatedConfig()).deep.eq({
-      notifications: [],
-      probes: [],
-      'status-notification': '0 6 * * *',
-      version: 'efde57d3b97ff787384fc2afde824615',
-    })
+    expect(getValidatedConfig().probes).deep.eq([])
   })
 })
 
@@ -151,15 +141,13 @@ describe('updateConfig', () => {
 
     try {
       // act
-      await updateConfig({ probes: [] })
+      await updateConfig({ probes: [{}] } as Config)
     } catch (error: unknown) {
       errorMessage = getErrorMessage(error)
     }
 
     // assert
-    expect(errorMessage).contain(
-      'Probes object does not exists or has length lower than 1!'
-    )
+    expect(errorMessage).contain('Monika configuration is invalid')
   })
 
   it('should update config', async () => {

--- a/src/components/config/sanitize.ts
+++ b/src/components/config/sanitize.ts
@@ -1,12 +1,18 @@
 import { createHash } from 'node:crypto'
-import type { Config, ValidatedConfig } from '../../interfaces/config'
+import type {
+  Certificate,
+  Config,
+  ValidatedConfig,
+} from '../../interfaces/config'
 
+const DEFAULT_TLS_EXPIRY_REMINDER_DAYS = 30
 const DEFAULT_STATUS_NOTIFICATION = '0 6 * * *'
 
 export function sanitizeConfig(config: Config): ValidatedConfig {
-  const { notifications = [], version } = config
+  const { certificate, notifications = [], version } = config
   const sanitizedConfigWithoutVersion = {
     ...config,
+    certificate: sanitizeCertificate(certificate),
     notifications,
     'status-notification':
       config['status-notification'] || DEFAULT_STATUS_NOTIFICATION,
@@ -20,4 +26,17 @@ export function sanitizeConfig(config: Config): ValidatedConfig {
 
 function md5Hash(data: Config): string {
   return createHash('md5').update(JSON.stringify(data)).digest('hex')
+}
+
+function sanitizeCertificate(
+  certificate?: Certificate
+): Required<Certificate> | undefined {
+  if (!certificate) {
+    return certificate
+  }
+
+  return {
+    ...certificate,
+    reminder: certificate.reminder || DEFAULT_TLS_EXPIRY_REMINDER_DAYS,
+  }
 }

--- a/src/components/config/validation/validator/probe.ts
+++ b/src/components/config/validation/validator/probe.ts
@@ -110,217 +110,210 @@ export async function validateProbes(probes: Probe[]): Promise<Probe[]> {
     port: joi.number().default(3306),
     username: joi.string().allow(''),
   })
-  const schema = joi
-    .array<Probe[]>()
-    .min(isSymonModeFrom(getContext().flags) ? 0 : 1)
-    .messages({
-      'array.min': 'Probes object does not exists or has length lower than 1!',
-    })
-    .items(
-      joi
-        .object({
-          alerts: joi
-            .array()
-            .items(alertSchema)
-            .default((parent) => {
-              if (isSymonModeFrom(getContext().flags)) {
-                return []
-              }
+  const schema = joi.array<Probe[]>().items(
+    joi
+      .object({
+        alerts: joi
+          .array()
+          .items(alertSchema)
+          .default((parent) => {
+            if (isSymonModeFrom(getContext().flags)) {
+              return []
+            }
 
-              const isHTTPProbe = Boolean(parent.requests)
+            const isHTTPProbe = Boolean(parent.requests)
 
-              if (!isHTTPProbe) {
-                return [{ id: uuid(), ...FAILED_REQUEST_ASSERTION }]
-              }
+            if (!isHTTPProbe) {
+              return [{ id: uuid(), ...FAILED_REQUEST_ASSERTION }]
+            }
 
-              return [
-                {
-                  id: uuid(),
-                  assertion: 'response.status < 200 or response.status > 299',
-                  message:
-                    'HTTP Status is {{ response.status }}, expecting 2xx',
-                },
-                {
-                  id: uuid(),
-                  assertion: 'response.time > 2000',
-                  message:
-                    'Response time is {{ response.time }}ms, expecting less than 2000ms',
-                },
-                { id: uuid(), ...FAILED_REQUEST_ASSERTION },
-              ]
-            }),
-          description: joi.string().allow(''),
-          id: joi.string().required(),
-          incidentThreshold: joi
-            .number()
-            .default(DEFAULT_INCIDENT_THRESHOLD)
-            .min(1),
-          recoveryThreshold: joi
-            .number()
-            .default(DEFAULT_RECOVERY_THRESHOLD)
-            .min(1),
-          interval: joi.number().default(DEFAULT_INTERVAL).min(1),
-          lastEvent: joi.object({
-            alertId: joi.string(),
-            createdAt: joi.string().allow(''),
-            recoveredAt: joi.string().allow('', null),
+            return [
+              {
+                id: uuid(),
+                assertion: 'response.status < 200 or response.status > 299',
+                message: 'HTTP Status is {{ response.status }}, expecting 2xx',
+              },
+              {
+                id: uuid(),
+                assertion: 'response.time > 2000',
+                message:
+                  'Response time is {{ response.time }}ms, expecting less than 2000ms',
+              },
+              { id: uuid(), ...FAILED_REQUEST_ASSERTION },
+            ]
           }),
-          name: joi
-            .string()
-            .allow('')
-            .default((parent) => `monika_${parent.id}`),
-          mariadb: joi.array().items(mysqlSchema),
-          mongo: joi.array().items(
-            joi.alternatives([
-              joi.object({
-                alerts: joi.array().items(alertSchema),
-                uri: joi.string().required(),
-              }),
-              joi.object({
-                alerts: joi.array().items(alertSchema),
-                host: joi
-                  .alternatives()
-                  .try(
-                    joi.string().allow('').hostname(),
-                    joi.string().allow('').ip()
-                  )
-                  .required(),
-                password: joi.string().allow(''),
-                port: joi.number().default(27_017).min(0).max(65_536),
-                username: joi.string().allow(''),
-              }),
-            ])
-          ),
-          mysql: joi.array().items(mysqlSchema),
-          ping: joi.array().items(
+        description: joi.string().allow(''),
+        id: joi.string().required(),
+        incidentThreshold: joi
+          .number()
+          .default(DEFAULT_INCIDENT_THRESHOLD)
+          .min(1),
+        recoveryThreshold: joi
+          .number()
+          .default(DEFAULT_RECOVERY_THRESHOLD)
+          .min(1),
+        interval: joi.number().default(DEFAULT_INTERVAL).min(1),
+        lastEvent: joi.object({
+          alertId: joi.string(),
+          createdAt: joi.string().allow(''),
+          recoveredAt: joi.string().allow('', null),
+        }),
+        name: joi
+          .string()
+          .allow('')
+          .default((parent) => `monika_${parent.id}`),
+        mariadb: joi.array().items(mysqlSchema),
+        mongo: joi.array().items(
+          joi.alternatives([
             joi.object({
               alerts: joi.array().items(alertSchema),
               uri: joi.string().required(),
-            })
-          ),
-          postgres: joi.array().items(
-            joi.alternatives([
-              joi.object({
-                alerts: joi.array().items(alertSchema),
-                uri: joi.string().required(),
-              }),
-              joi.object({
-                alerts: joi.array().items(alertSchema),
-                command: joi.string().allow(''),
-                data: joi
-                  .alternatives()
-                  .try(joi.string().allow(''), joi.number()),
-                database: joi.string().allow(''),
-                host: joi
-                  .alternatives()
-                  .try(
-                    joi.string().allow('').hostname(),
-                    joi.string().allow('').ip()
-                  )
-                  .required(),
-                password: joi.string().allow(''),
-                port: joi.number().default(5432),
-                username: joi.string().allow(''),
-              }),
-            ])
-          ),
-          redis: joi.array().items(
-            joi
-              .object({
-                alerts: joi.array().items(alertSchema),
-                command: joi.string().allow(''),
-                host: joi
-                  .alternatives()
-                  .try(
-                    joi.string().allow('').hostname(),
-                    joi.string().allow('').ip()
-                  ),
-                password: joi.string().allow(''),
-                port: joi.number().min(0).max(65_536),
-                uri: joi.string().allow(''),
-                username: joi.string().allow(''),
-              })
-              .xor('host', 'uri')
-              .and('host', 'port')
-          ),
-          requests: joi
-            .array()
-            .min(isSymonModeFrom(getContext().flags) ? 0 : 1)
-            .items(
-              joi.object({
-                alerts: joi.array().items(alertSchema),
-                allowUnauthorized: joi.bool(),
-                body: joi
-                  .alternatives()
-                  .try(
-                    joi.string().allow('', null),
-                    joi.object(),
-                    joi.array(),
-                    joi.number(),
-                    joi.bool()
-                  ),
-                followRedirects: joi
-                  .number()
-                  .min(0)
-                  .default(getContext().flags['follow-redirects']),
-                headers: joi.object().allow(null),
-                id: joi.string().allow(''),
-                interval: joi.number().min(1),
-                method: joi
-                  .string()
-                  .valid(
-                    'CONNECT',
-                    'GET',
-                    'POST',
-                    'PUT',
-                    'PATCH',
-                    'DELETE',
-                    'HEAD',
-                    'OPTIONS',
-                    'PURGE',
-                    'LINK',
-                    'TRACE',
-                    'UNLINK'
-                  )
-                  .default('GET')
-                  .insensitive()
-                  .label('Probe request method'),
-                ping: joi.bool(),
-                saveBody: joi.bool().default(false),
-                timeout: joi.number().default(10_000).min(1).allow(null),
-                url: joi
-                  .string()
-                  .custom((url) => {
-                    if (!isValidURL(url)) {
-                      throw new Error(
-                        `Probe request URL (${url}) should start with http:// or https://`
-                      )
-                    }
-
-                    return url
-                  })
-                  .label('Probe request URL')
-                  .required(),
-              })
-            )
-            .label('Probe requests'),
-          socket: joi.object({
+            }),
+            joi.object({
+              alerts: joi.array().items(alertSchema),
+              host: joi
+                .alternatives()
+                .try(
+                  joi.string().allow('').hostname(),
+                  joi.string().allow('').ip()
+                )
+                .required(),
+              password: joi.string().allow(''),
+              port: joi.number().default(27_017).min(0).max(65_536),
+              username: joi.string().allow(''),
+            }),
+          ])
+        ),
+        mysql: joi.array().items(mysqlSchema),
+        ping: joi.array().items(
+          joi.object({
             alerts: joi.array().items(alertSchema),
-            data: joi.string().allow('', null),
-            host: joi.string().required(),
-            port: joi.number().required(),
-          }),
-        })
-        .custom((probe) => {
-          if (!isProbeRequestExists(probe)) {
-            throw new Error(
-              'Probe requests does not exists or has length lower than 1!'
-            )
-          }
+            uri: joi.string().required(),
+          })
+        ),
+        postgres: joi.array().items(
+          joi.alternatives([
+            joi.object({
+              alerts: joi.array().items(alertSchema),
+              uri: joi.string().required(),
+            }),
+            joi.object({
+              alerts: joi.array().items(alertSchema),
+              command: joi.string().allow(''),
+              data: joi
+                .alternatives()
+                .try(joi.string().allow(''), joi.number()),
+              database: joi.string().allow(''),
+              host: joi
+                .alternatives()
+                .try(
+                  joi.string().allow('').hostname(),
+                  joi.string().allow('').ip()
+                )
+                .required(),
+              password: joi.string().allow(''),
+              port: joi.number().default(5432),
+              username: joi.string().allow(''),
+            }),
+          ])
+        ),
+        redis: joi.array().items(
+          joi
+            .object({
+              alerts: joi.array().items(alertSchema),
+              command: joi.string().allow(''),
+              host: joi
+                .alternatives()
+                .try(
+                  joi.string().allow('').hostname(),
+                  joi.string().allow('').ip()
+                ),
+              password: joi.string().allow(''),
+              port: joi.number().min(0).max(65_536),
+              uri: joi.string().allow(''),
+              username: joi.string().allow(''),
+            })
+            .xor('host', 'uri')
+            .and('host', 'port')
+        ),
+        requests: joi
+          .array()
+          .min(isSymonModeFrom(getContext().flags) ? 0 : 1)
+          .items(
+            joi.object({
+              alerts: joi.array().items(alertSchema),
+              allowUnauthorized: joi.bool(),
+              body: joi
+                .alternatives()
+                .try(
+                  joi.string().allow('', null),
+                  joi.object(),
+                  joi.array(),
+                  joi.number(),
+                  joi.bool()
+                ),
+              followRedirects: joi
+                .number()
+                .min(0)
+                .default(getContext().flags['follow-redirects']),
+              headers: joi.object().allow(null),
+              id: joi.string().allow(''),
+              interval: joi.number().min(1),
+              method: joi
+                .string()
+                .valid(
+                  'CONNECT',
+                  'GET',
+                  'POST',
+                  'PUT',
+                  'PATCH',
+                  'DELETE',
+                  'HEAD',
+                  'OPTIONS',
+                  'PURGE',
+                  'LINK',
+                  'TRACE',
+                  'UNLINK'
+                )
+                .default('GET')
+                .insensitive()
+                .label('Probe request method'),
+              ping: joi.bool(),
+              saveBody: joi.bool().default(false),
+              timeout: joi.number().default(10_000).min(1).allow(null),
+              url: joi
+                .string()
+                .custom((url) => {
+                  if (!isValidURL(url)) {
+                    throw new Error(
+                      `Probe request URL (${url}) should start with http:// or https://`
+                    )
+                  }
 
-          return probe
-        })
-    )
+                  return url
+                })
+                .label('Probe request URL')
+                .required(),
+            })
+          )
+          .label('Probe requests'),
+        socket: joi.object({
+          alerts: joi.array().items(alertSchema),
+          data: joi.string().allow('', null),
+          host: joi.string().required(),
+          port: joi.number().required(),
+        }),
+      })
+      .custom((probe) => {
+        if (!isProbeRequestExists(probe)) {
+          throw new Error(
+            'Probe requests does not exists or has length lower than 1!'
+          )
+        }
+
+        return probe
+      })
+  )
 
   try {
     return await schema.validateAsync(probes, {

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -25,7 +25,6 @@
 import type { RequestOptions } from 'node:https'
 import type { Notification } from '@hyperjumptech/monika-notification'
 import type { Probe } from './probe'
-import type { DBLimit } from './data'
 
 type DomainWithOptions = {
   domain: string
@@ -34,10 +33,16 @@ type DomainWithOptions = {
 
 export type Domain = string | DomainWithOptions
 
-type Certificate = {
+export type Certificate = {
   domains: Domain[]
   // The reminder is the number of days to send notification to user before the domain expires.
   reminder?: number
+}
+
+type DbLimit = {
+  max_db_size: number
+  deleted_data: number
+  cron_schedule: string
 }
 
 export type SymonConfig = {
@@ -52,7 +57,7 @@ export type SymonConfig = {
 export type Config = {
   probes: Probe[]
   certificate?: Certificate
-  db_limit?: DBLimit
+  db_limit?: DbLimit
   notifications?: Notification[]
   'status-notification'?: string
   symon?: SymonConfig
@@ -60,11 +65,11 @@ export type Config = {
 }
 
 export type ValidatedConfig = {
-  probes: Probe[]
-  notifications: Notification[]
   'status-notification': string
-  version: string
-  certificate?: Certificate
-  db_limit?: DBLimit
+  certificate?: Required<Certificate>
+  db_limit?: DbLimit
+  notifications: Notification[]
+  probes: Probe[]
   symon?: SymonConfig
+  version: string
 }

--- a/src/interfaces/data.ts
+++ b/src/interfaces/data.ts
@@ -1,5 +1,0 @@
-export interface DBLimit {
-  max_db_size: number
-  deleted_data: number
-  cron_schedule: string
-}

--- a/src/jobs/tls-check.ts
+++ b/src/jobs/tls-check.ts
@@ -37,42 +37,44 @@ import {
 } from '../components/notification/alert-message'
 import { checkTLS, getHostname } from '../components/tls-checker'
 import { getContext } from '../context'
+import { getErrorMessage } from '../utils/catch-error-handler'
 import getIp from '../utils/ip'
 import { log } from '../utils/pino'
 import { publicIpAddress } from '../utils/public-ip'
 
 export function tlsChecker(): void {
-  const config = getValidatedConfig()
-  const hasDomain = (config?.certificate?.domains?.length || 0) > 0
+  const { certificate, notifications } = getValidatedConfig()
+
+  if (!certificate) {
+    return
+  }
+
+  const hasDomain = certificate.domains.length > 0
 
   if (!hasDomain) {
     return
   }
 
-  const { certificate } = config
-  const defaultExpiryReminder = 30
+  const { domains, reminder } = certificate
+  const hasNotification = notifications.length > 0
 
-  for (const domain of certificate?.domains || []) {
+  for (const domain of domains) {
     const hostname = getHostname(domain)
-    const reminder = certificate?.reminder ?? defaultExpiryReminder
-
     log.info(`Running TLS check for ${hostname} every day at 00:00`)
 
     checkTLS(domain, reminder).catch((error) => {
-      log.error(error.message)
-
-      const { notifications } = config
-      const hasNotification = (notifications?.length || 0) > 0
+      const errorMessage = getErrorMessage(error)
+      log.error(errorMessage)
 
       if (!hasNotification) {
         return
       }
 
       sendErrorNotification({
-        errorMessage: error.message,
+        errorMessage,
         hostname,
         notifications,
-      }).catch(console.error)
+      }).catch((error) => log.error(getErrorMessage(error)))
     })
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -22,37 +22,27 @@
  * SOFTWARE.                                                                      *
  **********************************************************************************/
 
+import path from 'node:path'
 import { expect, test } from '@oclif/test'
-import path from 'path'
-import chai from 'chai'
+import { use } from 'chai'
 import spies from 'chai-spies'
+import { stub, type SinonStub } from 'sinon'
 import cmd from '../src/commands/monika'
-import sinon from 'sinon'
 import * as IpUtil from '../src/utils/public-ip'
 
 const { resolve } = path
 
-chai.use(spies)
+use(spies)
 
 describe('monika', () => {
-  let getPublicIPStub: sinon.SinonStub
-  let getPublicNetworkInfoStub: sinon.SinonStub
+  let getPublicIPStub: SinonStub
+
   beforeEach(() => {
-    getPublicIPStub = sinon.stub(IpUtil, 'getPublicIp' as never)
-    getPublicNetworkInfoStub = sinon
-      .stub(IpUtil, 'getPublicNetworkInfo' as never)
-      .callsFake(async () => ({
-        country: '',
-        city: '',
-        hostname: '',
-        isp: '',
-        privateIp: '',
-        publicIp: '',
-      }))
+    getPublicIPStub = stub(IpUtil, 'getPublicIp')
   })
+
   afterEach(() => {
     getPublicIPStub.restore()
-    getPublicNetworkInfoStub.restore()
   })
 
   test
@@ -94,9 +84,9 @@ describe('monika', () => {
     })
     .it('runs with config with invalid notification type')
 
-  // Probes Test`
+  // Probes Test
   test
-    .stderr()
+    .stdout()
     .do(() =>
       cmd.run([
         '--verbose',
@@ -104,12 +94,9 @@ describe('monika', () => {
         resolve('./test/testConfigs/probes/noProbes.yml'),
       ])
     )
-    .catch((error) => {
-      expect(error.message).to.contain(
-        'Probes object does not exists or has length lower than 1!'
-      )
+    .it('runs with config without probes', ({ stdout }) => {
+      expect(stdout).to.contain('Starting Monika.')
     })
-    .it('runs with config without probes')
 
   test
     .stdout()


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

Make TLS probe independent. It resolves #1261.

## How did you implement / how did you fix it

Remove validation that requires Monika configuration to have minimum a probe request.

## How to test

Run Monika with the following configuration.

```yaml
certificate:
  domains:
    - example.com
    - expired.badssl.com
    - domain: example.com
      options:
        path: '/foo'
  reminder: 30
```
