### PR TITLE
chore(docs): #1289 add docker guide for apple silicon

### DIFF
--- a/docs/src/pages/quick-start.md
+++ b/docs/src/pages/quick-start.md
@@ -91,6 +91,17 @@ When using remote configuration file, you can use the `--config-interval` to tel
 monika -c https://raw.githubusercontent.com/hyperjumptech/monika/main/config_sample/config.desktop.example.yml --config-interval 10
 ```
 
+## Run Monika on Docker
+
+```bash
+docker run --name monika \
+    --net=host \
+    -d hyperjump/monika:latest \
+    monika -c https://domain.com/path/to/your/configuration.yml
+```
+
+**On Apple Silicon chip**, you need to pass `--platform linux/amd64` to docker.
+
 Congratulations, you have successfully run Monika in your machine!
 
 ## Next Step

--- a/docs/src/pages/quick-start.md
+++ b/docs/src/pages/quick-start.md
@@ -100,7 +100,7 @@ docker run --name monika \
     monika -c https://domain.com/path/to/your/configuration.yml
 ```
 
-**On Apple Silicon chip**, you need to pass `--platform linux/amd64` to docker.
+**On ARM / Apple Silicon chip**, you need to pass `--platform linux/amd64` to docker.
 
 Congratulations, you have successfully run Monika in your machine!
 

--- a/docs/src/pages/tutorial/run-in-docker.md
+++ b/docs/src/pages/tutorial/run-in-docker.md
@@ -3,13 +3,21 @@ id: run-monika-in-docker
 title: Run Monika in Docker
 ---
 
-Monika is available as a docker image. You can find the image in the docker hub as `hyperjump/monika`, or pull the image with the following command:
+Monika is available as a docker image. You can find the image in the docker hub as `hyperjump/monika`, or pull the image with the following command
 
 ```bash
 docker pull hyperjump/monika
 ```
 
-Once you've pulled the latest image, you can run it using:
+## Running Monika on Apple Silicon
+
+Monika docker image only supports amd64 architecture, you have to pass `--platform linux/amd64` when using `hyperjump/monika` docker image
+
+```bash
+docker pull --platform linux/amd64 hyperjump/monika
+```
+
+Once you've pulled the latest image, you can run it using
 
 ```bash
 # Run Monika in foreground
@@ -17,6 +25,10 @@ docker run --name monika --net=host -it hyperjump/monika:latest
 
 # Or, if you prefer to run Monika in the background
 docker run --name monika --net=host --detach hyperjump/monika:latest
+
+# On Apple Silicon chip, pass --platform linux/amd64
+docker run --name monika --net=host --platform linux/amd64 -it hyperjump/monika:latest
+docker run --name monika --net=host --platform linux/amd64 --detach hyperjump/monika:latest
 ```
 
 In the example above, we create a container from the hyperjump/monika base image naming it with`--name monika`, indicate we'll use the host machine's network configuration with `--net=host` and let it run in the backround using the `--detach` switch (or interactively with `-it`).
@@ -42,6 +54,13 @@ docker run --name monika_interactive \
     -d hyperjump/monika:latest \
     monika -c /config/myConfig.yml --prometheus 3001
 
+# On Apple Silicon
+docker run --name monika_interactive \
+    --net=host \
+    --platform linux/amd64 \
+    -v ${PWD}/config:/config \
+    -d hyperjump/monika:latest \
+    monika -c /config/myConfig.yml --prometheus 3001
 ```
 
 ## Troubleshooting

--- a/docs/src/pages/tutorial/run-in-docker.md
+++ b/docs/src/pages/tutorial/run-in-docker.md
@@ -9,7 +9,7 @@ Monika is available as a docker image. You can find the image in the docker hub 
 docker pull hyperjump/monika
 ```
 
-## Running Monika on Apple Silicon
+## Running Monika on ARM / Apple Silicon
 
 Monika docker image only supports amd64 architecture, you have to pass `--platform linux/amd64` when using `hyperjump/monika` docker image
 
@@ -26,7 +26,7 @@ docker run --name monika --net=host -it hyperjump/monika:latest
 # Or, if you prefer to run Monika in the background
 docker run --name monika --net=host --detach hyperjump/monika:latest
 
-# On Apple Silicon chip, pass --platform linux/amd64
+# On ARM / Apple Silicon chip, pass --platform linux/amd64
 docker run --name monika --net=host --platform linux/amd64 -it hyperjump/monika:latest
 docker run --name monika --net=host --platform linux/amd64 --detach hyperjump/monika:latest
 ```
@@ -54,7 +54,7 @@ docker run --name monika_interactive \
     -d hyperjump/monika:latest \
     monika -c /config/myConfig.yml --prometheus 3001
 
-# On Apple Silicon
+# On ARM / Apple Silicon
 docker run --name monika_interactive \
     --net=host \
     --platform linux/amd64 \


### PR DESCRIPTION
# Monika Pull Request (PR)

This PR resolves #1289 

## What feature/issue does this PR add

1. Add docker guide for apple silicon

## How did you implement / how did you fix it

1. Add docker instruction on Quick Start Guide
2. Add `--platform linux/amd64` on Monika docker tutorial

## How to test

1. `cd docs`
2. `npm ci --legacy-peer-deps`
3. `npm run dev`
4. Visit `http://localhost:3000/quick-start`
5. Visit `http://localhost:3000/tutorial/run-in-docker`

### Screenshot Quick Start
![image](https://github.com/hyperjumptech/monika/assets/9563873/a3cc6a73-e77c-40df-9025-54e83b86432d)

### Screenshot Docker Tutorial
![image](https://github.com/hyperjumptech/monika/assets/9563873/1e42bfe8-6e39-4e1c-8b7c-7c76d16feb7a)
