### PR TITLE
Feat: adding sendWithCustomContent in monika-notif

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40457,7 +40457,7 @@
     },
     "packages/notification": {
       "name": "@hyperjumptech/monika-notification",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "license": "MIT",
       "dependencies": {
         "@sendgrid/mail": "^7.4.2",

--- a/packages/notification/channel/monika-notif.ts
+++ b/packages/notification/channel/monika-notif.ts
@@ -26,7 +26,7 @@ import Joi from 'joi'
 import type { NotificationMessage } from '.'
 import { sendHttpRequest } from '../utils/http'
 
-type MonikaAlertNotifDataBody = {
+export type MonikaAlertNotifDataBody = {
   type: 'incident' | 'recovery'
   alert: string
   url: string
@@ -58,7 +58,7 @@ type MonikaNotifDataBody =
   | MonikaStartAndTerminationNotifDataBody
   | MonikaStatusUpdateNotifDataBody
 
-type NotificationData = {
+export type NotificationData = {
   url: string
 }
 
@@ -72,6 +72,21 @@ export const send = async (
 ): Promise<void> => {
   const content = getContent(message)
 
+  if (!content) {
+    throw new Error('Unknown notification type')
+  }
+
+  await sendHttpRequest({
+    method: 'POST',
+    url,
+    data: content,
+  })
+}
+
+export const sendWithCustomContent = async (
+  { url }: NotificationData,
+  content: MonikaAlertNotifDataBody
+): Promise<void> => {
   if (!content) {
     throw new Error('Unknown notification type')
   }

--- a/packages/notification/channel/monika-notif.ts
+++ b/packages/notification/channel/monika-notif.ts
@@ -27,7 +27,7 @@ import type { NotificationMessage } from '.'
 import { sendHttpRequest } from '../utils/http'
 
 export type MonikaAlertNotifDataBody = {
-  type: 'incident' | 'recovery'
+  type: 'incident' | 'recovery' | 'incident-symon' | 'recovery-symon'
   alert: string
   url: string
   time: string

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperjumptech/monika-notification",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "description": "notification package for monika",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add
1. Implement `sendWithCustomContent` in monika-notif like #1109  

## How did you implement / how did you fix it
1. export types to be used in neosense
2. add `sendWithCustomContent` function to support [Neosense](https://neosense.bgnlab.id/)

## How to test
1. run monika with [monika-notif](https://whatsapp.hyperjump.tech/?tab=register) notification config
3. check is monika running without error
4. get WhatsApp notif that monika is starting and nothing is broken
![Screenshot 2024-05-02 at 10 36 39 2](https://github.com/hyperjumptech/monika/assets/5974862/6301f638-a241-4620-9ff7-de8a8cce1b93)


