### PR TITLE
feat(http prober): #1285 implement cache http response

### DIFF
--- a/docs/src/pages/guides/cli-options.md
+++ b/docs/src/pages/guides/cli-options.md
@@ -338,7 +338,9 @@ monika --ignoreInvalidTLS
 
 ## TTL Cache
 
-Time-to-live for in-memory (HTTP) cache entries in minutes. Defaults to 5 minutes. Setting to 0 means disabling this cache.
+Time-to-live for in-memory (HTTP) cache entries in minutes. Defaults to 5 minutes. Setting to 0 means disabling this cache. This cache is used for requests with identical HTTP request config, e.g. headers, method, url.
+
+Only usable for probes which does not have [chaining requests.](https://hyperjumptech.github.io/monika/guides/examples#requests-chaining)
 
 ```bash
 # Set TTL cache for HTTP to 5 minutes
@@ -351,6 +353,14 @@ Like your app to be more chatty and honest revealing all its internal details? U
 
 ```bash
 monika --verbose
+```
+
+## Verbose Cache
+
+Show (HTTP) cache hit / miss messages to log
+
+```bash
+monika --verbose-cache
 ```
 
 ## Version

--- a/docs/src/pages/guides/cli-options.md
+++ b/docs/src/pages/guides/cli-options.md
@@ -357,7 +357,9 @@ monika --verbose
 
 ## Verbose Cache
 
-Show (HTTP) cache hit / miss messages to log
+Show (HTTP) cache hit / miss messages to log.
+
+This will only show for probes which does not have [chaining requests.](https://hyperjumptech.github.io/monika/guides/examples#requests-chaining)
 
 ```bash
 monika --verbose-cache

--- a/docs/src/pages/guides/cli-options.md
+++ b/docs/src/pages/guides/cli-options.md
@@ -336,6 +336,15 @@ If there is a probe with request(s) that uses HTTPS, Monika will show an error i
 monika --ignoreInvalidTLS
 ```
 
+## TTL Cache
+
+Time-to-live for in-memory (HTTP) cache entries in minutes. Defaults to 5 minutes. Setting to 0 means disabling this cache.
+
+```bash
+# Set TTL cache for HTTP to 5 minutes
+monika --ttl-cache 5
+```
+
 ## Verbose
 
 Like your app to be more chatty and honest revealing all its internal details? Use the `--verbose` flag.

--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -75,6 +75,10 @@ Details of the field are given in the table below.
 | allowUnauthorized (optional) | (boolean), If set to true, will make https agent to not check for ssl certificate validity                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | followRedirects (optional)   | The request follows redirects as many times as specified here. If unspecified, it will fallback to the value set by the [follow redirects flag](https://monika.hyperjump.tech/guides/cli-options#follow-redirects)                                                                                                                                                                                                                                                                                                                                                                                |
 
+### Good to know
+
+To reduce network usage, HTTP responses are cached with 30s time-to-live by default.
+
 ## Request Body
 
 By default, the request body will be treated as-is. If the request header's `Content-Type` is set to `application/x-www-form-urlencoded`, it will be serialized into URL-safe string in UTF-8 encoding. Body payloads will vary on the specific probes being requested. For HTTP requests, the body and headers are defined like this:

--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -77,7 +77,9 @@ Details of the field are given in the table below.
 
 ### Good to know
 
-To reduce network usage, HTTP responses are cached with 30s time-to-live by default. This cache is then reused for requests with identical HTTP request config, e.g. headers, method, url.
+To reduce network usage, HTTP responses are cached with 5 time-to-live by default. This cache is then reused for requests with identical HTTP request config, e.g. headers, method, url.
+
+This cache is usable for probes which does not have [chaining requests.](https://hyperjumptech.github.io/monika/guides/examples#requests-chaining)
 
 ## Request Body
 

--- a/docs/src/pages/guides/probes.md
+++ b/docs/src/pages/guides/probes.md
@@ -77,7 +77,7 @@ Details of the field are given in the table below.
 
 ### Good to know
 
-To reduce network usage, HTTP responses are cached with 30s time-to-live by default.
+To reduce network usage, HTTP responses are cached with 30s time-to-live by default. This cache is then reused for requests with identical HTTP request config, e.g. headers, method, url.
 
 ## Request Body
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "dependencies": {
         "@faker-js/faker": "^7.4.0",
         "@hyperjumptech/monika-notification": "^1.18.0",
+        "@isaacs/ttlcache": "^1.4.1",
         "@oclif/core": "3.16.0",
         "@oclif/plugin-help": "^6.0.9",
         "@oclif/plugin-version": "^2.0.11",
@@ -1637,6 +1638,14 @@
       "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
       "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
       "dev": true
+    },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+      "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@faker-js/faker": "^7.4.0",
     "@hyperjumptech/monika-notification": "^1.18.0",
+    "@isaacs/ttlcache": "^1.4.1",
     "@oclif/core": "3.16.0",
     "@oclif/plugin-help": "^6.0.9",
     "@oclif/plugin-version": "^2.0.11",

--- a/src/components/probe/prober/http/index.ts
+++ b/src/components/probe/prober/http/index.ts
@@ -22,7 +22,6 @@
  * SOFTWARE.                                                                      *
  **********************************************************************************/
 
-import { createHash } from 'node:crypto'
 import { BaseProber, NotificationType, type ProbeParams } from '..'
 import { getContext } from '../../../../context'
 import events from '../../../../events'
@@ -41,7 +40,6 @@ import { addIncident } from '../../../incident'
 import { saveProbeRequestLog } from '../../../logger/history'
 import { logResponseTime } from '../../../logger/response-time-log'
 import { httpRequest } from './request'
-import { getCache, putCache } from './response-cache'
 
 type ProbeResultMessageParams = {
   request: RequestConfig
@@ -55,41 +53,14 @@ export class HTTPProber extends BaseProber {
     const responses: ProbeRequestResponse[] = []
 
     for (const requestConfig of requests) {
-      // current request may be attempting to retry because of triggered alert
-      // if this is NOT first attempt, do real http request
-      if (incidentRetryAttempt > 0) {
-        responses.push(
-          // eslint-disable-next-line no-await-in-loop
-          await httpRequest({
-            requestConfig: { ...requestConfig, signal },
-            responses,
-          })
-        )
-
-        // immediately process next request
-        continue
-      }
-
-      // if this is first attempt, use cache where possible
-      const hashRequest = createHash('SHA1')
-        .update(JSON.stringify(requestConfig))
-        .digest('hex')
-
-      const cache = getCache(hashRequest)
-      let response: ProbeRequestResponse
-      if (cache) {
-        response = cache
-      } else {
+      responses.push(
         // eslint-disable-next-line no-await-in-loop
-        response = await httpRequest({
+        await httpRequest({
+          isRetrying: incidentRetryAttempt > 0,
           requestConfig: { ...requestConfig, signal },
           responses,
         })
-
-        putCache(hashRequest, response)
-      }
-
-      responses.push(response)
+      )
     }
 
     const hasFailedRequest = responses.find(

--- a/src/components/probe/prober/http/index.ts
+++ b/src/components/probe/prober/http/index.ts
@@ -40,6 +40,7 @@ import { addIncident } from '../../../incident'
 import { saveProbeRequestLog } from '../../../logger/history'
 import { logResponseTime } from '../../../logger/response-time-log'
 import { httpRequest } from './request'
+import { getCache, putCache } from './response-cache'
 
 type ProbeResultMessageParams = {
   request: RequestConfig
@@ -52,15 +53,26 @@ export class HTTPProber extends BaseProber {
     // sending multiple http requests for request chaining
     const responses: ProbeRequestResponse[] = []
 
-    for (const requestConfig of requests) {
-      responses.push(
-        // eslint-disable-next-line no-await-in-loop
-        await httpRequest({
-          isRetrying: incidentRetryAttempt > 0,
-          requestConfig: { ...requestConfig, signal },
-          responses,
-        })
-      )
+    // do http request
+    // force fresh request if :
+    // - probe has chaining requests, OR
+    // - this is a retrying attempt
+    if (requests.length > 1 || incidentRetryAttempt > 0) {
+      for (const requestConfig of requests) {
+        responses.push(
+          // eslint-disable-next-line no-await-in-loop
+          await this.doRequest(requestConfig, signal, responses)
+        )
+      }
+    }
+    // use cached response when possible
+    // or fallback to fresh request if cache expired
+    else {
+      const responseCache = getCache(requests[0])
+      const response =
+        responseCache || (await this.doRequest(requests[0], signal, responses))
+      if (!responseCache) putCache(requests[0], response)
+      responses.push(response)
     }
 
     const hasFailedRequest = responses.find(
@@ -164,6 +176,17 @@ export class HTTPProber extends BaseProber {
         })
       }
     }
+  }
+
+  private doRequest(
+    config: RequestConfig,
+    signal: AbortSignal | undefined,
+    responses: ProbeRequestResponse[]
+  ) {
+    return httpRequest({
+      requestConfig: { ...config, signal },
+      responses,
+    })
   }
 
   generateVerboseStartupMessage(): string {

--- a/src/components/probe/prober/http/request.ts
+++ b/src/components/probe/prober/http/request.ts
@@ -41,6 +41,8 @@ import { sendHttpRequest, sendHttpRequestFetch } from '../../../../utils/http'
 import { log } from '../../../../utils/pino'
 import { AxiosError } from 'axios'
 import { getErrorMessage } from '../../../../utils/catch-error-handler'
+import { createHash } from 'crypto'
+import { getCache, putCache } from './response-cache'
 
 // Register Handlebars helpers
 registerFakes(Handlebars)
@@ -48,6 +50,7 @@ registerFakes(Handlebars)
 type probingParams = {
   requestConfig: Omit<RequestConfig, 'saveBody' | 'alert'> // is a config object
   responses: Array<ProbeRequestResponse> // an array of previous responses
+  isRetrying?: boolean
 }
 
 const UndiciErrorValidator = Joi.object({
@@ -62,6 +65,7 @@ const UndiciErrorValidator = Joi.object({
 export async function httpRequest({
   requestConfig,
   responses,
+  isRetrying = false,
 }: probingParams): Promise<ProbeRequestResponse> {
   // Compile URL using handlebars to render URLs that uses previous responses data
   const {
@@ -102,24 +106,43 @@ export async function httpRequest({
       requestHeaders.set(key, value)
     }
 
-    // Do the request using compiled URL and compiled headers (if exists)
-    if (getContext().flags['native-fetch']) {
-      return await probeHttpFetch({
-        startTime,
-        maxRedirects: followRedirects,
-        renderedURL,
-        requestParams: { ...newReq, headers: requestHeaders },
-        allowUnauthorized,
-      })
+    const hashRequest = createHash('SHA1')
+      .update(
+        JSON.stringify({
+          maxRedirects: followRedirects,
+          renderedURL,
+          requestParams: { ...newReq, headers: requestHeaders },
+          allowUnauthorized,
+        })
+      )
+      .digest('hex')
+
+    // this request may be attempting to retry triggered by alerts
+    // use cache only if this not a retry
+    if (!isRetrying) {
+      const cache = getCache(hashRequest)
+      if (cache) return cache
     }
 
-    return await probeHttpAxios({
-      startTime,
-      maxRedirects: followRedirects,
-      renderedURL,
-      requestParams: { ...newReq, headers: requestHeaders },
-      allowUnauthorized,
-    })
+    // Do the request using compiled URL and compiled headers (if exists)
+    const response = await (getContext().flags['native-fetch']
+      ? probeHttpFetch({
+          startTime,
+          maxRedirects: followRedirects,
+          renderedURL,
+          requestParams: { ...newReq, headers: requestHeaders },
+          allowUnauthorized,
+        })
+      : probeHttpAxios({
+          startTime,
+          maxRedirects: followRedirects,
+          renderedURL,
+          requestParams: { ...newReq, headers: requestHeaders },
+          allowUnauthorized,
+        }))
+
+    putCache(hashRequest, response)
+    return response
   } catch (error: unknown) {
     const responseTime = Date.now() - startTime
 
@@ -372,7 +395,7 @@ function transformContentByType(
     case 'multipart/form-data': {
       const form = new FormData()
       for (const contentKey of Object.keys(content)) {
-        form.append(contentKey, (content as any)[contentKey])
+        form.append(contentKey, (content as never)[contentKey])
       }
 
       return { content: form, contentType: form.getHeaders()['content-type'] }

--- a/src/components/probe/prober/http/request.ts
+++ b/src/components/probe/prober/http/request.ts
@@ -111,7 +111,11 @@ export async function httpRequest({
         JSON.stringify({
           maxRedirects: followRedirects,
           renderedURL,
-          requestParams: { ...newReq, headers: requestHeaders },
+          requestParams: {
+            ...newReq,
+            signal: undefined,
+            headers: requestHeaders,
+          },
           allowUnauthorized,
         })
       )

--- a/src/components/probe/prober/http/response-cache.ts
+++ b/src/components/probe/prober/http/response-cache.ts
@@ -1,0 +1,97 @@
+/**********************************************************************************
+ * MIT License                                                                    *
+ *                                                                                *
+ * Copyright (c) 2021 Hyperjump Technology                                        *
+ *                                                                                *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy   *
+ * of this software and associated documentation files (the "Software"), to deal  *
+ * in the Software without restriction, including without limitation the rights   *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      *
+ * copies of the Software, and to permit persons to whom the Software is          *
+ * furnished to do so, subject to the following conditions:                       *
+ *                                                                                *
+ * The above copyright notice and this permission notice shall be included in all *
+ * copies or substantial portions of the Software.                                *
+ *                                                                                *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  *
+ * SOFTWARE.                                                                      *
+ **********************************************************************************/
+
+import { getContext } from '../../../../context'
+import { ProbeRequestResponse } from 'src/interfaces/request'
+import { log } from '../../../../utils/pino'
+import { serialize } from 'v8'
+/**
+ * Simple implementation for caching Monika HTTP responses.
+ * With default total cache size limited to 50 MB.
+ * And default time-to-live for each cache entries is 30s.
+ *
+ * About cache size 50 MB limit :
+ * Assuming a typical web page response is around 500 KB
+ * This cache can fit around 100 entries of web pages
+ * A typical response with empty body is around 300 bytes of headers
+ * That means, this cache can fit around 160K entries of empty body responses
+ */
+const DEFAULT_CACHE_LIMIT = 50_000_000 // 50 MB in bytes
+const DEFAULT_TIME_TO_LIVE = 30_000 // 30s in ms
+const responseCache = new Map<
+  string,
+  { expireAt: number; response: ProbeRequestResponse }
+>()
+
+// ensureCacheSize ensures total size of cache is under DEFAULT_CACHE_LIMIT
+function ensureCacheSize() {
+  const totalCacheSize = serialize(responseCache).byteLength
+  const firstKey = responseCache.keys().next().value
+  if (totalCacheSize > DEFAULT_CACHE_LIMIT && firstKey) {
+    responseCache.delete(firstKey)
+    // recursive until cache size is under limit
+    ensureCacheSize()
+  }
+}
+
+// ensureCacheTtl ensures cache entries are within valid time-to-live
+// this will delete already expired cache entries
+function ensureCacheTtl() {
+  const now = Date.now()
+  for (const [key, { expireAt }] of responseCache.entries()) {
+    if (expireAt <= now) {
+      responseCache.delete(key)
+    } else {
+      // next items have valid time-to-live
+      // break out of loop to save time
+      break
+    }
+  }
+}
+
+function put(key: string, value: ProbeRequestResponse) {
+  const expireAt = Date.now() + DEFAULT_TIME_TO_LIVE
+  responseCache.set(key, { expireAt, response: value })
+  // after put into cache, ensure total cache size is under limit
+  ensureCacheSize()
+}
+
+function get(key: string) {
+  // remove expired entries before actually getting cache
+  ensureCacheTtl()
+  const response = responseCache.get(key)?.response
+  const isVerbose = getContext().flags.verbose
+  const shortHash = key.slice(Math.max(0, key.length - 7))
+  if (isVerbose && response) {
+    const time = new Date().toISOString()
+    log.info(`${time} - [${shortHash}] Cache HIT`)
+  } else if (isVerbose) {
+    const time = new Date().toISOString()
+    log.info(`${time} - [${shortHash}] Cache MISS`)
+  }
+
+  return response
+}
+
+export { responseCache, put as putCache, get as getCache }

--- a/src/components/probe/prober/http/response-cache.ts
+++ b/src/components/probe/prober/http/response-cache.ts
@@ -59,12 +59,14 @@ function ensureCacheSize() {
 // this will delete already expired cache entries
 function ensureCacheTtl() {
   const now = Date.now()
+  // iterate over cache entries
+  // since we use map, the order of entries are based on insertion order
   for (const [key, { expireAt }] of responseCache.entries()) {
     if (expireAt <= now) {
       responseCache.delete(key)
     } else {
       // next items have valid time-to-live
-      // break out of loop to save time
+      // iteration is not necessary anymore
       break
     }
   }

--- a/src/components/probe/prober/http/response-cache.ts
+++ b/src/components/probe/prober/http/response-cache.ts
@@ -28,7 +28,7 @@ import { log } from '../../../../utils/pino'
 import TTLCache from '@isaacs/ttlcache'
 import { createHash } from 'crypto'
 
-const ttlCache = new TTLCache({ ttl: getContext().flags['ttl-cache'] * 60_000 })
+const ttlCache = new TTLCache()
 const cacheHash = new Map<RequestConfig, string>()
 
 function getOrCreateHash(config: RequestConfig) {
@@ -43,7 +43,10 @@ function getOrCreateHash(config: RequestConfig) {
 function put(config: RequestConfig, value: ProbeRequestResponse) {
   if (!getContext().flags['ttl-cache'] || getContext().isTest) return
   const hash = getOrCreateHash(config)
-  ttlCache.set(hash, value)
+  // manually set time-to-live for each cache entry
+  // moved from "new TTLCache()" initialization above because corresponding flag is not yet parsed
+  const ttl = getContext().flags['ttl-cache'] * 60_000
+  ttlCache.set(hash, value, { ttl })
 }
 
 function get(config: RequestConfig): ProbeRequestResponse | undefined {

--- a/src/components/probe/prober/http/response-cache.ts
+++ b/src/components/probe/prober/http/response-cache.ts
@@ -71,6 +71,7 @@ function ensureCacheTtl() {
 }
 
 function put(key: string, value: ProbeRequestResponse) {
+  if (getContext().isTest) return
   const expireAt = Date.now() + DEFAULT_TIME_TO_LIVE
   responseCache.set(key, { expireAt, response: value })
   // after put into cache, ensure total cache size is under limit

--- a/src/components/probe/prober/http/response-cache.ts
+++ b/src/components/probe/prober/http/response-cache.ts
@@ -28,10 +28,7 @@ import { log } from '../../../../utils/pino'
 import TTLCache from '@isaacs/ttlcache'
 import { createHash } from 'crypto'
 
-const ttlCache =
-  getContext().flags['ttl-cache'] > 0
-    ? new TTLCache({ ttl: getContext().flags['ttl-cache'] * 60_000 })
-    : undefined
+const ttlCache = new TTLCache({ ttl: getContext().flags['ttl-cache'] * 60_000 })
 const cacheHash = new Map<RequestConfig, string>()
 
 function getOrCreateHash(config: RequestConfig) {
@@ -44,16 +41,16 @@ function getOrCreateHash(config: RequestConfig) {
 }
 
 function put(config: RequestConfig, value: ProbeRequestResponse) {
-  if (!ttlCache || getContext().isTest) return
+  if (!getContext().flags['ttl-cache'] || getContext().isTest) return
   const hash = getOrCreateHash(config)
   ttlCache.set(hash, value)
 }
 
 function get(config: RequestConfig): ProbeRequestResponse | undefined {
-  if (!ttlCache || getContext().isTest) return undefined
+  if (!getContext().flags['ttl-cache'] || getContext().isTest) return undefined
   const key = getOrCreateHash(config)
   const response = ttlCache.get(key)
-  const isVerbose = getContext().flags.verbose
+  const isVerbose = getContext().flags['verbose-cache']
   const shortHash = key.slice(Math.max(0, key.length - 7))
   if (isVerbose && response) {
     const time = new Date().toISOString()

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -70,6 +70,7 @@ export type MonikaFlags = {
   text?: string
   'ttl-cache': number
   verbose: boolean
+  'verbose-cache': boolean
 }
 
 const DEFAULT_CONFIG_INTERVAL_SECONDS = 900
@@ -101,6 +102,7 @@ export const monikaFlagsDefaultValue: MonikaFlags = {
   symonReportLimit: 100,
   'ttl-cache': 5,
   verbose: false,
+  'verbose-cache': false,
 }
 
 function getDefaultConfig(): Array<string> {
@@ -279,12 +281,16 @@ export const flags = {
     exclusive: ['postman', 'insomnia', 'sitemap', 'har'],
   }),
   'ttl-cache': Flags.integer({
-    description: `Time-to-live for in-memory (HTTP) cache entries in minutes. Defaults to ${monikaFlagsDefaultValue['ttl-cache']} minutes.`,
+    description: `Time-to-live for in-memory (HTTP) cache entries in minutes. Defaults to ${monikaFlagsDefaultValue['ttl-cache']} minutes`,
     default: monikaFlagsDefaultValue['ttl-cache'],
   }),
   verbose: Flags.boolean({
     default: monikaFlagsDefaultValue.verbose,
     description: 'Show verbose log messages',
+  }),
+  'verbose-cache': Flags.boolean({
+    default: monikaFlagsDefaultValue.verbose,
+    description: 'Show cache hit / miss messages to log',
   }),
   version: Flags.version({ char: 'v' }),
 }

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -44,6 +44,7 @@ export type MonikaFlags = {
   force: boolean
   har?: string
   id?: string
+  ignoreInvalidTLS: boolean
   insomnia?: string
   'keep-verbose-logs': boolean
   logs: boolean
@@ -68,7 +69,6 @@ export type MonikaFlags = {
   symonUrl?: string
   text?: string
   'ttl-cache': number
-  ignoreInvalidTLS: boolean
   verbose: boolean
 }
 

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -67,6 +67,7 @@ export type MonikaFlags = {
   symonGetProbesIntervalMs: number
   symonUrl?: string
   text?: string
+  'ttl-cache': number
   ignoreInvalidTLS: boolean
   verbose: boolean
 }
@@ -98,6 +99,7 @@ export const monikaFlagsDefaultValue: MonikaFlags = {
   symonGetProbesIntervalMs: 60_000,
   symonReportInterval: DEFAULT_SYMON_REPORT_INTERVAL_MS,
   symonReportLimit: 100,
+  'ttl-cache': 5,
   verbose: false,
 }
 
@@ -275,6 +277,10 @@ export const flags = {
   text: Flags.string({
     description: 'Run Monika using a Simple text file',
     exclusive: ['postman', 'insomnia', 'sitemap', 'har'],
+  }),
+  'ttl-cache': Flags.integer({
+    description: `Time-to-live for in-memory (HTTP) cache entries in minutes. Defaults to ${monikaFlagsDefaultValue['ttl-cache']} minutes.`,
+    default: monikaFlagsDefaultValue['ttl-cache'],
   }),
   verbose: Flags.boolean({
     default: monikaFlagsDefaultValue.verbose,


### PR DESCRIPTION
# Monika Pull Request (PR)

This PR resolves #1285 

## What feature/issue does this PR add

1. Added new file `src/components/probe/prober/http/response-cache.ts` : in-memory cache for HTTP response

## How did you implement / how did you fix it

1. Create in-memory cache with `@isaac/ttl-cache`
2. Changed `HTTPProber` to use cached response on first probing attempt
3. Added new CLI option `--ttl-cache` to set cache's time-to-live
4. Added new CLI option `--verbose-cache` to monitor cache use

## How to test

1. `npm run start -- --verbose-cache`
2. Observe messages for `Cache HIT` and `Cache MISS`

![image](https://github.com/hyperjumptech/monika/assets/9563873/366eff19-2646-492a-a669-e88f6953288f)
