### PR TITLE
Fix: Monika sends null request body as string null

### DIFF
--- a/src/components/config/__tests__/expected.textfile.yml
+++ b/src/components/config/__tests__/expected.textfile.yml
@@ -5,7 +5,6 @@ probes:
       - url: https://monika.hyperjump.tech
         method: GET
         timeout: 10000
-        body: {}
         followRedirects: 21
     interval: 900
     alerts:
@@ -19,7 +18,6 @@ probes:
       - url: https://github.com
         method: GET
         timeout: 10000
-        body: {}
         followRedirects: 21
     interval: 900
     alerts:

--- a/src/components/config/parser/text.ts
+++ b/src/components/config/parser/text.ts
@@ -67,7 +67,6 @@ export const parseConfigFromText = (configString: string): Config => {
               url,
               method: 'GET',
               timeout: 10_000,
-              body: {} as JSON,
               followRedirects: getContext().flags['follow-redirects'],
             },
           ],

--- a/src/components/probe/prober/http/request.test.ts
+++ b/src/components/probe/prober/http/request.test.ts
@@ -537,6 +537,34 @@ describe('probingHTTP', () => {
       // assert
       expect(res.status).to.eq(302)
     })
+
+    it('should send no body', async () => {
+      // arrange
+      let body
+      server.use(
+        http.get('https://example.com', async ({ request }) => {
+          body = request.body
+
+          return new HttpResponse(null, {
+            status: 200,
+          })
+        })
+      )
+      const request = {
+        url: 'https://example.com',
+        body: null,
+      } as RequestConfig
+
+      // act
+      const res = await httpRequest({
+        requestConfig: request,
+        responses: [],
+      })
+
+      // assert
+      expect(res.status).to.eq(200)
+      expect(body).to.eq(null)
+    })
   })
 
   describe('Unit test', () => {

--- a/src/interfaces/request.ts
+++ b/src/interfaces/request.ts
@@ -56,11 +56,10 @@ export interface ProbeRequestResponse<T = unknown> {
 }
 
 // ProbeRequest is used to define the requests that is being made.
-export interface RequestConfig extends Omit<RequestInit, 'headers' | 'body'> {
+export interface RequestConfig extends Omit<RequestInit, 'headers'> {
   id?: string
   saveBody?: boolean // save response body to db?
   url: string
-  body: object | string
   followRedirects: number
   timeout: number // request timeout
   alerts?: ProbeAlert[]

--- a/src/symon/index.test.ts
+++ b/src/symon/index.test.ts
@@ -206,7 +206,7 @@ describe('Symon initiate', () => {
         })
       ),
       http.get('http://localhost:4000/api/v1/monika/1234/probes', () => {
-        throw new Error('Failed')
+        throw new Error('Failed to get probes from Symon')
       })
     )
 


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

Fix Monika sends `null` request body as `"null"`.

## How did you implement / how did you fix it

1. Add a test.
2. Change the request body type.
3. Remove the non string body conversion using `JSON.stringify` that caused `null` becomes `"null"`.

## How to test

Run Monika with the following configuration:

```yaml
probes:
  - id: '1'
    interval: 1
    requests:
      - url: https://idp.sinarmas.com/api/health
        body: null
```

## Demo
[output.webm](https://github.com/hyperjumptech/monika/assets/15191978/64f5bae5-247a-4fc6-8764-213da6207519)
