### PR TITLE
fix(ci): publish Snap package to stable channel instead of edge

### DIFF
--- a/.github/workflows/publish-snap.yml
+++ b/.github/workflows/publish-snap.yml
@@ -61,4 +61,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
           snap: ${{ steps.snapcraft.outputs.snap }}
-          release: edge
+          release: stable


### PR DESCRIPTION
## Summary
Fixes #1316 — the Snapcraft publish workflow was configured to release to the "edge" channel, causing users on the stable channel to never receive updates.

## Change
- `.github/workflows/publish-snap.yml`: changed `release: edge` → `release: stable`

## Why
The `snapcore/action-publish@v1` action's `release` parameter controls which Snapcraft channel the package is published to. Publishing to `edge` means the release never reaches users who have subscribed to the default `stable` channel. This one-line change fixes the publication target so that stable releases go to the stable channel.

## Type of Change
- [x] Bug fix (CI/CD)

## Checklist
- [x] Single-line change, minimal blast radius
- [x] No code or dependency changes