### PR TITLE
feat(ping): #1260 deprecate ping request

### DIFF
--- a/docs/src/pages/tutorial/run-using-ping-method.md
+++ b/docs/src/pages/tutorial/run-using-ping-method.md
@@ -24,23 +24,15 @@ probes:
     name: ping_test
     description: requesting icmp ping
     interval: 10
-    requests:
-      - url: https://google.com
-        ping: true
-      - method: GET
-        url: https://reqres.in/api/users
-    alerts:
-      - query: response.status != 200
-        message: Status code is not 200
-      - query: response.time > 2000
-        message: Request took more than 2 seconds
+    ping:
+      - uri: google.com
 ```
 
 Let me explain this configuration a little bit:
 
 - This configuration uses Desktop notifications
-- This probe configuration will do two requests: **Hit google.com using PING**. After PING success, it will **hit** [**https://reqres.in/api/users**](https://reqres.in/api/users) **using the GET method**. If by chance the first request fails, it will not proceed to the next request.
-- This probe configuration will alert you if the status code is not 200, or the request took longer than two seconds
+- This probe configuration will **hit google.com using PING**
+- This probe configuration will alert you if ping request is not successful (200), or the request took longer than two seconds
 
 Save the configuration above as `monika.yaml` in your local machine and run `monika -c monika.yaml` command in your terminal inside the directory where you saved the configuration file.
 

--- a/monika.example.yml
+++ b/monika.example.yml
@@ -34,7 +34,7 @@ probes:
 #   description: requesting icmp ping
 #   interval: 10
 #   ping:
-#     - url: http://google.com
+#     - uri: http://google.com
 
 # Configuration example for sending Multiple requests
 # Requests could be define in array to run for multiple requests

--- a/monika.example.yml
+++ b/monika.example.yml
@@ -33,12 +33,8 @@ probes:
 #   name: ping_test
 #   description: requesting icmp ping
 #   interval: 10
-#   requests:
+#   ping:
 #     - url: http://google.com
-#       ping: true
-#   alerts:
-#     - assertion: response.status == 500
-#       message: response status message
 
 # Configuration example for sending Multiple requests
 # Requests could be define in array to run for multiple requests

--- a/src/components/logger/startup-message.ts
+++ b/src/components/logger/startup-message.ts
@@ -98,7 +98,7 @@ function generateStartupMessage({
     startupMessage += generateNotificationMessage(notifications)
   }
 
-  if (probes.some((p) => p.ping)) {
+  if (probes.some((p) => p.requests?.some((r) => r.ping))) {
     startupMessage += generateDeprecatedPingMessage()
   }
 

--- a/src/components/logger/startup-message.ts
+++ b/src/components/logger/startup-message.ts
@@ -98,6 +98,10 @@ function generateStartupMessage({
     startupMessage += generateNotificationMessage(notifications)
   }
 
+  if (probes.some((p) => p.ping)) {
+    startupMessage += generateDeprecatedPingMessage()
+  }
+
   return startupMessage
 }
 
@@ -106,6 +110,21 @@ function generateEmptyNotificationMessage(): string {
   Please refer to the Monika documentations on how to how to configure notifications (e.g., Telegram, Slack, Desktop notification, etc.) at https://monika.hyperjump.tech/guides/notifications.`
 
   return boxen(chalk.yellow(NO_NOTIFICATIONS_MESSAGE), {
+    padding: 1,
+    margin: {
+      top: 2,
+      right: 1,
+      bottom: 2,
+      left: 1,
+    },
+    borderStyle: 'bold',
+    borderColor: 'yellow',
+  })
+}
+
+function generateDeprecatedPingMessage(): string {
+  const message = `We are deprecating probe requests with flag "ping: true", please migrate to standalone probe https://monika.hyperjump.tech/guides/probes#ping-request`
+  return boxen(chalk.yellow(message), {
     padding: 1,
     margin: {
       top: 2,

--- a/src/components/probe/prober/http/request.ts
+++ b/src/components/probe/prober/http/request.ts
@@ -65,6 +65,7 @@ export async function httpRequest({
 }: probingParams): Promise<ProbeRequestResponse> {
   // Compile URL using handlebars to render URLs that uses previous responses data
   const {
+    id,
     method,
     url,
     headers,
@@ -91,6 +92,9 @@ export async function httpRequest({
   try {
     // is this a request for ping?
     if (newReq.ping === true) {
+      log.warn(
+        `Probe ID ${id}: Request with "ping: true" is deprecated, please migrate your ping configuration based on this guide https://monika.hyperjump.tech/guides/probes#ping-request`
+      )
       return icmpRequest({ host: renderedURL })
     }
 

--- a/src/components/probe/prober/http/request.ts
+++ b/src/components/probe/prober/http/request.ts
@@ -65,7 +65,6 @@ export async function httpRequest({
 }: probingParams): Promise<ProbeRequestResponse> {
   // Compile URL using handlebars to render URLs that uses previous responses data
   const {
-    id,
     method,
     url,
     headers,
@@ -93,7 +92,7 @@ export async function httpRequest({
     // is this a request for ping?
     if (newReq.ping === true) {
       log.warn(
-        `Probe ${id}: Request with "ping: true" is deprecated, please migrate to standalone probe https://monika.hyperjump.tech/guides/probes#ping-request`
+        `PING ${renderedURL}: Requests with "ping: true" is deprecated, please migrate to standalone probe https://monika.hyperjump.tech/guides/probes#ping-request`
       )
       return icmpRequest({ host: renderedURL })
     }

--- a/src/components/probe/prober/http/request.ts
+++ b/src/components/probe/prober/http/request.ts
@@ -93,7 +93,7 @@ export async function httpRequest({
     // is this a request for ping?
     if (newReq.ping === true) {
       log.warn(
-        `Probe ID ${id}: Request with "ping: true" is deprecated, please migrate your ping configuration based on this guide https://monika.hyperjump.tech/guides/probes#ping-request`
+        `Probe ${id}: Request with "ping: true" is deprecated, please migrate to standalone probe https://monika.hyperjump.tech/guides/probes#ping-request`
       )
       return icmpRequest({ host: renderedURL })
     }

--- a/src/components/probe/prober/icmp/request.ts
+++ b/src/components/probe/prober/icmp/request.ts
@@ -75,7 +75,6 @@ export async function icmpRequest(
 
     return processICMPRequestResult(icmpResp)
   } catch (error: unknown) {
-    console.error('icmp got error:', error)
     baseResponse.data = ''
     baseResponse.error = getErrorMessage(error)
   }

--- a/src/monika-config-schema.json
+++ b/src/monika-config-schema.json
@@ -296,11 +296,6 @@
           "alerts": {
             "$ref": "#/definitions/alerts"
           },
-          "ping": {
-            "title": "Ping",
-            "type": "boolean",
-            "description": "If defined and to true, the request is an ICMP ping"
-          },
           "allowUnauthorized": {
             "title": "AllowUnauthorized",
             "type": "boolean",

--- a/src/monika-config-schema.json
+++ b/src/monika-config-schema.json
@@ -246,6 +246,9 @@
         "type": "object",
         "additionalProperties": false,
         "required": ["url"],
+        "patternProperties": {
+          "ping": { "type": "boolean" }
+        },
         "properties": {
           "id": {
             "title": "Id",


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

This PR is a deprecation step before removing ping from HTTP probe. See #1260 

## How did you implement / how did you fix it

1. Remove `"ping: true"` from `monika-config-schema.json`
2. Add deprecation warning to startup message
3. Add deprecation warning to HTTP probe message
4. Update ping tutorial
5. Update `monika.yml` sample

## How to test

1. Setup monika configuration below

```
probes:
  - id: 'ping_test'
    name: ping_test
    description: requesting icmp ping
    interval: 10
    requests:
      - url: http://google.com
        ping: true
    alerts:
      - assertion: response.status != 200
        message: response status message
```

2. `npm run start -- -r 1`
3. Expected screenshot below
![image](https://github.com/hyperjumptech/monika/assets/9563873/931141de-0774-46be-a65d-465dc2659fbe)