### PR TITLE
fix: failed request assertion not found

### DIFF
--- a/src/commands/monika.ts
+++ b/src/commands/monika.ts
@@ -25,7 +25,6 @@
 import { Command, Errors } from '@oclif/core'
 import pEvent from 'p-event'
 import type { ValidatedConfig } from '../interfaces/config'
-import type { Probe } from '../interfaces/probe'
 
 import {
   getValidatedConfig,
@@ -33,7 +32,6 @@ import {
   initConfig,
 } from '../components/config'
 import { createConfig } from '../components/config/create'
-import { sortProbes } from '../components/config/sort'
 import { printAllLogs } from '../components/logger'
 import { flush } from '../components/logger/flush'
 import { closeLog } from '../components/logger/history'
@@ -43,10 +41,10 @@ import { sendMonikaStartMessage } from '../components/notification/start-message
 import { printSummary } from '../components/summary'
 import { getContext, setContext } from '../context'
 import events from '../events'
-import { type MonikaFlags, sanitizeFlags, flags } from '../flag'
+import { sanitizeFlags, flags } from '../flag'
 import { savePidFile } from '../jobs/summary-notification'
 import initLoaders from '../loaders'
-import { sanitizeProbe, startProbing } from '../looper'
+import { startProbing } from '../looper'
 import SymonClient from '../symon'
 import { getEventEmitter } from '../utils/events'
 import { log } from '../utils/pino'
@@ -57,6 +55,7 @@ import {
   close as closeSentry,
   flush as flushSentry,
 } from '@sentry/node'
+import { getProbes } from '../components/config/probe'
 
 const em = getEventEmitter()
 let symonClient: SymonClient
@@ -163,7 +162,7 @@ export default class Monika extends Command {
 
       for (;;) {
         const config = getValidatedConfig()
-        const probes = getProbes({ config, flags })
+        const probes = getProbes()
 
         // emit the sanitized probe
         em.emit(events.config.sanitized, probes)
@@ -229,19 +228,6 @@ async function logRunningInfo({ isVerbose, isSymonMode }: RunningInfoParams) {
   } catch (error) {
     log.warn(`Failed to obtain location/ISP info. Got: ${error}`)
   }
-}
-
-type GetProbesParams = {
-  config: ValidatedConfig
-  flags: MonikaFlags
-}
-
-function getProbes({ config, flags }: GetProbesParams): Probe[] {
-  const sortedProbes = sortProbes(config.probes, flags.id)
-
-  return sortedProbes.map((probe: Probe) =>
-    sanitizeProbe(isSymonModeFrom(flags), probe)
-  )
 }
 
 function deprecationHandler(config: ValidatedConfig): ValidatedConfig {

--- a/src/components/config/sanitize.ts
+++ b/src/components/config/sanitize.ts
@@ -4,14 +4,19 @@ import type {
   Config,
   ValidatedConfig,
 } from '../../interfaces/config'
+import { sanitizeProbe } from '../../looper'
+import { isSymonModeFrom } from '.'
+import { getContext } from '../../context'
 
 const DEFAULT_TLS_EXPIRY_REMINDER_DAYS = 30
 const DEFAULT_STATUS_NOTIFICATION = '0 6 * * *'
 
 export function sanitizeConfig(config: Config): ValidatedConfig {
-  const { certificate, notifications = [], version } = config
-  const sanitizedConfigWithoutVersion = {
+  const isSymonMode = isSymonModeFrom(getContext().flags)
+  const { certificate, notifications = [], version, probes } = config
+  const sanitizedConfigWithoutVersion: Omit<ValidatedConfig, 'version'> = {
     ...config,
+    probes: probes.map((probe) => sanitizeProbe(isSymonMode, probe)),
     certificate: sanitizeCertificate(certificate),
     notifications,
     'status-notification':

--- a/src/looper/index.ts
+++ b/src/looper/index.ts
@@ -79,10 +79,14 @@ export const FAILED_REQUEST_ASSERTION = {
 }
 
 function addFailedRequestAssertions(assertions: ProbeAlert[]) {
+  // create uuid seed from FAILED_REQUEST_ASSERTION to make the id deterministic
+  const idSeed = Buffer.from(JSON.stringify(FAILED_REQUEST_ASSERTION))
   return [
     ...assertions,
     {
-      id: uuid(),
+      id: uuid({
+        random: idSeed,
+      }),
       ...FAILED_REQUEST_ASSERTION,
     },
   ]

--- a/src/looper/index.ts
+++ b/src/looper/index.ts
@@ -79,7 +79,8 @@ export const FAILED_REQUEST_ASSERTION = {
 }
 
 function addFailedRequestAssertions(assertions: ProbeAlert[]) {
-  // create uuid seed from FAILED_REQUEST_ASSERTION to make the id deterministic
+  // create uuid seed from FAILED_REQUEST_ASSERTION
+  // to make the id deterministic, consistent, and testable
   const idSeed = Buffer.from(JSON.stringify(FAILED_REQUEST_ASSERTION))
   return [
     ...assertions,


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

This PR resolves #1330 

## How did you implement / how did you fix it

1. Move probe handling logic from monika.ts to config component
2. Add probe sanitization during config validation
3. Add tests for config sanitization
4. Make failed request assertion ID deterministic

## How to test

1. Create following config

```
probes:
  - id: 'http-1'
    name: 'status-401-test'
    requests:
      - url: https://httpbin.org/status/401
        method: PATCH
    alerts:
      - assertion: response.status < 200 or response.status > 308
        message: HTTP Status is not 200
      - assertion: response.ime > 2000
        message: Too sloow
```

2. `npm run start -- --config monika.yml`
3. Observe log `WARN: 2025-01-05T10:30:46.044Z 1 id:http-1 ERROR: ECONNREFUSED: Attempted to connect to a server, but the server declined the connection. Ensure the server is running and accepting connections., NOTIF: Service probably down`
4. Observe desktop notification "Probe is not accessible"
