### PR TITLE
fix(snap) : #1255 fix notification not included in snap binary

### DIFF
--- a/.github/workflows/publish-snap.yml
+++ b/.github/workflows/publish-snap.yml
@@ -33,7 +33,7 @@ jobs:
         name: Run production test
   build:
     runs-on: ubuntu-latest
-    needs: test
+    # needs: test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -45,20 +45,20 @@ jobs:
         name: Build workspaces
       - run: npm ci
         name: Install dependencies
-      - run: sed -i 's#packages/notification/hyperjumptech-monika-notification#../../packages/notification/hyperjumptech-monika-notification#g' package.json
-        name: Change monika notification package path
       - run: npm run pack-tarballs
         name: Pack as tarball
-      - run: mv dist/monika*.tar.gz .
-        name: Move the tarball from dist folder to root
-      - run: mv monika*.tar.gz monika.tar.gz
-        name: Rename tarball
+      - run: mv dist/monika*.tar.gz dist/monika.tar.gz
+        name: Rename tarball in dist/ directory
+      - run: tar -zvxf dist/monika.tar.gz -C dist/
+        name: Extract tarball into dist/ directory
+      - run: cp -r packages/notification/lib/* dist/monika/packages/notification/
+        name: Copy built notification into dist/ directory
       - uses: snapcore/action-build@v1
         id: snapcraft
         name: Build Snap package
-      - uses: snapcore/action-publish@v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-        with:
-          snap: ${{ steps.snapcraft.outputs.snap }}
-          release: edge
+      # - uses: snapcore/action-publish@v1
+      #   env:
+      #     SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      #   with:
+      #     snap: ${{ steps.snapcraft.outputs.snap }}
+      #     release: edge

--- a/.github/workflows/publish-snap.yml
+++ b/.github/workflows/publish-snap.yml
@@ -51,7 +51,7 @@ jobs:
         name: Rename tarball in dist/ directory
       - run: tar -zvxf dist/monika.tar.gz -C dist/
         name: Extract tarball into dist/ directory
-      - run: cp -r packages/notification/lib/* dist/monika/packages/notification/
+      - run: cp -vr packages/notification/lib/* dist/monika/packages/notification/
         name: Copy built notification into dist/ directory
       - uses: snapcore/action-build@v1
         id: snapcraft

--- a/.github/workflows/publish-snap.yml
+++ b/.github/workflows/publish-snap.yml
@@ -33,7 +33,7 @@ jobs:
         name: Run production test
   build:
     runs-on: ubuntu-latest
-    # needs: test
+    needs: test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -56,9 +56,9 @@ jobs:
       - uses: snapcore/action-build@v1
         id: snapcraft
         name: Build Snap package
-      # - uses: snapcore/action-publish@v1
-      #   env:
-      #     SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-      #   with:
-      #     snap: ${{ steps.snapcraft.outputs.snap }}
-      #     release: edge
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: ${{ steps.snapcraft.outputs.snap }}
+          release: edge

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -25,7 +25,7 @@ apps:
 parts:
   monika:
     plugin: dump
-    source: .dist/monika
+    source: .dist/monika/
     override-pull: |
       sudo apt-get install -y jq curl
       CLI_VERSION=$(curl https://api.github.com/repos/hyperjumptech/monika/releases/latest -s | jq .tag_name -r)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -25,7 +25,7 @@ apps:
 parts:
   monika:
     plugin: dump
-    source: ./monika.tar.gz
+    source: .dist/monika
     override-pull: |
       sudo apt-get install -y jq curl
       CLI_VERSION=$(curl https://api.github.com/repos/hyperjumptech/monika/releases/latest -s | jq .tag_name -r)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -25,7 +25,7 @@ apps:
 parts:
   monika:
     plugin: dump
-    source: .dist/monika/
+    source: ./dist/monika
     override-pull: |
       sudo apt-get install -y jq curl
       CLI_VERSION=$(curl https://api.github.com/repos/hyperjumptech/monika/releases/latest -s | jq .tag_name -r)


### PR DESCRIPTION
# Monika Pull Request (PR)
This PR resolves #1255 

## What feature/issue does this PR add

1. Fix snap package job not including monika notification package

## How did you implement / how did you fix it

1. Extract tarball
2. Copy package/notification/lib/ content into extracted tarball path
3. Use extract path as snapcraft's build source

## How to test
### Prerequisites
- Linux x64 platform
- Snapcraft build environment

Duplicate steps to build snap binary from `publish-snap.yml`
1. `npm ci --workspaces --if-present`
2. `npm run build --workspaces --if-present`
3. `npm ci`
4. `npm run pack-tarballs`
5. `mv dist/monika*.tar.gz dist/monika.tar.gz`
6. `tar -zvxf dist/monika.tar.gz -C dist/`
7. `cp -vr packages/notification/lib/* dist/monika/packages/notification/`
8. `snapcraft`
9. `sudo snap install monika*.snap --devmode`
10. Confirm monika bin location by `which monika`
11. Copy config from #1255 
12. `monika -r 1`
![image](https://github.com/hyperjumptech/monika/assets/9563873/2029f089-3b6f-4e05-845d-a4f0f1c4b53d)

