### PR TITLE
docs: rephrase landing-page idiom "two birds with one stone"

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -605,7 +605,7 @@ export default function IndexPage() {
             <div className="container19">
               <ArticleCard
                 text="TLS certificate reminder"
-                text1="With Monika, you don’t have to worry about expiring TLS certificates anymore. Not that only you have prevented your TLS certificate from being expired, you also monitored your website performance. Hitting two birds with one stone."
+                text1="With Monika, you don’t have to worry about expiring TLS certificates anymore. Not that only you have prevented your TLS certificate from being expired, you also monitored your website performance. Accomplishing two things at once."
                 text3="Read more"
                 image_src="/playground_assets/0_rkxf1wgagwy5ofi--200h.jpg"
                 link_text="https://medium.com/hyperjump-tech/forgot-to-renew-the-tls-certificates-monika-will-remind-you-from-now-on-188407c484ba"


### PR DESCRIPTION
docs: rephrase landing-page idiom "two birds with one stone"

Small docs nit on the landing page (`docs/src/pages/index.js`): the
sentence "Hitting two birds with one stone." is a figurative idiom that
doesn't translate cleanly for an international audience. Replacing it
with "Accomplishing two things at once." preserves the meaning (TLS
expiry reminders + performance monitoring as two outcomes from one
tool) with a literal phrasing.

Happy to revise the phrasing or close this PR if it doesn't fit the
project's voice.
