### PR TITLE
Reproduce 1301

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 node_modules
+packages/notification/node_modules
 .nyc_output
 .github
 .vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20-alpine AS builder
 
-RUN apk update && apk add python3 py3-setuptools make
+RUN apk update && apk add python3 py3-setuptools make gcc
 
 WORKDIR /monika
 
@@ -18,7 +18,7 @@ RUN npm pack
 
 FROM node:18-alpine AS runner
 
-RUN apk update && apk add python3 py3-setuptools make
+RUN apk update && apk add python3 py3-setuptools make gcc
 
 COPY --from=builder /monika/hyperjumptech-monika-*.tgz ./
 COPY --from=builder /monika/packages/notification/hyperjumptech-monika-notification-*.tgz ./packages/notification/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:20-alpine AS builder
 
+RUN apk update && apk add python3 py3-setuptools make
+
 WORKDIR /monika
 
 COPY package*.json ./
@@ -15,6 +17,8 @@ COPY . .
 RUN npm pack
 
 FROM node:18-alpine AS runner
+
+RUN apk update && apk add python3 py3-setuptools make
 
 COPY --from=builder /monika/hyperjumptech-monika-*.tgz ./
 COPY --from=builder /monika/packages/notification/hyperjumptech-monika-notification-*.tgz ./packages/notification/


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

1.  [Issue-1301](https://github.com/hyperjumptech/monika/issues/1301)

## How did you implement / how did you fix it

1. Added a line in the .dockerignore file to prevent `packages/notification/node_modules` from being copied into the docker container build stage. Please refer to the explanation below
2. Added command to add python3, py3-setuptools, make, and gcc as the dependencies of sqlite3 rebuilding needed by monika notifications.

## How to test

1. Clone the project
2. Issue a `npm run build -w packages/notification/` to build dependencies packages
3. Issue a `npm ci` to pull dependencies
4. Issue a `make docker` at the project root

## Explanation

The [line](https://github.com/hyperjumptech/monika/blob/05370493a2c5be10f3d2376148717951ba6c6937/Dockerfile#L13) and .dockerignore file allow the content of `packages/notification/node_modules` directory on the host to be copied into the docker container build stage which in this case is using alpine while the host is not. As you can see in the following log snippet

```
15.10  ›   ModuleLoadError Plugin: @hyperjumptech/monika: [MODULE_NOT_FOUND] require
15.10  ›   failed to load /monika/lib/commands/monika.js: Cannot find module
15.10  ›   '/monika/packages/notification/node_modules/sqlite3/lib/binding/napi-v6-li
15.10  ›   nux-musl-x64/node_sqlite3.node'
15.10  ›   Require stack:
15.10  ›   -
15.10  ›   /monika/packages/notification/node_modules/sqlite3/lib/sqlite3-binding.js
15.10  ›   - /monika/packages/notification/node_modules/sqlite3/lib/sqlite3.js
```

In the snippet, we can see that it failed to load a module. The clue comes from the module path, it contains `linux-musl-x64`. It means the module has a native compilation part, which in this case uses `musl` instead of `glibc`. Native binaries compiled against different libc won't mix.