### PR TITLE
Fix: --ignoreInvalidTLS has no effect

### DIFF
--- a/src/components/probe/prober/http/index.ts
+++ b/src/components/probe/prober/http/index.ts
@@ -187,7 +187,12 @@ export class HTTPProber extends BaseProber {
     responses: ProbeRequestResponse[]
   ) {
     return httpRequest({
-      requestConfig: { ...config, signal },
+      requestConfig: {
+        ...config,
+        allowUnauthorized:
+          config.allowUnauthorized ?? getContext().flags.ignoreInvalidTLS,
+        signal,
+      },
       responses,
     })
   }

--- a/src/components/probe/prober/http/request.ts
+++ b/src/components/probe/prober/http/request.ts
@@ -71,8 +71,7 @@ export async function httpRequest({
     timeout,
     body,
     ping,
-    allowUnauthorized = requestConfig.allowUnauthorized ??
-      getContext().flags.ignoreInvalidTLS,
+    allowUnauthorized,
     followRedirects,
     signal,
   } = requestConfig

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -41,6 +41,10 @@ type HttpRequestParams = {
 // More information here: https://rakshanshetty.in/nodejs-http-keep-alive/
 const httpAgent = new http.Agent({ keepAlive: true })
 const httpsAgent = new https.Agent({ keepAlive: true })
+const insecureHttpsAgent = new https.Agent({
+  keepAlive: true,
+  rejectUnauthorized: false,
+})
 export const DEFAULT_TIMEOUT = 10_000
 
 // Create an instance of axios here so it will be reused instead of creating a new one all the time.
@@ -57,9 +61,7 @@ export async function sendHttpRequest(
     headers: convertHeadersToAxios(headers),
     timeout: timeout ?? DEFAULT_TIMEOUT, // Ensure default timeout if not filled.
     httpAgent,
-    httpsAgent: allowUnauthorizedSsl
-      ? new https.Agent({ keepAlive: true, rejectUnauthorized: true })
-      : httpsAgent,
+    httpsAgent: allowUnauthorizedSsl ? insecureHttpsAgent : httpsAgent,
   })
 }
 


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

This PR fixes #1327

## How did you implement / how did you fix it

1. Moved the assignment for getContext().flags.ignoreInvalidTLS to [src/components/probe/prober/http/index.ts](https://github.com/hyperjumptech/monika/compare/issue/1327?expand=1#diff-537950d0505c20b7b3ec67590102fdafdbbbbddb0130d5dbf7a4ac232060598d)
2. Create agent for insecure HTTPS 

## How to test

Using this config:
```yaml
probes:
  - id: '1'
    name: Example
    interval: 3
    requests:
      - url: https://www.banksinarmas.com/PersonalBanking/loginCustomer.do
        method: GET
notifications:
  - id: '1'
    type: desktop
```

1. In src/components/probe/prober/http/request.ts, add this in line 81

  log.info(`Doing HTTP Request with options: ${JSON.stringify(requestConfig)}`)
2. Run monika using `npm run start`
3. Run Monika using `npm run start -- --ignoreInvalidTLS`

## Screenshot

Previously failed insecure request
Without --ignoreInvalidTLS
<img width="1799" alt="Screenshot 2024-12-09 at 16 25 45" src="https://github.com/user-attachments/assets/68fb51df-b7fa-4c7d-8848-96e3fb4b9496">
With --ignoreInvalidTLS
<img width="1799" alt="Screenshot 2024-12-09 at 16 26 17" src="https://github.com/user-attachments/assets/bde12673-d72d-4b3d-9ea9-a3dc1595d33b">

New
Without --ignoreInvalidTLS
<img width="1799" alt="Screenshot 2024-12-09 at 16 20 18" src="https://github.com/user-attachments/assets/5adaf2ae-a0c1-4575-beb5-cf74d7025120">
With --ignoreInvalidTLS
<img width="1799" alt="Screenshot 2024-12-09 at 16 21 22" src="https://github.com/user-attachments/assets/27d7803d-2652-4d66-b078-976b99bb6e55">
