### PR TITLE
Feat: Handle CERT_HAS_EXPIRED error

### DIFF
--- a/src/components/probe/prober/http/request.ts
+++ b/src/components/probe/prober/http/request.ts
@@ -587,6 +587,14 @@ function getErrorStatusWithExplanation(error: unknown): {
       }
     }
 
+    case 'CERT_HAS_EXPIRED': {
+      return {
+        status: 18,
+        description:
+          "CERT_HAS_EXPIRED: The website's SSL/TLS certificates has expired.",
+      }
+    }
+
     case 'UNABLE_TO_VERIFY_LEAF_SIGNATURE': {
       return {
         status: 27,


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

 This PR handles CERT_HAS_EXPIRED error #1298 

## How did you implement / how did you fix it

1. Map the CERT_HAS_EXPIRED to status code 18

## How to test

Use this config:
```yaml
probes:
  - id: '1'
    name: 'Coding Horror'
    description: 'Probe to check Coding Horror blog'
    interval: 10 # in seconds (every 10 minutes)
    requests:
      - method: GET
        url: 'https://expired.badssl.com'
    alerts: 
      - assertion: response.status != 200
        message: Status not 200
```

![image](https://github.com/hyperjumptech/monika/assets/16670475/4b65f79e-1177-4be2-8998-684d5571b1a6)


