### PR TITLE
Feat: Disable Cache by Default

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   httpbin:
     image: kennethreitz/httpbin
     ports:
-      - 3000:80
+      - 3002:80
   mariadb:
     image: mariadb:11
     container_name: monika_mariadb

--- a/docs/src/pages/guides/cli-options.md
+++ b/docs/src/pages/guides/cli-options.md
@@ -338,7 +338,7 @@ monika --ignoreInvalidTLS
 
 ## TTL Cache
 
-Time-to-live for in-memory (HTTP) cache entries in minutes. Defaults to 5 minutes. Setting to 0 means disabling this cache. This cache is used for requests with identical HTTP request config, e.g. headers, method, url.
+Enable time-to-live for in-memory (HTTP) cache entries in minutes. This cache is used for requests with identical HTTP request config, e.g. headers, method, url.
 
 Only usable for probes which does not have [chaining requests.](https://hyperjumptech.github.io/monika/guides/examples#requests-chaining)
 

--- a/src/components/probe/prober/http/index.ts
+++ b/src/components/probe/prober/http/index.ts
@@ -40,7 +40,7 @@ import { addIncident } from '../../../incident'
 import { saveProbeRequestLog } from '../../../logger/history'
 import { logResponseTime } from '../../../logger/response-time-log'
 import { httpRequest } from './request'
-import { getCache, putCache } from './response-cache'
+import { get as getCache, put as putCache } from './response-cache'
 
 type ProbeResultMessageParams = {
   request: RequestConfig
@@ -57,17 +57,20 @@ export class HTTPProber extends BaseProber {
     // force fresh request if :
     // - probe has chaining requests, OR
     // - this is a retrying attempt
-    if (requests.length > 1 || incidentRetryAttempt > 0) {
+    if (
+      requests.length > 1 ||
+      incidentRetryAttempt > 0 ||
+      !getContext().flags['ttl-cache']
+    ) {
       for (const requestConfig of requests) {
         responses.push(
           // eslint-disable-next-line no-await-in-loop
           await this.doRequest(requestConfig, signal, responses)
         )
       }
-    }
-    // use cached response when possible
-    // or fallback to fresh request if cache expired
-    else {
+    } else {
+      // use cached response when possible
+      // or fallback to fresh request if cache expired
       const responseCache = getCache(requests[0])
       const response =
         responseCache || (await this.doRequest(requests[0], signal, responses))

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -100,7 +100,7 @@ export const monikaFlagsDefaultValue: MonikaFlags = {
   symonGetProbesIntervalMs: 60_000,
   symonReportInterval: DEFAULT_SYMON_REPORT_INTERVAL_MS,
   symonReportLimit: 100,
-  'ttl-cache': 5,
+  'ttl-cache': 0,
   verbose: false,
   'verbose-cache': false,
 }
@@ -281,7 +281,8 @@ export const flags = {
     exclusive: ['postman', 'insomnia', 'sitemap', 'har'],
   }),
   'ttl-cache': Flags.integer({
-    description: `Time-to-live for in-memory (HTTP) cache entries in minutes. Defaults to ${monikaFlagsDefaultValue['ttl-cache']} minutes`,
+    description:
+      'Enables time-to-live for in-memory (HTTP) cache entries in minutes',
     default: monikaFlagsDefaultValue['ttl-cache'],
   }),
   verbose: Flags.boolean({


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

Disable cache by default.

## How did you implement / how did you fix it

Change the default value of the `ttl-cache` flag.

## How to test

1. Run `docker compose -f ./dev/docker-compose.yaml up httpbin`.
2. Run `npm start` with the following configuration.
```yaml
probes:
  - id: '1'
    requests:
      - url: http://localhost:3002/status/200
    interval: 3
    incidentThreshold: 1
    recoveryThreshold: 1

```
3. Stop the docker compose command from the step one.
4. Re-run the docker compose command from the step one.

## Demo

### Before

https://github.com/hyperjumptech/monika/assets/15191978/82f64438-879c-4abf-90b8-560da9d0fc8a



### After

https://github.com/hyperjumptech/monika/assets/15191978/77fbcd82-6465-4d25-a163-8000064f70d2

