### PR TITLE
Add Flowtriq notification channel

### DIFF
--- a/packages/notification/channel/flowtriq.ts
+++ b/packages/notification/channel/flowtriq.ts
@@ -1,0 +1,73 @@
+/**********************************************************************************
+ * MIT License                                                                    *
+ *                                                                                *
+ * Copyright (c) 2021 Hyperjump Technology                                        *
+ *                                                                                *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy   *
+ * of this software and associated documentation files (the "Software"), to deal  *
+ * in the Software without restriction, including without limitation the rights   *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      *
+ * copies of the Software, and to permit persons to whom the Software is          *
+ * furnished to do so, subject to the following conditions:                       *
+ *                                                                                *
+ * The above copyright notice and this permission notice shall be included in all *
+ * copies or substantial portions of the Software.                                *
+ *                                                                                *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  *
+ * SOFTWARE.                                                                      *
+ **********************************************************************************/
+
+import Joi from 'joi'
+import type { NotificationMessage } from './index.js'
+import { sendHttpRequest } from '../utils/http.js'
+
+type NotificationData = {
+  url: string
+  apiKey?: string
+}
+
+export const validator = Joi.object().keys({
+  url: Joi.string().uri().required().label('Flowtriq Webhook URL'),
+  apiKey: Joi.string().optional().allow('').label('Flowtriq API Key'),
+})
+
+export const send = async (
+  { url, apiKey }: NotificationData,
+  message: NotificationMessage
+): Promise<void> => {
+  const { meta, summary } = message
+
+  if (meta.type !== 'incident' && meta.type !== 'recovery') {
+    return
+  }
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+
+  if (apiKey) {
+    headers['X-API-Key'] = apiKey
+  }
+
+  await sendHttpRequest({
+    method: 'POST',
+    url,
+    headers,
+    data: {
+      source: 'monika',
+      probe: meta.url || meta.probeID,
+      status: meta.type,
+      message: summary,
+      timestamp: meta.time,
+    },
+  })
+}
+
+export function additionalStartupMessage({ url }: NotificationData): string {
+  return `    URL: ${url}\n`
+}

--- a/packages/notification/channel/index.ts
+++ b/packages/notification/channel/index.ts
@@ -27,6 +27,7 @@ import type { ArraySchema, ObjectSchema } from 'joi'
 import * as dingtalk from './dingtalk.js'
 import * as discord from './discord.js'
 import * as desktop from './desktop.js'
+import * as flowtriq from './flowtriq.js'
 import * as googlechat from './googlechat.js'
 import * as gotify from './gotify.js'
 import * as instatus from './instatus/index.js'
@@ -112,6 +113,7 @@ export const channels: Record<string, NotificationChannel> = {
   dingtalk: dingtalk as NotificationChannel<object>,
   discord: discord as NotificationChannel<object>,
   desktop: desktop as NotificationChannel<unknown>,
+  flowtriq: flowtriq as NotificationChannel<object>,
   'google-chat': googlechat as NotificationChannel<object>,
   gotify: gotify as NotificationChannel<object>,
   instatus: instatus as NotificationChannel<object>,


### PR DESCRIPTION
## Summary

- Adds [Flowtriq](https://flowtriq.com) as a new notification channel. Flowtriq is a DDoS detection and traffic analytics platform.
- Correlating Monika probe failures with Flowtriq DDoS detection lets operators quickly distinguish between application-level issues and volumetric network attacks.
- The channel POSTs incident and recovery events to a configurable webhook URL with an optional API key (`X-API-Key` header).

## Configuration

```json
{
  "notifications": [
    {
      "id": "flowtriq",
      "type": "flowtriq",
      "data": {
        "url": "https://app.flowtriq.com/api/webhooks/monika",
        "apiKey": "your-api-key"
      }
    }
  ]
}
```

`apiKey` is optional. When provided, it is sent as the `X-API-Key` header.

## Webhook payload

```json
{
  "source": "monika",
  "probe": "https://example.com",
  "status": "incident",
  "message": "Response time exceeded threshold",
  "timestamp": "2026-06-26 12:00:00 +00:00"
}
```

## Changes

- `packages/notification/channel/flowtriq.ts` - new notification channel
- `packages/notification/channel/index.ts` - register the channel

## Test plan

- [ ] Configure a Monika instance with the Flowtriq notification type and verify incident/recovery events are posted to the webhook URL
- [ ] Verify the `X-API-Key` header is included when `apiKey` is set
- [ ] Verify start/termination events are silently skipped (only incident/recovery are forwarded)
- [ ] Verify config validation rejects missing `url`