### PR TITLE
Fix config cli help text

### DIFF
--- a/src/flag.ts
+++ b/src/flag.ts
@@ -136,7 +136,7 @@ export const flags = {
     char: 'c',
     default: monikaFlagsDefaultValue.config,
     description:
-      'JSON configuration filename or URL. If none is supplied, will look for monika.yml in the current directory',
+      'Monika configuration YAML file or URL. If none is supplied, will look for monika.yml in the current directory',
     env: 'MONIKA_JSON_CONFIG',
     multiple: true,
   }),


### PR DESCRIPTION
# Monika Pull Request (PR)

## What feature/issue does this PR add

1. Fix inaccurate help text on the CLI mode

## How to test

1. On the console `npm start -- -h` on the root
Expect to see corrected help text.

## After PR
![image](https://github.com/user-attachments/assets/61199059-ed46-47b8-9391-fb39ed95d692)

## Before PR
![image](https://github.com/user-attachments/assets/372e53d3-5271-490d-a771-ec74e6eccc68)

