### PR TITLE
Feat[1332] : Skip startup message

### DIFF
--- a/docs/src/pages/guides/cli-options.md
+++ b/docs/src/pages/guides/cli-options.md
@@ -309,10 +309,10 @@ monika --follow-redirects 0 # disable following redirects
 
 ## SKIP
 
-For applications where a startup message is not desired, you can skip monika startup message using `--skip-startup-message`.
+For applications where a startup message or startup notification is not desired, you can skip monika startup message using `--skip-start-message`.
 
 ```bash
-monika --skip-startup-message
+monika --skip-start-message
 ```
 
 ## STUN

--- a/docs/src/pages/guides/cli-options.md
+++ b/docs/src/pages/guides/cli-options.md
@@ -299,6 +299,14 @@ By default Monika will follow redirects 21 times. You can set the value of `--fo
 monika --follow-redirects 0 # disable following redirects
 ```
 
+## SKIP
+
+For applications where a startup message is not desired, you can skip monika startup message using `--skip-startup-message`.
+
+```bash
+monika --skip-startup-message
+```
+
 ## STUN
 
 By default monika will continuously check the [STUN](https://en.wikipedia.org/wiki/STUN) server every 20 second intervals. Continuously STUN checking ensures that connectivity to the outside world is guaranteed. When STUN checking fails, Monika assumes the network is down and probing will be paused.

--- a/src/commands/monika.ts
+++ b/src/commands/monika.ts
@@ -170,11 +170,14 @@ export default class Monika extends Command {
         // save some data into files for later
         savePidFile(flags.config, config)
         deprecationHandler(config)
-        logStartupMessage({
-          config,
-          flags,
-          isFirstRun,
-        })
+
+        if (flags['skip-start-message'] === false) {
+          logStartupMessage({
+            config,
+            flags,
+            isFirstRun,
+          })
+        }
 
         const controller = new AbortController()
         const { signal } = controller
@@ -192,6 +195,7 @@ export default class Monika extends Command {
         sendMonikaStartMessage(notifications).catch((error) =>
           log.error(error.message)
         )
+
         // schedule status update notification
         scheduleSummaryNotification({ config, flags })
 

--- a/src/commands/monika.ts
+++ b/src/commands/monika.ts
@@ -192,9 +192,12 @@ export default class Monika extends Command {
           break
         }
 
-        sendMonikaStartMessage(notifications).catch((error) =>
-          log.error(error.message)
-        )
+        if (flags['skip-start-message'] === false) {
+          // if skipping, skip also startup notification
+          sendMonikaStartMessage(notifications).catch((error) =>
+            log.error(error.message)
+          )
+        }
 
         // schedule status update notification
         scheduleSummaryNotification({ config, flags })

--- a/src/commands/monika.ts
+++ b/src/commands/monika.ts
@@ -144,7 +144,9 @@ export default class Monika extends Command {
       }
 
       await initLoaders(flags, this.config)
-      await logRunningInfo({ isSymonMode, isVerbose: flags.verbose })
+      if (flags['skip-start-message'] === false) {
+        await logRunningInfo({ isSymonMode, isVerbose: flags.verbose })
+      }
 
       if (isSymonMode) {
         symonClient = new SymonClient(flags)
@@ -171,13 +173,11 @@ export default class Monika extends Command {
         savePidFile(flags.config, config)
         deprecationHandler(config)
 
-        if (flags['skip-start-message'] === false) {
-          logStartupMessage({
-            config,
-            flags,
-            isFirstRun,
-          })
-        }
+        logStartupMessage({
+          config,
+          flags,
+          isFirstRun,
+        })
 
         const controller = new AbortController()
         const { signal } = controller

--- a/src/components/logger/startup-message.test.ts
+++ b/src/components/logger/startup-message.test.ts
@@ -521,4 +521,41 @@ describe('Startup message', () => {
       expect(logMessage).include('config file')
     })
   })
+
+  describe.only('Skip startup test', () => {
+    it('should show startup message', () => {
+      // act
+      logStartupMessage({
+        config: defaultConfig,
+        flags: sanitizeFlags({
+          config: ['./test/testConfigs/simple-1p-1n.yaml'],
+          symonKey: '',
+          symonUrl: '',
+          verbose: false,
+        }),
+        isFirstRun: false,
+      })
+
+      // assert
+      expect(logMessage).include('Using config file:')
+    })
+
+    it('should not startup message', () => {
+      // act
+      logStartupMessage({
+        config: defaultConfig,
+        flags: sanitizeFlags({
+          'skip-start-message': true,
+          config: ['./test/testConfigs/simple-1p-1n.yaml'],
+          symonKey: '',
+          symonUrl: '',
+          verbose: false,
+        }),
+        isFirstRun: false,
+      })
+
+      // assert
+      expect(logMessage).not.include('Using config file:')
+    })
+  })
 })

--- a/src/components/logger/startup-message.test.ts
+++ b/src/components/logger/startup-message.test.ts
@@ -522,7 +522,7 @@ describe('Startup message', () => {
     })
   })
 
