### PR TITLE
Fix: Fallback for getOSName

### DIFF
--- a/src/components/notification/alert-message.ts
+++ b/src/components/notification/alert-message.ts
@@ -221,14 +221,21 @@ export async function getOSName(): Promise<string> {
   const isLinux = osPlatform === 'linux'
 
   if (isLinux) {
-    const linuxDistro = await getLinuxDistro()
+    try {
+      const linuxDistro = await getLinuxDistro()
 
-    // checking again due to inconsistency of getos module return type
-    if (linuxDistro.os !== 'linux') {
-      return linuxDistro.os
+      // Checking again due to inconsistency of getos module return type
+      if (linuxDistro.os !== 'linux') {
+        return linuxDistro.os
+      }
+
+      return `${linuxDistro?.dist || 'Unknown Linux Distribution'} - ${
+        linuxDistro?.release || 'Unknown Release'
+      }`.trim()
+    } catch (error: unknown) {
+      console.error('Cannot get Linux distribution:', (error as Error).message)
+      return 'Unknown Linux Distribution - Unknown Release'
     }
-
-    return `${linuxDistro?.dist} ${linuxDistro?.release}`
   }
 
   return osName()


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

1. Add fallback for getOSName so that it does not crash if fails to fetch the os name

## How did you implement / how did you fix it

1. Wrapped the function using try-catch
2. Add fallback OS Name

## How to test

1. Run npm run start with notifications enabled. You should see the OS Name
3. Build Docker (`docker build . -t monika`) and run it `docker run -v ./monika.yml:/config/monika.yml --name monika monika monika --config /config/monika.yml`. Be advised that notifications MUST be enabled. You should see the OS Name

## Images
![image](https://github.com/user-attachments/assets/1f88f011-3b25-43e5-95fc-71e0351c36e0)
![image](https://github.com/user-attachments/assets/3175b1d7-0b18-4450-9904-f924183dc533)

## Additional Context

My machine is detected as macOS unknown, this is caused by old version of `os-name`. While I try to upgrade it, it didn't work because the newest version is ESM only, and you know how it goes with ESM modules for Monika... 😅