-  describe.only('Skip startup test', () => {
+  describe('Skip startup test', () => {
     it('should show startup message', () => {
       // act
       logStartupMessage({

--- a/src/components/logger/startup-message.ts
+++ b/src/components/logger/startup-message.ts
@@ -39,7 +39,12 @@ type LogStartupMessage = {
   config: ValidatedConfig
   flags: Pick<
     MonikaFlags,
-    'config' | 'symonKey' | 'symonUrl' | 'verbose' | 'native-fetch'
+    | 'config'
+    | 'symonKey'
+    | 'symonUrl'
+    | 'verbose'
+    | 'native-fetch'
+    | 'skip-start-message'
   >
   isFirstRun: boolean
 }
@@ -49,6 +54,11 @@ export function logStartupMessage({
   flags,
   isFirstRun,
 }: LogStartupMessage): void {
+  if (flags['skip-start-message'] === true) {
+    // if skipping, wont have any message
+    return
+  }
+
   if (isSymonModeFrom(flags)) {
     log.info('Running in Symon mode')
     return
@@ -81,6 +91,11 @@ function generateStartupMessage({
   const hasNotification = notificationTotal > 0
 
   let startupMessage = ''
+
+  if (flags['skip-start-message'] === true) {
+    // if skipping, wont have any message
+    return ''
+  }
 
   // warn if config is empty
   if (!hasNotification) {

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -56,6 +56,7 @@ export type MonikaFlags = {
   retryInitialDelayMs: number
   retryMaxDelayMs: number
   sitemap?: string
+  'skip-start-message'?: boolean
   'status-notification'?: string
   stun: number
   summary: boolean
@@ -96,8 +97,8 @@ export const monikaFlagsDefaultValue: MonikaFlags = {
   repeat: 0,
   retryInitialDelayMs: 2000,
   retryMaxDelayMs: 30_000,
-  // default is 20s interval lookup
-  stun: 20,
+  'skip-start-message': false,
+  stun: 20, // default is 20s interval lookup
   summary: false,
   'symon-api-version': SYMON_API_VERSION.v1,
   symonGetProbesIntervalMs: 60_000,
@@ -236,6 +237,9 @@ export const flags = {
   sitemap: Flags.string({
     description: 'Run Monika using a Sitemap xml file.',
     exclusive: ['har', 'insomnia', 'postman', 'text'],
+  }),
+  'skip-start-message': Flags.boolean({
+    description: 'Skip Monika startup message',
   }),
   'status-notification': Flags.string({
     description: 'Cron syntax for status notification schedule',


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

1. Implements #1332 
2. Bypass startup messages 
3. Bypass startup notification ("Monika is started" notification)

## How did you implement / how did you fix it

1. Add a switch `--skip-start-message` to bypass greetings and startup info messages

## How to test

1. Use the following test.yaml config: 

```yaml
probes:
  - id: 'http-1'
    name: 'status-200-test'
    requests:
      - url: https://httpbin.org/status/401
        method: PATCH
    alerts:
      - assertion: response.status < 200 or response.status > 308
        message: HTTP Status is not 200
      - assertion: response.time > 2000
        message: Too sloow
```
2. Run monika with the switch `npm start -- -c test.yaml --skip-start-message` 
3. Expect monika to start probing without greeting and startup messages
4. Expect no startup notification is sent

# Screenshot

After PR
![image](https://github.com/user-attachments/assets/422b761a-7ba3-4b74-9097-48d8f4822d27)


Before PR
![image](https://github.com/user-attachments/assets/d2040a68-9639-49d0-aba8-d999ec74ddc9)


